### PR TITLE
Add proxy support + fix sudo for mkfs.ext4

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -35,6 +35,7 @@ func DeployCommand() *coral.Command {
 	cmd.Flags().StringVarP(&m.ComponentToDeploy, "component", "c", "", "[master|volume|filer|envoy] only install one component")
 	cmd.Flags().BoolVarP(&m.PrepareVolumeDisks, "mountDisks", "", true, "auto mount disks on volume server if unmounted")
 	cmd.Flags().BoolVarP(&m.ForceRestart, "restart", "", false, "force to restart the service")
+	cmd.Flags().StringVarP(&m.ProxyUrl, "proxy", "x", "", "proxy for curl in format PROTO://PROXY (example: http://someproxy.com:8080/)")
 
 	cmd.RunE = func(command *coral.Command, args []string) error {
 

--- a/pkg/cluster/manager/deploy_envoy_server.go
+++ b/pkg/cluster/manager/deploy_envoy_server.go
@@ -86,6 +86,12 @@ func (m *Manager) deployEnvoyInstance(op operator.CommandOperator, component str
 		"SkipStart":         m.skipStart,
 		"ForceRestart":      m.ForceRestart,
 		"Version":           envoySpec.Version,
+		"ProxyConfig":       "",
+	}
+
+	// Configure proxy if specified
+	if m.ProxyUrl != "" {
+		data["ProxyConfig"] = "--proxy " + m.ProxyUrl
 	}
 
 	installScript, err := scripts.RenderScript("install_envoy.sh", data)

--- a/pkg/cluster/manager/deploy_volume_server.go
+++ b/pkg/cluster/manager/deploy_volume_server.go
@@ -103,7 +103,7 @@ func (m *Manager) prepareUnmountedDisks(op operator.CommandOperator) error {
 	for _, dev := range disks {
 		if dev.FilesystemType == "" {
 			info("mkfs " + dev.Path)
-			if err := op.Execute(fmt.Sprintf("mkfs.ext4 %s", dev.Path)); err != nil {
+			if err := m.sudo(op, fmt.Sprintf("mkfs.ext4 %s", dev.Path)); err != nil {
 				return fmt.Errorf("create file system on %s: %v", dev.Path, err)
 			}
 		}

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -9,6 +9,7 @@ type Manager struct {
 	User               string // username to login to the SSH server
 	IdentityFile       string // path to the private key file
 	UsePassword        bool   // use password instead of identity file for ssh connection
+	ProxyUrl           string // proxy URL for binary download
 	ComponentToDeploy  string
 	Version            string
 	SshPort            int

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -125,6 +125,12 @@ func (m *Manager) deployComponentInstance(op operator.CommandOperator, component
 		"SkipStart":         m.skipStart,
 		"ForceRestart":      m.ForceRestart,
 		"Version":           m.Version,
+		"ProxyConfig":       "",
+	}
+
+	// Configure proxy if specified
+	if m.ProxyUrl != "" {
+		data["ProxyConfig"] = "--proxy " + m.ProxyUrl
 	}
 
 	installScript, err := scripts.RenderScript("install.sh", data)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,10 +119,10 @@ download_and_install() {
     LARGE_SUFIX="_large_disk"
     assetFileName="${OS}_${SUFFIX}${FULL_SUFIX}${LARGE_SUFIX}.tar.gz"
     info "Downloading ${SEAWEED_VERSION} ${assetFileName}"
-    curl -o "$TMP_DIR/seaweed_${SEAWEED_VERSION}_${assetFileName}" -sfL "https://github.com/seaweedfs/seaweedfs/releases/download/${SEAWEED_VERSION}/${assetFileName}"
+    curl {{.ProxyConfig}} -o "$TMP_DIR/seaweed_${SEAWEED_VERSION}_${assetFileName}" -sfL "https://github.com/seaweedfs/seaweedfs/releases/download/${SEAWEED_VERSION}/${assetFileName}"
 
     info "Downloading ${SEAWEED_VERSION} ${assetFileName} md5"
-    curl -o "$TMP_DIR/seaweed_${SEAWEED_VERSION}_${assetFileName}.md5" -sfL "https://github.com/seaweedfs/seaweedfs/releases/download/${SEAWEED_VERSION}/${assetFileName}.md5"
+    curl {{.ProxyConfig}} -o "$TMP_DIR/seaweed_${SEAWEED_VERSION}_${assetFileName}.md5" -sfL "https://github.com/seaweedfs/seaweedfs/releases/download/${SEAWEED_VERSION}/${assetFileName}.md5"
     info "Verifying downloaded ${SEAWEED_VERSION} ${assetFileName}"
     md5Value=`cat $TMP_DIR/seaweed_${SEAWEED_VERSION}_${assetFileName}.md5`
     echo "${md5Value}  seaweed_${SEAWEED_VERSION}_${assetFileName}" | md5sum -c

--- a/scripts/install_envoy.sh
+++ b/scripts/install_envoy.sh
@@ -119,7 +119,7 @@ download_and_install() {
     assetFileName="${BINARY}-${SEAWEED_VERSION}-${OS}-${ARCH}"
     sourceUrl="https://github.com/envoyproxy/envoy/releases/download/v${SEAWEED_VERSION}/${assetFileName}"
     info "Downloading ${sourceUrl} to ${BIN_DIR}/${BINARY}"
-    $SUDO curl -o "${TMP_DIR}/${BINARY}" -fL "${sourceUrl}"
+    $SUDO curl {{.ProxyConfig}} -o "${TMP_DIR}/${BINARY}" -fL "${sourceUrl}"
     $SUDO chmod 755 ${TMP_DIR}/${BINARY}
     $SUDO mv ${TMP_DIR}/${BINARY} ${BIN_DIR}/${BINARY}
   fi


### PR DESCRIPTION
Fixed 2 issues i've faced during deploy attempt, sorry for single pull request:

1. Added support of proxy for deploy process (for servers, that don't have direct access to the internet)
2. Fixed mkfs.ext4 - SUDO is required for this command

In future it will be fine to implement deployment via seawed-up server (i.e. server will download all binaries and push it to destination server via ssh connection).