### PR TITLE
Resolve: Dynamic disk configuration is not correctly provisioned

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -28,10 +28,12 @@ func DeployCommand() *coral.Command {
 	}
 	var fileName string
 	cmd.Flags().StringVarP(&fileName, "file", "f", "", "configuration file")
+	cmd.Flags().StringVarP(&m.DynamicConfigFile, "dynamicFile", "d", "", "dynamic configuration file")
 	cmd.Flags().StringVarP(&m.User, "user", "u", utils.CurrentUser(), "The user name to login via SSH. The user must has root (or sudo) privilege.")
 	cmd.Flags().IntVarP(&m.SshPort, "port", "p", 22, "The port to SSH.")
 	cmd.Flags().StringVarP(&m.IdentityFile, "identity_file", "i", m.IdentityFile, "The path of the SSH identity file. If specified, public key authentication will be used.")
 	cmd.Flags().StringVarP(&m.Version, "version", "v", "", "The SeaweedFS version")
+	cmd.Flags().StringVarP(&m.EnvoyVersion, "envoyVersion", "", "", "Envoy version")
 	cmd.Flags().StringVarP(&m.ComponentToDeploy, "component", "c", "", "[master|volume|filer|envoy] only install one component")
 	cmd.Flags().BoolVarP(&m.PrepareVolumeDisks, "mountDisks", "", true, "auto mount disks on volume server if unmounted")
 	cmd.Flags().BoolVarP(&m.ForceRestart, "restart", "", false, "force to restart the service")
@@ -48,16 +50,37 @@ func DeployCommand() *coral.Command {
 		}
 
 		fmt.Println(fileName)
-		spec := &spec.Specification{}
+		deploySpec := &spec.Specification{}
 		data, readErr := os.ReadFile(fileName)
 		if readErr != nil {
 			return fmt.Errorf("read %s: %v", fileName, readErr)
 		}
-		if unmarshalErr := yaml.Unmarshal(data, spec); unmarshalErr != nil {
+		if unmarshalErr := yaml.Unmarshal(data, deploySpec); unmarshalErr != nil {
 			return fmt.Errorf("unmarshal %s: %v", fileName, unmarshalErr)
 		}
 
-		return m.DeployCluster(spec)
+		// Check if DynamicConfig file name is specified and file exists
+		if len(m.DynamicConfigFile) > 0 {
+			if _, err := os.Stat(m.DynamicConfigFile); err == nil {
+				// Try to load dynamic config
+				data, readErr := os.ReadFile(m.DynamicConfigFile)
+				if readErr != nil {
+					return fmt.Errorf("read dynamic config %s: %v", m.DynamicConfigFile, readErr)
+				}
+				dList := make(map[string][]spec.FolderSpec)
+				if unmarshalErr := yaml.Unmarshal(data, dList); unmarshalErr != nil {
+					return fmt.Errorf("unmarshal dynamic config %s: %v", fileName, unmarshalErr)
+				}
+				m.DynamicConfig.DynamicVolumeServers = dList
+			}
+		}
+
+		// dynamic config file name MUST be specified if prepare volume disks is active
+		if m.PrepareVolumeDisks && (len(m.DynamicConfigFile) < 1) {
+			return fmt.Errorf("`--dynamicFile <dynamic_config_file.yml>` should be specified when `--mountDisks` is set to true")
+		}
+
+		return m.DeployCluster(deploySpec)
 	}
 
 	return cmd

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -11,6 +11,8 @@ import (
 	"github.com/seaweedfs/seaweed-up/pkg/utils"
 	"github.com/seaweedfs/seaweed-up/scripts"
 	"github.com/thanhpk/randstr"
+	"gopkg.in/yaml.v3"
+	"io/ioutil"
 	"sync"
 )
 
@@ -40,14 +42,30 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 
 	if m.shouldInstall("volume") {
 		for index, volumeSpec := range specification.VolumeServers {
-			wg.Add(1)
-			go func(index int, volumeSpec *spec.VolumeServerSpec) {
-				defer wg.Done()
-				if err := m.DeployVolumeServer(masters, volumeSpec, index); err != nil {
-					deployErrors = append(deployErrors, fmt.Errorf("deploy to volume server %s:%d :%v", volumeSpec.Ip, volumeSpec.PortSsh, err))
-				}
-			}(index, volumeSpec)
+			//			wg.Add(1)
+			//			go func(index int, volumeSpec *spec.VolumeServerSpec) {
+			//				defer wg.Done()
+			if err := m.DeployVolumeServer(masters, volumeSpec, index); err != nil {
+				deployErrors = append(deployErrors, fmt.Errorf("deploy to volume server %s:%d :%v", volumeSpec.Ip, volumeSpec.PortSsh, err))
+			}
+			//			}(index, volumeSpec)
 		}
+
+		// Update dynamic volume server specification
+		m.DynamicConfig.Lock()
+		if m.DynamicConfig.Changed {
+			// TODO: Save changes to file
+			b, err := yaml.Marshal(m.DynamicConfig.DynamicVolumeServers)
+			if err != nil {
+				deployErrors = append(deployErrors, fmt.Errorf("error yaml marshal for Dynamic Volume Servers: %v", err))
+			} else {
+				err = ioutil.WriteFile(m.DynamicConfigFile, b, 0666)
+				if err != nil {
+					deployErrors = append(deployErrors, fmt.Errorf("error writing to %s with Dynamic Volume Servers: %v", m.DynamicConfigFile, err))
+				}
+			}
+		}
+		m.DynamicConfig.Unlock()
 	}
 	if m.shouldInstall("filer") {
 		for index, filerSpec := range specification.FilerServers {
@@ -66,12 +84,15 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	}
 
 	if m.shouldInstall("envoy") {
-		latest, err := config.GitHubLatestRelease(context.Background(), "0", "envoyproxy", "envoy")
-		if err != nil {
-			return errors.Wrapf(err, "unable to get latest version number, define a version manually with the --version flag")
+		if m.EnvoyVersion == "" {
+			latest, err := config.GitHubLatestRelease(context.Background(), "0", "envoyproxy", "envoy")
+			if err != nil {
+				return errors.Wrapf(err, "unable to get latest version number, define a version manually with the --version flag")
+			}
+			m.EnvoyVersion = latest.Version
 		}
 		for index, envoySpec := range specification.EnvoyServers {
-			envoySpec.Version = utils.Nvl(envoySpec.Version, latest.Version)
+			envoySpec.Version = utils.Nvl(envoySpec.Version, m.EnvoyVersion)
 			if err := m.DeployEnvoyServer(specification.FilerServers, envoySpec, index); err != nil {
 				return fmt.Errorf("deploy to envoy server %s:%d :%v", envoySpec.Ip, envoySpec.PortSsh, err)
 			}

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -45,7 +45,7 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 			//			wg.Add(1)
 			//			go func(index int, volumeSpec *spec.VolumeServerSpec) {
 			//				defer wg.Done()
-			if err := m.DeployVolumeServer(masters, volumeSpec, index); err != nil {
+			if err := m.DeployVolumeServer(masters, specification.GlobalOptions, volumeSpec, index); err != nil {
 				deployErrors = append(deployErrors, fmt.Errorf("deploy to volume server %s:%d :%v", volumeSpec.Ip, volumeSpec.PortSsh, err))
 			}
 			//			}(index, volumeSpec)

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -19,11 +19,12 @@ type (
 	}
 
 	Specification struct {
-		GlobalOptions GlobalOptions       `yaml:"global,omitempty" validate:"global:editable"`
-		ServerConfigs ServerConfigs       `yaml:"server_configs,omitempty" validate:"server_configs:ignore"`
-		MasterServers []*MasterServerSpec `yaml:"master_servers"`
-		VolumeServers []*VolumeServerSpec `yaml:"volume_servers"`
-		FilerServers  []*FilerServerSpec  `yaml:"filer_servers"`
-		EnvoyServers  []*EnvoyServerSpec  `yaml:"envoy_servers"`
+		GlobalOptions        GlobalOptions       `yaml:"global,omitempty" validate:"global:editable"`
+		ServerConfigs        ServerConfigs       `yaml:"server_configs,omitempty" validate:"server_configs:ignore"`
+		MasterServers        []*MasterServerSpec `yaml:"master_servers"`
+		VolumeServers        []*VolumeServerSpec `yaml:"volume_servers"`
+		FilerServers         []*FilerServerSpec  `yaml:"filer_servers"`
+		EnvoyServers         []*EnvoyServerSpec  `yaml:"envoy_servers"`
+		DynamicVolumeServers []*VolumeServerSpec `yaml:"dynamic_volume_servers,omitempty"`
 	}
 )

--- a/pkg/cluster/spec/volume_server_spec.go
+++ b/pkg/cluster/spec/volume_server_spec.go
@@ -24,9 +24,11 @@ type VolumeServerSpec struct {
 	OS                 string                 `yaml:"os,omitempty"`
 }
 type FolderSpec struct {
-	Folder   string `yaml:"folder"`
-	DiskType string `yaml:"disk" default:"hdd"`
-	Max      int    `yaml:"max,omitempty"`
+	Folder      string `yaml:"folder"`
+	DiskType    string `yaml:"disk" default:"hdd"`
+	Max         int    `yaml:"max,omitempty"`
+	BlockDevice string `yaml:"blockDevice,omitempty"`
+	UUID        string `yaml:"uuid,omitempty"`
 }
 
 func (vs *VolumeServerSpec) WriteToBuffer(masters []string, buf *bytes.Buffer) {

--- a/pkg/disks/disks.go
+++ b/pkg/disks/disks.go
@@ -3,6 +3,7 @@ package disks
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"github.com/seaweedfs/seaweed-up/pkg/operator"
 	"regexp"
 	"strconv"
@@ -20,6 +21,20 @@ type BlockDevice struct {
 	MountPoint     string
 	SerialId       string
 	Type           string
+}
+
+func GetDiskUUID(op operator.CommandOperator, devName string) (UUID string, err error) {
+	devices, _, err := ListBlockDevices(op, []string{devName})
+
+	if err != nil {
+		return "", err
+	}
+	for _, dev := range devices {
+		if dev.Path == devName {
+			return dev.UUID, nil
+		}
+	}
+	return "", fmt.Errorf("uuid not found")
 }
 
 func ListBlockDevices(op operator.CommandOperator, prefixes []string) (output []*BlockDevice, mountpoints map[string]struct{}, err error) {
@@ -65,7 +80,7 @@ func ListBlockDevices(op operator.CommandOperator, prefixes []string) (output []
 				for _, prefix := range prefixes {
 					if strings.HasPrefix(dev.Path, prefix) {
 						hasValidPrefix = true
-						println("valid path", dev.Path)
+						//println("valid path", dev.Path)
 						break
 					}
 				}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -151,6 +151,8 @@ Description=Seaweed${COMPONENT_INSTANCE}
 Documentation=https://github.com/seaweedfs/seaweedfs/wiki
 Wants=network-online.target
 After=network-online.target
+StartLimitBurst=3
+StartLimitIntervalSec=10
 
 [Service]
 WorkingDirectory=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR}
@@ -162,8 +164,6 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 Restart=on-failure
 RestartSec=2
-StartLimitBurst=3
-StartLimitIntervalSec=10
 TasksMax=infinity
 
 [Install]

--- a/scripts/install_envoy.sh
+++ b/scripts/install_envoy.sh
@@ -144,6 +144,8 @@ Description=Seaweed${COMPONENT_INSTANCE}
 Documentation=https://github.com/seaweedfs/seaweedfs/wiki
 Wants=network-online.target
 After=network-online.target
+StartLimitBurst=3
+StartLimitIntervalSec=10
 
 [Service]
 WorkingDirectory=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR}
@@ -155,8 +157,6 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 Restart=on-failure
 RestartSec=2
-StartLimitBurst=3
-StartLimitIntervalSec=10
 TasksMax=infinity
 
 [Install]

--- a/scripts/prepare_disk.sh
+++ b/scripts/prepare_disk.sh
@@ -27,6 +27,7 @@ setup_env() {
 
   MOUNT_POINT={{.MountPoint}}
   DEVICE_PATH={{.DevicePath}}
+  DEVICE_UUID={{.DeviceUUID}}
 }
 
 setup_mount() {
@@ -34,9 +35,9 @@ setup_mount() {
   info "Setup Mount Point"
   $SUDO mkdir -p -m 755 ${MOUNT_POINT}
   info "add ${DEVICE_PATH} ${MOUNT_POINT} to fstab"
-  echo "${DEVICE_PATH} ${MOUNT_POINT} ext4 noatime 0 2" | $SUDO tee -a /etc/fstab
-  info "mount ${DEVICE_PATH} ${MOUNT_POINT}"
-  $SUDO mount ${DEVICE_PATH} ${MOUNT_POINT}
+  echo "UUID=\"${DEVICE_UUID}\" ${MOUNT_POINT} ext4 noatime 0 2" | $SUDO tee -a /etc/fstab
+  info "mount ${DEVICE_PATH} with UUID=${DEVICE_UUID} at ${MOUNT_POINT}"
+  $SUDO mount ${MOUNT_POINT}
 
   return 0
 }


### PR DESCRIPTION
Fixed several issues in single commit.
All changes were tested on Ubuntu 20.04 LTS in 5-nodes cluster, each with 5 /dev/sdX spare disks for dynamic provisioning.
Right now i disabled parallel volume server deployment, but it can be returned back if it's really needed.

List of issues:
1. Non root user with passwordless sudo didn't handled correctly
2. Minor issue in systemd service fixed
3. Added option `--dynamicFile <name_of_dynamic_config_file.yml>` for dynamic disk provisioning
4. Fixed automatic disk mount feature - disks are provisioned, info is saved in dynamic config. Redeploy will not lose disk information.

To use dynamic provisioning now user need to specify file with/for dynamically provisioned data `-f filename`, for example, cluster can be provisioned by this command:

`./seaweed-up deploy --version 3.43 --envoyVersion 1.25.3 -u ubuntu -f examples/cluster2.yml -d examples/cluster2-dynamic.yml -x http://proxy.local:8080/`


Now it's possible to run deploy several times, all disk info will be provisioned correctly (at least, it's provisioned correctly in my test lab).

