### PR TITLE
Update go-scp package and minor optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,12 @@
 *.dll
 *.so
 *.dylib
-
+*.pem
 # Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
+.idea
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/alexellis/go-execute v0.5.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
-	github.com/bramvdbogaerde/go-scp v1.2.0 // indirect
+	github.com/bramvdbogaerde/go-scp v1.3.0 // indirect
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/bramvdbogaerde/go-scp v1.2.0 h1:mNF1lCXQ6jQcxCBBuc2g/CQwVy/4QONaoD5Aqg9r+Zg=
 github.com/bramvdbogaerde/go-scp v1.2.0/go.mod h1:s4ZldBoRAOgUg8IrRP2Urmq5qqd2yPXQTPshACY8vQ0=
+github.com/bramvdbogaerde/go-scp v1.3.0 h1:2EDcH4fQr6ylcVV4p9HLI0Lcr6JuHZyR+sBOPukXSAA=
+github.com/bramvdbogaerde/go-scp v1.3.0/go.mod h1:27lDUlS44PyAtY6BGtu2a8ksStHLNaJraqw65UmRA8c=
 github.com/cheggaaa/pb/v3 v3.1.0 h1:3uouEsl32RL7gTiQsuaXD4Bzbfl5tGztXGUvXbs4O04=
 github.com/cheggaaa/pb/v3 v3.1.0/go.mod h1:YjrevcBqadFDaGQKRdmZxTY42pXEqda48Ea3lt0K/BE=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/pkg/cluster/manager/deploy_envoy_server.go
+++ b/pkg/cluster/manager/deploy_envoy_server.go
@@ -104,7 +104,7 @@ func (m *Manager) deployEnvoyInstance(op operator.CommandOperator, component str
 		return fmt.Errorf("error received during upload install script: %s", err)
 	}
 
-	err = op.Upload(buf, fmt.Sprintf("%s/config/%s.yaml", dir, component), "0755")
+	err = op.Upload(buf, fmt.Sprintf("%s/config/%s.yaml", dir, component), "0644")
 	if err != nil {
 		return fmt.Errorf("error received during upload %s.yaml: %s", component, err)
 	}

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -65,7 +65,7 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 		return deployErrors[0]
 	}
 
-	if m.shouldInstall("envoy") {
+	if m.shouldInstall("envoy") && len(specification.EnvoyServers) > 0 {
 		latest, err := config.GitHubLatestRelease(context.Background(), "0", "envoyproxy", "envoy")
 		if err != nil {
 			return errors.Wrapf(err, "unable to get latest version number, define a version manually with the --version flag")
@@ -143,7 +143,7 @@ func (m *Manager) deployComponentInstance(op operator.CommandOperator, component
 		return fmt.Errorf("error received during upload install script: %s", err)
 	}
 
-	err = op.Upload(cliOptions, fmt.Sprintf("%s/config/%s.options", dir, component), "0755")
+	err = op.Upload(cliOptions, fmt.Sprintf("%s/config/%s.options", dir, component), "0644")
 	if err != nil {
 		return fmt.Errorf("error received during upload %s.options: %s", component, err)
 	}

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -96,7 +96,7 @@ func GitHubLatestRelease(ctx context.Context, ver string, owner, repo string) (R
 	}
 	if ver == "0" {
 		release = releaseList[0]
-		log.Printf("latest version is %v", release.TagName)
+		log.Printf("latest version is %v / %v", release.TagName, release.PublishedAt.Local())
 	} else {
 		for _, r := range releaseList {
 			if r.TagName == ver {

--- a/pkg/operator/ssh.go
+++ b/pkg/operator/ssh.go
@@ -60,22 +60,8 @@ func (s SSHOperator) Execute(command string) error {
 }
 
 func (s SSHOperator) Upload(source io.Reader, remotePath string, mode string) error {
-	sess, err := s.conn.NewSession()
-	if err != nil {
-		return err
-	}
-
-	defer sess.Close()
-
-	client := scp.Client{
-		Session:      sess,
-		Conn:         s.conn,
-		RemoteBinary: "scp",
-	}
-
-	err = client.CopyFile(context.Background(), source, remotePath, mode)
-
-	return err
+	client, _ := scp.NewClientBySSH(s.conn)
+	return client.CopyFile(context.Background(), source, remotePath, mode)
 }
 
 func (s SSHOperator) UploadFile(path string, remotePath string, mode string) error {


### PR DESCRIPTION
- Update go-scp package to v1.3.0
- Modify the permissions of the YAML&options file
- The latest version log has a published date