### PR TITLE
Add IAM control field for embedded IAM in S3 server

### DIFF
--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -62,6 +62,9 @@ type (
 		WebDAV             bool     `yaml:"webdav,omitempty"`
 		S3Port             int      `yaml:"s3_port,omitempty" default:"8333"`
 		WebDAVPort         int      `yaml:"webdav_port,omitempty" default:"7333"`
+		// IAM controls whether IAM API is embedded in S3 server (default: true when S3 is enabled)
+		// IAM API is accessible on the same port as S3 (S3Port)
+		IAM *bool `yaml:"iam,omitempty"`
 	}
 
 	// EnvoyServerSpec represents an envoy proxy configuration

--- a/pkg/exporters/kubernetes.go
+++ b/pkg/exporters/kubernetes.go
@@ -634,7 +634,13 @@ func (k *KubernetesExporter) generateFilerServer(cluster *spec.Specification, fi
 		// Add S3 command arguments
 		container := deployment["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]map[string]interface{})[0]
 		container["command"] = append(container["command"].([]string), fmt.Sprintf("-s3.port=%d", filer.S3Port))
-		
+
+		// IAM is embedded in S3 by default. Only add -iam=false if explicitly disabled
+		if filer.IAM != nil && !*filer.IAM {
+			container["command"] = append(container["command"].([]string), "-iam=false")
+		}
+		// Note: IAM API is accessible on the same port as S3 (S3Port) when embedded
+
 		// Add S3 port to container ports
 		container["ports"] = append(container["ports"].([]map[string]interface{}), map[string]interface{}{
 			"name":          "s3",


### PR DESCRIPTION
## Summary

This PR adds support for the new embedded IAM architecture introduced in [seaweedfs/seaweedfs#7740](https://github.com/seaweedfs/seaweedfs/pull/7740).

## Background

IAM API is now embedded in the S3 server by default (on the same port as S3), following the pattern used by **MinIO** and **Ceph RGW**.

## Changes

### Cluster Spec (`pkg/cluster/spec/spec.go`)
- Added `IAM` field to `FilerServerSpec` to control embedded IAM
- IAM is enabled by default when S3 is enabled

### Kubernetes Exporter (`pkg/exporters/kubernetes.go`)
- Added support for `-iam=false` flag when IAM is explicitly disabled
- IAM API is accessible on the same port as S3 when embedded

## Usage

```yaml
filer_servers:
  - ip: 192.168.1.10
    port: 8888
    s3: true
    s3_port: 8333
    # iam: true  # Default when S3 is enabled
    # IAM API available on same port as S3 (8333)
```

To disable embedded IAM:
```yaml
filer_servers:
  - ip: 192.168.1.10
    port: 8888
    s3: true
    s3_port: 8333
    iam: false  # Explicitly disable embedded IAM
```

## Related PRs
- [seaweedfs/seaweedfs#7740](https://github.com/seaweedfs/seaweedfs/pull/7740) - Embed IAM API into S3 server
- [seaweedfs/seaweedfs-operator#167](https://github.com/seaweedfs/seaweedfs-operator/pull/167) - Update operator for embedded IAM