### PR TITLE
Remove IAM option - IAM is embedded in S3 by default

### DIFF
--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -62,9 +62,8 @@ type (
 		WebDAV             bool     `yaml:"webdav,omitempty"`
 		S3Port             int      `yaml:"s3_port,omitempty" default:"8333"`
 		WebDAVPort         int      `yaml:"webdav_port,omitempty" default:"7333"`
-		// IAM controls whether IAM API is embedded in S3 server (default: true when S3 is enabled)
-		// IAM API is accessible on the same port as S3 (S3Port)
-		IAM *bool `yaml:"iam,omitempty"`
+		// Note: IAM API is now embedded in S3 by default (on the same port as S3).
+		// No configuration needed - IAM is automatically enabled when S3 is enabled.
 	}
 
 	// EnvoyServerSpec represents an envoy proxy configuration

--- a/pkg/exporters/kubernetes.go
+++ b/pkg/exporters/kubernetes.go
@@ -632,14 +632,9 @@ func (k *KubernetesExporter) generateFilerServer(cluster *spec.Specification, fi
 		)
 
 		// Add S3 command arguments
+		// Note: IAM API is now embedded in S3 by default (on the same port)
 		container := deployment["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]map[string]interface{})[0]
 		container["command"] = append(container["command"].([]string), fmt.Sprintf("-s3.port=%d", filer.S3Port))
-
-		// IAM is embedded in S3 by default. Only add -iam=false if explicitly disabled
-		if filer.IAM != nil && !*filer.IAM {
-			container["command"] = append(container["command"].([]string), "-iam=false")
-		}
-		// Note: IAM API is accessible on the same port as S3 (S3Port) when embedded
 
 		// Add S3 port to container ports
 		container["ports"] = append(container["ports"].([]map[string]interface{}), map[string]interface{}{


### PR DESCRIPTION
## Summary

This PR removes the IAM configuration option since IAM is now embedded in the S3 server by default.

## Background

In [seaweedfs/seaweedfs#7740](https://github.com/seaweedfs/seaweedfs/pull/7740), IAM was embedded into the S3 server. When S3 is enabled, IAM is automatically available on the same port (8333). No separate configuration is needed.

## Changes

- Removed `IAM` field from `FilerServerSpec`
- Removed IAM-related code from Kubernetes exporter
- Added comment noting IAM is embedded in S3 by default

## Result

Simpler configuration - just enable S3 and IAM is automatically available on the same port.

```yaml
filer_servers:
  - ip: 192.168.1.10
    port: 8888
    s3: true       # S3 + IAM on port 8333
    s3_port: 8333
```