### PR TITLE
feat(upgrade): rolling upgrade with health gates and rollback

### DIFF
--- a/.github/workflows/integration-upgrade.yml
+++ b/.github/workflows/integration-upgrade.yml
@@ -1,0 +1,247 @@
+name: Integration Tests - Rolling Upgrade
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: test/integration
+
+jobs:
+  upgrade-test:
+    name: Rolling Upgrade Test
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Build seaweed-up binary
+        working-directory: .
+        run: go build -v -o seaweed-up .
+
+      - name: Create Docker network
+        run: |
+          docker network create --driver bridge --subnet 172.28.0.0/16 seaweed-up-net
+
+      - name: Start containers with docker run
+        run: |
+          # Use docker run with --cgroupns=host which is required for systemd on GitHub Actions
+          docker run -d \
+            --name seaweed-up-host1 \
+            --hostname host1 \
+            --privileged \
+            --cgroupns=host \
+            --network seaweed-up-net \
+            --ip 172.28.0.10 \
+            -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+            geerlingguy/docker-ubuntu2204-ansible:latest
+
+          docker run -d \
+            --name seaweed-up-host2 \
+            --hostname host2 \
+            --privileged \
+            --cgroupns=host \
+            --network seaweed-up-net \
+            --ip 172.28.0.11 \
+            -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+            geerlingguy/docker-ubuntu2204-ansible:latest
+
+          docker run -d \
+            --name seaweed-up-host3 \
+            --hostname host3 \
+            --privileged \
+            --cgroupns=host \
+            --network seaweed-up-net \
+            --ip 172.28.0.12 \
+            -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+            geerlingguy/docker-ubuntu2204-ansible:latest
+
+          echo "Waiting for containers to start..."
+          sleep 10
+          docker ps -a
+
+          for host in seaweed-up-host1 seaweed-up-host2 seaweed-up-host3; do
+            status=$(docker inspect -f '{{.State.Status}}' $host 2>/dev/null || echo "not found")
+            echo "Container $host status: $status"
+            if [ "$status" != "running" ]; then
+              docker logs $host 2>&1 || true
+              exit 1
+            fi
+          done
+
+          echo "Waiting for systemd to initialize..."
+          for host in seaweed-up-host1 seaweed-up-host2 seaweed-up-host3; do
+            for i in {1..60}; do
+              state=$(docker exec $host systemctl is-system-running 2>/dev/null || echo "starting")
+              if [ "$state" = "running" ] || [ "$state" = "degraded" ]; then
+                echo "Systemd ready on $host (state: $state)"
+                break
+              fi
+              if [ $i -eq 60 ]; then
+                echo "Timeout waiting for systemd on $host"
+                docker logs $host 2>&1 || true
+                exit 1
+              fi
+              sleep 2
+            done
+          done
+
+      - name: Install SSH on containers
+        run: |
+          for host in seaweed-up-host1 seaweed-up-host2 seaweed-up-host3; do
+            docker exec $host bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server curl netcat-openbsd"
+            docker exec $host bash -c "mkdir -p /run/sshd"
+            docker exec $host bash -c "sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config"
+            docker exec $host bash -c "sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config"
+            docker exec $host bash -c "systemctl enable ssh && systemctl start ssh"
+          done
+
+          sleep 5
+          for ip in 172.28.0.10 172.28.0.11 172.28.0.12; do
+            for j in {1..30}; do
+              if nc -z $ip 22 2>/dev/null; then
+                echo "SSH ready on $ip"
+                break
+              fi
+              if [ $j -eq 30 ]; then
+                echo "SSH not ready on $ip"
+                exit 1
+              fi
+              sleep 1
+            done
+          done
+
+      - name: Setup SSH keys
+        run: |
+          mkdir -p .ssh
+          ssh-keygen -t rsa -b 2048 -f .ssh/id_rsa_test -N "" -q
+
+          PUB_KEY=$(cat .ssh/id_rsa_test.pub)
+
+          for host in seaweed-up-host1 seaweed-up-host2 seaweed-up-host3; do
+            docker exec $host bash -c "mkdir -p /root/.ssh && chmod 700 /root/.ssh"
+            docker exec $host bash -c "echo '$PUB_KEY' > /root/.ssh/authorized_keys"
+            docker exec $host bash -c "chmod 600 /root/.ssh/authorized_keys && chown root:root /root/.ssh/authorized_keys"
+          done
+
+      - name: Verify SSH connectivity
+        run: |
+          for ip in 172.28.0.10 172.28.0.11 172.28.0.12; do
+            ssh -i .ssh/id_rsa_test -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 root@$ip "echo 'SSH OK to $ip'"
+          done
+
+      - name: Deploy initial cluster at pinned version
+        run: |
+          ../../seaweed-up cluster deploy test-upgrade \
+            -f testdata/cluster-single.yaml \
+            -u root \
+            --identity .ssh/id_rsa_test \
+            --version 3.73 \
+            --yes
+
+          sleep 15
+          nc -z 172.28.0.10 9333 || (echo "Master not running" && exit 1)
+          echo "Initial deploy verified"
+
+          echo "=== /dir/status before upgrade ==="
+          curl -sS "http://172.28.0.10:9333/dir/status" || true
+
+      - name: Run rolling upgrade
+        run: |
+          ../../seaweed-up cluster upgrade test-upgrade \
+            -f testdata/cluster-single.yaml \
+            -u root \
+            --identity .ssh/id_rsa_test \
+            --version 3.80 \
+            --yes
+
+          sleep 10
+          echo "=== /dir/status after upgrade ==="
+          curl -sS "http://172.28.0.10:9333/dir/status" || true
+
+          # Assert master is still healthy after upgrade
+          nc -z 172.28.0.10 9333 || (echo "Master not running after upgrade" && exit 1)
+
+          # Best-effort: check the reported version contains the upgraded version
+          for i in {1..30}; do
+            status_body=$(curl -sS "http://172.28.0.10:9333/dir/status" || true)
+            if echo "$status_body" | grep -q "3.80"; then
+              echo "Master reports upgraded version 3.80"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "Master did not report upgraded version 3.80"
+              echo "Last status: $status_body"
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Test rollback on bogus upgrade
+        run: |
+          set +e
+          ../../seaweed-up cluster upgrade test-upgrade \
+            -f testdata/cluster-single.yaml \
+            -u root \
+            --identity .ssh/id_rsa_test \
+            --version 0.0.0-does-not-exist \
+            --rollback-on-failure=true \
+            --yes
+          rc=$?
+          set -e
+          echo "Bogus upgrade exit code: $rc (expected non-zero)"
+
+          sleep 5
+          echo "=== /dir/status after rollback ==="
+          curl -sS "http://172.28.0.10:9333/dir/status" || true
+
+          # After rollback the master should still be reachable
+          nc -z 172.28.0.10 9333 || (echo "Master unreachable after rollback" && exit 1)
+          echo "Master reachable after rollback"
+
+      - name: Save logs
+        if: always()
+        run: |
+          echo "=== Container Status ===" > upgrade.log
+          docker ps -a >> upgrade.log
+
+          for host in seaweed-up-host1 seaweed-up-host2 seaweed-up-host3; do
+            echo "=== Logs for $host ===" >> upgrade.log
+            docker logs $host >> upgrade.log 2>&1 || true
+            echo "=== journal seaweed* on $host ===" >> upgrade.log
+            docker exec $host journalctl -u 'seaweed*' --no-pager -n 200 >> upgrade.log 2>&1 || true
+          done
+
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: upgrade-test-logs
+          path: test/integration/upgrade.log
+          retention-days: 7
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker stop seaweed-up-host1 seaweed-up-host2 seaweed-up-host3 || true
+          docker rm seaweed-up-host1 seaweed-up-host2 seaweed-up-host3 || true
+          docker network rm seaweed-up-net || true
+          rm -rf .ssh

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -169,6 +169,7 @@ This command safely upgrades cluster components with minimal downtime:
 	cmd.Flags().BoolVarP(&opts.SkipConfirm, "yes", "y", false, "skip confirmation prompts")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "show what would be done without making changes")
 	cmd.Flags().BoolVar(&opts.RollbackOnFailure, "rollback-on-failure", true, "reinstall previous version on a host if its post-upgrade health check fails")
+	cmd.Flags().BoolVar(&opts.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "skip TLS certificate verification for upgrade health probes")
 
 	_ = cmd.MarkFlagRequired("version")
 	_ = cmd.MarkFlagRequired("file")

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -126,8 +126,11 @@ Shows real-time information about cluster components including:
 }
 
 func newClusterUpgradeCmd() *cobra.Command {
-	opts := &ClusterUpgradeOptions{}
-	
+	opts := &ClusterUpgradeOptions{
+		SSHPort:           22,
+		RollbackOnFailure: true,
+	}
+
 	cmd := &cobra.Command{
 		Use:   "upgrade <cluster-name>",
 		Short: "Upgrade cluster to a new SeaweedFS version",
@@ -138,28 +141,37 @@ This command safely upgrades cluster components with minimal downtime:
 - Performs health checks before and after upgrade
 - Supports rollback on failure
 - Maintains data availability during upgrade`,
-		
+
 		Example: `  # Upgrade to specific version
-  seaweed-up cluster upgrade prod-cluster --version=3.75
-  
+  seaweed-up cluster upgrade prod-cluster -f cluster.yaml --version=3.75
+
   # Upgrade to latest version
-  seaweed-up cluster upgrade prod-cluster --version=latest
-  
+  seaweed-up cluster upgrade prod-cluster -f cluster.yaml --version=latest
+
   # Dry run to see what would be upgraded
-  seaweed-up cluster upgrade prod-cluster --version=3.75 --dry-run`,
-		
-		Args: cobra.ExactArgs(1),
+  seaweed-up cluster upgrade prod-cluster -f cluster.yaml --version=3.75 --dry-run`,
+
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runClusterUpgrade(args[0], opts)
+			name := ""
+			if len(args) > 0 {
+				name = args[0]
+			}
+			return runClusterUpgrade(name, opts)
 		},
 	}
-	
+
 	cmd.Flags().StringVar(&opts.Version, "version", "", "target version to upgrade to (required)")
-	cmd.Flags().StringVarP(&opts.ConfigFile, "file", "f", "", "cluster configuration file")
+	cmd.Flags().StringVarP(&opts.ConfigFile, "file", "f", "", "cluster configuration file (required)")
+	cmd.Flags().StringVarP(&opts.User, "user", "u", "", "SSH user (default: current user)")
+	cmd.Flags().IntVarP(&opts.SSHPort, "port", "p", 22, "SSH port")
+	cmd.Flags().StringVarP(&opts.IdentityFile, "identity", "i", "", "SSH identity file")
 	cmd.Flags().BoolVarP(&opts.SkipConfirm, "yes", "y", false, "skip confirmation prompts")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "show what would be done without making changes")
-	
+	cmd.Flags().BoolVar(&opts.RollbackOnFailure, "rollback-on-failure", true, "reinstall previous version on a host if its post-upgrade health check fails")
+
 	_ = cmd.MarkFlagRequired("version")
+	_ = cmd.MarkFlagRequired("file")
 
 	return cmd
 }

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -325,12 +327,53 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 	return nil
 }
 
-// versionRegex captures semver-ish version tokens like "3.64" or "v3.64.1".
-var versionRegex = regexp.MustCompile(`v?\d+\.\d+(?:\.\d+)?`)
+// seaweedVersionRegexes are ordered-by-preference patterns used to extract a
+// SeaweedFS version from a master's /dir/status or /cluster/status response.
+//
+// SeaweedFS versions look like "30GB 3.85 b2f34c..." (disk-unit, version,
+// commit) or "seaweedfs 3.85". We deliberately avoid a bare `\d+\.\d+` match
+// because the master's response can legitimately contain IP addresses (e.g.
+// "172.28.0.10") which would otherwise be mis-parsed as versions — that caused
+// a rolling upgrade rollback to try to reinstall "172.28.0" and fail.
+var seaweedVersionRegexes = []*regexp.Regexp{
+	// "30GB 3.85 abcd1234" — the canonical /dir/status Version field.
+	regexp.MustCompile(`\b\d+\s*[KMGT]B\s+(\d+\.\d+(?:\.\d+)?)\b`),
+	// "seaweedfs 3.85" or "weed 3.85".
+	regexp.MustCompile(`(?i)\b(?:seaweedfs|weed)\s+v?(\d+\.\d+(?:\.\d+)?)\b`),
+	// "seaweedfs/3.85" (e.g. Server header).
+	regexp.MustCompile(`(?i)\b(?:seaweedfs|weed)/v?(\d+\.\d+(?:\.\d+)?)\b`),
+}
 
-// probeCurrentClusterVersion asks one of the master hosts for its running
-// version. It tries /cluster/status first and falls back to /dir/status,
-// looking in both the JSON body and the Server response header.
+// extractSeaweedVersion returns a version token from s, or "" if nothing
+// plausible is found. Matches must come from the Seaweed-specific patterns
+// above; a raw IP address like "172.28.0.10" will never match.
+func extractSeaweedVersion(s string) string {
+	if s == "" {
+		return ""
+	}
+	for _, re := range seaweedVersionRegexes {
+		if m := re.FindStringSubmatch(s); len(m) >= 2 && m[1] != "" {
+			return m[1]
+		}
+	}
+	return ""
+}
+
+// dirStatusPayload is the minimal subset of SeaweedFS's /dir/status response
+// we care about for version probing.
+type dirStatusPayload struct {
+	Version string `json:"Version"`
+}
+
+// probeCurrentClusterVersion asks the master hosts for their running version.
+// It tries /dir/status first and falls back to /cluster/status, preferring a
+// typed JSON Version field and then falling back to the Server response header.
+//
+// The parser is strict: it only accepts tokens that match a Seaweed-specific
+// version pattern. An IP-like substring ("172.28.0.10") will never be returned.
+// If a master responds 2xx but no version could be extracted, probing
+// continues with the remaining masters; "" + nil is returned only when all
+// masters responded successfully without a recognizable version.
 //
 // When the cluster is TLS-enabled, the default http.Client uses the system
 // cert pool. Pass insecureSkipTLSVerify=true to disable certificate
@@ -350,9 +393,11 @@ func probeCurrentClusterVersion(clusterSpec *spec.Specification, insecureSkipTLS
 		Transport: newUpgradeHTTPTransport(insecureSkipTLSVerify),
 	}
 	var lastErr error
+	sawHealthyMasterWithoutVersion := false
 	for _, ms := range clusterSpec.MasterServers {
-		for _, path := range []string{"/cluster/status", "/dir/status"} {
-			url := fmt.Sprintf("%s://%s:%d%s", scheme, ms.Ip, ms.Port, path)
+		for _, path := range []string{"/dir/status", "/cluster/status"} {
+			addr := net.JoinHostPort(ms.Ip, strconv.Itoa(ms.Port))
+			url := fmt.Sprintf("%s://%s%s", scheme, addr, path)
 			req, err := http.NewRequest(http.MethodGet, url, nil)
 			if err != nil {
 				lastErr = err
@@ -375,34 +420,39 @@ func probeCurrentClusterVersion(clusterSpec *spec.Specification, insecureSkipTLS
 				lastErr = fmt.Errorf("read body from %s: %w", url, readErr)
 				continue
 			}
-			// Try common JSON fields. Only accept matches that look like a
-			// version — if a field exists but doesn't match the regex (e.g. a
-			// commit hash), keep searching rather than silently returning it.
+			// Prefer the typed JSON Version field.
+			var typed dirStatusPayload
+			if jsonErr := json.Unmarshal(body, &typed); jsonErr == nil && typed.Version != "" {
+				if v := extractSeaweedVersion(typed.Version); v != "" {
+					return v, nil
+				}
+			}
+			// Generic map lookup covers responses that use lowercase "version".
 			var payload map[string]interface{}
 			if jsonErr := json.Unmarshal(body, &payload); jsonErr == nil {
 				for _, key := range []string{"Version", "version"} {
-					if v, ok := payload[key].(string); ok && v != "" {
-						if m := versionRegex.FindString(v); m != "" {
-							return m, nil
+					if raw, ok := payload[key].(string); ok && raw != "" {
+						if v := extractSeaweedVersion(raw); v != "" {
+							return v, nil
 						}
 					}
 				}
 			}
 			// Fall back to the Server response header.
-			if serverHeader != "" {
-				if m := versionRegex.FindString(serverHeader); m != "" {
-					return m, nil
-				}
+			if v := extractSeaweedVersion(serverHeader); v != "" {
+				return v, nil
 			}
-			// Last-ditch: regex scan the raw body.
-			if m := versionRegex.FindString(string(body)); m != "" {
-				return m, nil
-			}
-			// Nothing matched the version regex on this endpoint. Treat as
-			// "unknown version" rather than returning a non-version string.
-			// Return empty + nil so the caller proceeds with rollback disabled.
-			return "", nil
+			// Nothing matched on this endpoint. Remember that this master
+			// responded 2xx but didn't yield a recognizable version, and
+			// keep probing other masters/endpoints.
+			sawHealthyMasterWithoutVersion = true
 		}
+	}
+	if sawHealthyMasterWithoutVersion {
+		// All reachable masters responded but none exposed a parseable
+		// version. Return empty + nil so the caller proceeds with rollback
+		// disabled rather than treating this as a hard error.
+		return "", nil
 	}
 	if lastErr == nil {
 		lastErr = fmt.Errorf("no master responded")

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -1,11 +1,16 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"syscall"
 	"time"
@@ -286,6 +291,17 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 		}
 	}
 
+	// Probe the currently-running cluster version so that rollback has a target
+	// to restore to. If probing fails we proceed with previousVersion="" and
+	// rollback will be disabled for this run.
+	if current, err := probeCurrentClusterVersion(clusterSpec); err != nil {
+		color.Yellow("⚠️  Could not determine current cluster version (%v); rollback will be disabled.", err)
+		mgr.Version = ""
+	} else {
+		color.Cyan("ℹ️  Current cluster version detected: %s", current)
+		mgr.Version = current
+	}
+
 	upgradeOpts := manager.UpgradeOptions{
 		RollbackOnFailure: opts.RollbackOnFailure,
 		DryRun:            opts.DryRun,
@@ -302,6 +318,83 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 		color.Green("✅ Cluster upgraded to %s", opts.Version)
 	}
 	return nil
+}
+
+// versionRegex captures semver-ish version tokens like "3.64" or "v3.64.1".
+var versionRegex = regexp.MustCompile(`v?\d+\.\d+(?:\.\d+)?`)
+
+// probeCurrentClusterVersion asks one of the master hosts for its running
+// version. It tries /cluster/status first and falls back to /dir/status,
+// looking in both the JSON body and the Server response header.
+//
+// TODO: plumb the cluster CA bundle through so we can set
+// InsecureSkipVerify=false. For now we intentionally skip verification so
+// upgrades work on self-signed clusters out of the box.
+func probeCurrentClusterVersion(clusterSpec *spec.Specification) (string, error) {
+	if len(clusterSpec.MasterServers) == 0 {
+		return "", fmt.Errorf("no master servers in spec")
+	}
+	scheme := "http"
+	if clusterSpec.GlobalOptions.TLSEnabled {
+		scheme = "https"
+	}
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // see TODO above
+			},
+		},
+	}
+	var lastErr error
+	for _, ms := range clusterSpec.MasterServers {
+		for _, path := range []string{"/cluster/status", "/dir/status"} {
+			url := fmt.Sprintf("%s://%s:%d%s", scheme, ms.Ip, ms.Port, path)
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				lastErr = fmt.Errorf("status %d from %s", resp.StatusCode, url)
+				continue
+			}
+			// Try common JSON fields.
+			var payload map[string]interface{}
+			if jsonErr := json.Unmarshal(body, &payload); jsonErr == nil {
+				for _, key := range []string{"Version", "version"} {
+					if v, ok := payload[key].(string); ok && v != "" {
+						if m := versionRegex.FindString(v); m != "" {
+							return m, nil
+						}
+						return v, nil
+					}
+				}
+			}
+			// Fall back to the Server response header.
+			if s := resp.Header.Get("Server"); s != "" {
+				if m := versionRegex.FindString(s); m != "" {
+					return m, nil
+				}
+			}
+			// Last-ditch: regex scan the raw body.
+			if m := versionRegex.FindString(string(body)); m != "" {
+				return m, nil
+			}
+			lastErr = fmt.Errorf("no version found in response from %s", url)
+		}
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no master responded")
+	}
+	return "", lastErr
 }
 
 func runClusterScaleOut(clusterName string, opts *ClusterScaleOutOptions) error {

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -360,10 +360,16 @@ func probeCurrentClusterVersion(clusterSpec *spec.Specification) (string, error)
 				lastErr = err
 				continue
 			}
-			body, _ := io.ReadAll(resp.Body)
-			_ = resp.Body.Close()
 			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 				lastErr = fmt.Errorf("status %d from %s", resp.StatusCode, url)
+				_ = resp.Body.Close()
+				continue
+			}
+			body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+			serverHeader := resp.Header.Get("Server")
+			_ = resp.Body.Close()
+			if readErr != nil {
+				lastErr = fmt.Errorf("read body from %s: %w", url, readErr)
 				continue
 			}
 			// Try common JSON fields.
@@ -379,8 +385,8 @@ func probeCurrentClusterVersion(clusterSpec *spec.Specification) (string, error)
 				}
 			}
 			// Fall back to the Server response header.
-			if s := resp.Header.Get("Server"); s != "" {
-				if m := versionRegex.FindString(s); m != "" {
+			if serverHeader != "" {
+				if m := versionRegex.FindString(serverHeader); m != "" {
 					return m, nil
 				}
 			}

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -41,10 +41,14 @@ type ClusterStatusOptions struct {
 }
 
 type ClusterUpgradeOptions struct {
-	Version     string
-	ConfigFile  string
-	SkipConfirm bool
-	DryRun      bool
+	Version           string
+	ConfigFile        string
+	User              string
+	SSHPort           int
+	IdentityFile      string
+	SkipConfirm       bool
+	DryRun            bool
+	RollbackOnFailure bool
 }
 
 type ClusterScaleOutOptions struct {
@@ -227,14 +231,76 @@ func displayClusterStatus(args []string, opts *ClusterStatusOptions) error {
 
 func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 	color.Green("⬆️  Upgrading cluster: %s to version %s", clusterName, opts.Version)
-	
+
+	if opts.Version == "" {
+		return fmt.Errorf("--version is required")
+	}
+
+	clusterSpec, err := loadClusterSpec(opts.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("failed to load cluster configuration: %w", err)
+	}
+	if clusterName != "" {
+		clusterSpec.Name = clusterName
+	}
+
+	mgr := manager.NewManager()
+	mgr.SshPort = opts.SSHPort
+	if mgr.SshPort == 0 {
+		mgr.SshPort = 22
+	}
+
+	if opts.User == "" {
+		currentUser, err := utils.CurrentUser()
+		if err != nil {
+			return fmt.Errorf("failed to get current user for SSH: %w", err)
+		}
+		mgr.User = currentUser
+	} else {
+		mgr.User = opts.User
+	}
+
+	if opts.IdentityFile == "" {
+		home, err := utils.UserHome()
+		if err != nil {
+			return fmt.Errorf("failed to determine home directory for SSH identity file: %w", err)
+		}
+		mgr.IdentityFile = filepath.Join(home, ".ssh", "id_rsa")
+	} else {
+		mgr.IdentityFile = opts.IdentityFile
+	}
+
 	if opts.DryRun {
 		color.Yellow("🔍 Dry run mode - no changes will be made")
+	} else if !opts.SkipConfirm {
+		color.Yellow("📋 Upgrade Summary:")
+		fmt.Printf("  Cluster: %s\n", clusterSpec.Name)
+		fmt.Printf("  Target Version: %s\n", opts.Version)
+		fmt.Printf("  Masters: %d\n", len(clusterSpec.MasterServers))
+		fmt.Printf("  Volumes: %d\n", len(clusterSpec.VolumeServers))
+		fmt.Printf("  Filers:  %d\n", len(clusterSpec.FilerServers))
+		fmt.Printf("  Rollback on failure: %v\n", opts.RollbackOnFailure)
+		if !utils.PromptForConfirmation("Proceed with rolling upgrade?") {
+			color.Yellow("⚠️  Upgrade cancelled by user")
+			return nil
+		}
 	}
-	
-	// TODO: Implement upgrade logic
-	fmt.Println("Upgrade functionality not yet implemented")
-	
+
+	upgradeOpts := manager.UpgradeOptions{
+		RollbackOnFailure: opts.RollbackOnFailure,
+		DryRun:            opts.DryRun,
+	}
+
+	if err := mgr.UpgradeCluster(clusterSpec, opts.Version, upgradeOpts); err != nil {
+		color.Red("❌ Upgrade failed: %v", err)
+		return err
+	}
+
+	if opts.DryRun {
+		color.Green("✅ Dry-run complete.")
+	} else {
+		color.Green("✅ Cluster upgraded to %s", opts.Version)
+	}
 	return nil
 }
 

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -84,7 +84,7 @@ type ClusterListOptions struct {
 }
 
 func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOptions) error {
-	color.Green("🚀 Deploying SeaweedFS cluster...")
+	color.Green("Deploying SeaweedFS cluster...")
 	
 	// Load cluster specification
 	clusterSpec, err := loadClusterSpec(opts.ConfigFile)
@@ -139,7 +139,7 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 	
 	// Confirm deployment if not skipped
 	if !opts.SkipConfirm {
-		color.Yellow("📋 Deployment Summary:")
+		color.Yellow("Deployment Summary:")
 		fmt.Printf("  Cluster: %s\n", clusterSpec.Name)
 		fmt.Printf("  Version: %s\n", mgr.Version)
 		fmt.Printf("  Masters: %d\n", len(clusterSpec.MasterServers))
@@ -147,19 +147,19 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 		fmt.Printf("  Filers:  %d\n", len(clusterSpec.FilerServers))
 		
 		if !utils.PromptForConfirmation("Proceed with deployment?") {
-			color.Yellow("⚠️  Deployment cancelled by user")
+			color.Yellow("WARN: Deployment cancelled by user")
 			return nil
 		}
 	}
 	
 	// Deploy cluster
 	if err := mgr.DeployCluster(clusterSpec); err != nil {
-		color.Red("❌ Deployment failed: %v", err)
+		color.Red("Error: Deployment failed: %v", err)
 		return err
 	}
 	
-	color.Green("✅ Cluster deployed successfully!")
-	color.Cyan("💡 Next steps:")
+	color.Green("Cluster deployed successfully!")
+	color.Cyan("Next steps:")
 	fmt.Println("  - Check cluster status: seaweed-up cluster status", clusterSpec.Name)
 	fmt.Println("  - View logs: seaweed-up cluster logs", clusterSpec.Name)
 	
@@ -182,21 +182,21 @@ func runClusterStatus(args []string, opts *ClusterStatusOptions) error {
 		if err := displayClusterStatus(args, opts); err != nil {
 			return err
 		}
-		color.Cyan("🔄 Refreshing every %d seconds (Press Ctrl+C to stop)", opts.Refresh)
+		color.Cyan("Refreshing every %d seconds (Press Ctrl+C to stop)", opts.Refresh)
 
 		for {
 			select {
 			case <-sigChan:
 				// Graceful shutdown on interrupt
 				fmt.Println()
-				color.Yellow("⏹️  Refresh stopped by user")
+				color.Yellow("Refresh stopped by user")
 				return nil
 			case <-ticker.C:
 				clearScreen()
 				if err := displayClusterStatus(args, opts); err != nil {
 					return err
 				}
-				color.Cyan("🔄 Refreshing every %d seconds (Press Ctrl+C to stop)", opts.Refresh)
+				color.Cyan("Refreshing every %d seconds (Press Ctrl+C to stop)", opts.Refresh)
 			}
 		}
 	}
@@ -222,15 +222,15 @@ func clearScreen() {
 // displayClusterStatus shows the actual cluster status
 func displayClusterStatus(args []string, opts *ClusterStatusOptions) error {
 	// TODO: Implement actual status collection
-	color.Green("📊 Cluster Status")
+	color.Green("Cluster Status")
 	
 	if len(args) == 0 {
-		color.Yellow("📋 All Clusters:")
+		color.Yellow("All Clusters:")
 		// Show all clusters
 		fmt.Println("No clusters found. Deploy a cluster first with 'seaweed-up cluster deploy'")
 	} else {
 		clusterName := args[0]
-		color.Yellow("📋 Cluster: %s", clusterName)
+		color.Yellow("Cluster: %s", clusterName)
 		fmt.Println("Status collection not yet implemented")
 	}
 	
@@ -238,7 +238,7 @@ func displayClusterStatus(args []string, opts *ClusterStatusOptions) error {
 }
 
 func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
-	color.Green("⬆️  Upgrading cluster: %s to version %s", clusterName, opts.Version)
+	color.Green("Upgrading cluster: %s to version %s", clusterName, opts.Version)
 
 	if opts.Version == "" {
 		return fmt.Errorf("--version is required")
@@ -279,9 +279,9 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 	}
 
 	if opts.DryRun {
-		color.Yellow("🔍 Dry run mode - no changes will be made")
+		color.Yellow("Dry run mode - no changes will be made")
 	} else if !opts.SkipConfirm {
-		color.Yellow("📋 Upgrade Summary:")
+		color.Yellow("Upgrade Summary:")
 		fmt.Printf("  Cluster: %s\n", clusterSpec.Name)
 		fmt.Printf("  Target Version: %s\n", opts.Version)
 		fmt.Printf("  Masters: %d\n", len(clusterSpec.MasterServers))
@@ -289,7 +289,7 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 		fmt.Printf("  Filers:  %d\n", len(clusterSpec.FilerServers))
 		fmt.Printf("  Rollback on failure: %v\n", opts.RollbackOnFailure)
 		if !utils.PromptForConfirmation("Proceed with rolling upgrade?") {
-			color.Yellow("⚠️  Upgrade cancelled by user")
+			color.Yellow("WARN: Upgrade cancelled by user")
 			return nil
 		}
 	}
@@ -298,13 +298,13 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 	// to restore to. If probing fails we proceed with previousVersion="" and
 	// rollback will be disabled for this run.
 	if current, err := probeCurrentClusterVersion(clusterSpec, opts.InsecureSkipTLSVerify); err != nil {
-		color.Yellow("⚠️  Could not determine current cluster version (%v); rollback will be disabled.", err)
+		color.Yellow("WARN: Could not determine current cluster version (%v); rollback will be disabled.", err)
 		mgr.Version = ""
 	} else if current == "" {
-		color.Yellow("⚠️  Current cluster version could not be parsed from master response; rollback will be disabled.")
+		color.Yellow("WARN: Current cluster version could not be parsed from master response; rollback will be disabled.")
 		mgr.Version = ""
 	} else {
-		color.Cyan("ℹ️  Current cluster version detected: %s", current)
+		color.Cyan("Current cluster version detected: %s", current)
 		mgr.Version = current
 	}
 
@@ -315,14 +315,14 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 	}
 
 	if err := mgr.UpgradeCluster(clusterSpec, opts.Version, upgradeOpts); err != nil {
-		color.Red("❌ Upgrade failed: %v", err)
+		color.Red("Error: Upgrade failed: %v", err)
 		return err
 	}
 
 	if opts.DryRun {
-		color.Green("✅ Dry-run complete.")
+		color.Green("Dry-run complete.")
 	} else {
-		color.Green("✅ Cluster upgraded to %s", opts.Version)
+		color.Green("Cluster upgraded to %s", opts.Version)
 	}
 	return nil
 }
@@ -475,7 +475,7 @@ func newUpgradeHTTPTransport(insecureSkipTLSVerify bool) *http.Transport {
 }
 
 func runClusterScaleOut(clusterName string, opts *ClusterScaleOutOptions) error {
-	color.Green("📈 Scaling out cluster: %s", clusterName)
+	color.Green("Scaling out cluster: %s", clusterName)
 	
 	if opts.AddVolume > 0 {
 		fmt.Printf("Adding %d volume servers\n", opts.AddVolume)
@@ -491,7 +491,7 @@ func runClusterScaleOut(clusterName string, opts *ClusterScaleOutOptions) error 
 }
 
 func runClusterScaleIn(clusterName string, opts *ClusterScaleInOptions) error {
-	color.Green("📉 Scaling in cluster: %s", clusterName)
+	color.Green("Scaling in cluster: %s", clusterName)
 	
 	if len(opts.RemoveNodes) > 0 {
 		fmt.Printf("Removing nodes: %v\n", opts.RemoveNodes)
@@ -504,17 +504,17 @@ func runClusterScaleIn(clusterName string, opts *ClusterScaleInOptions) error {
 }
 
 func runClusterDestroy(clusterName string, opts *ClusterDestroyOptions) error {
-	color.Red("💥 WARNING: This will destroy cluster '%s'", clusterName)
+	color.Red("WARNING: This will destroy cluster '%s'", clusterName)
 	
 	if opts.RemoveData {
-		color.Red("⚠️  ALL DATA WILL BE PERMANENTLY DELETED!")
+		color.Red("WARN: ALL DATA WILL BE PERMANENTLY DELETED!")
 	}
 	
 	if !opts.SkipConfirm {
 		confirmation := utils.PromptForInput("Type the cluster name to confirm destruction: ")
 		
 		if confirmation != clusterName {
-			color.Yellow("⚠️  Destruction cancelled - cluster name didn't match")
+			color.Yellow("WARN: Destruction cancelled - cluster name didn't match")
 			return nil
 		}
 	}
@@ -526,7 +526,7 @@ func runClusterDestroy(clusterName string, opts *ClusterDestroyOptions) error {
 }
 
 func runClusterList(opts *ClusterListOptions) error {
-	color.Green("📋 Managed Clusters")
+	color.Green("Managed Clusters")
 	
 	// TODO: Implement cluster listing
 	fmt.Println("No clusters found. Deploy a cluster first with 'seaweed-up cluster deploy'")

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -46,14 +46,15 @@ type ClusterStatusOptions struct {
 }
 
 type ClusterUpgradeOptions struct {
-	Version           string
-	ConfigFile        string
-	User              string
-	SSHPort           int
-	IdentityFile      string
-	SkipConfirm       bool
-	DryRun            bool
-	RollbackOnFailure bool
+	Version               string
+	ConfigFile            string
+	User                  string
+	SSHPort               int
+	IdentityFile          string
+	SkipConfirm           bool
+	DryRun                bool
+	RollbackOnFailure     bool
+	InsecureSkipTLSVerify bool
 }
 
 type ClusterScaleOutOptions struct {
@@ -294,8 +295,11 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 	// Probe the currently-running cluster version so that rollback has a target
 	// to restore to. If probing fails we proceed with previousVersion="" and
 	// rollback will be disabled for this run.
-	if current, err := probeCurrentClusterVersion(clusterSpec); err != nil {
+	if current, err := probeCurrentClusterVersion(clusterSpec, opts.InsecureSkipTLSVerify); err != nil {
 		color.Yellow("⚠️  Could not determine current cluster version (%v); rollback will be disabled.", err)
+		mgr.Version = ""
+	} else if current == "" {
+		color.Yellow("⚠️  Current cluster version could not be parsed from master response; rollback will be disabled.")
 		mgr.Version = ""
 	} else {
 		color.Cyan("ℹ️  Current cluster version detected: %s", current)
@@ -303,8 +307,9 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 	}
 
 	upgradeOpts := manager.UpgradeOptions{
-		RollbackOnFailure: opts.RollbackOnFailure,
-		DryRun:            opts.DryRun,
+		RollbackOnFailure:     opts.RollbackOnFailure,
+		DryRun:                opts.DryRun,
+		InsecureSkipTLSVerify: opts.InsecureSkipTLSVerify,
 	}
 
 	if err := mgr.UpgradeCluster(clusterSpec, opts.Version, upgradeOpts); err != nil {
@@ -327,10 +332,12 @@ var versionRegex = regexp.MustCompile(`v?\d+\.\d+(?:\.\d+)?`)
 // version. It tries /cluster/status first and falls back to /dir/status,
 // looking in both the JSON body and the Server response header.
 //
-// TODO: plumb the cluster CA bundle through so we can set
-// InsecureSkipVerify=false. For now we intentionally skip verification so
-// upgrades work on self-signed clusters out of the box.
-func probeCurrentClusterVersion(clusterSpec *spec.Specification) (string, error) {
+// When the cluster is TLS-enabled, the default http.Client uses the system
+// cert pool. Pass insecureSkipTLSVerify=true to disable certificate
+// verification (for self-signed dev clusters).
+//
+// TODO: use cluster CA once tls bootstrap PR lands.
+func probeCurrentClusterVersion(clusterSpec *spec.Specification, insecureSkipTLSVerify bool) (string, error) {
 	if len(clusterSpec.MasterServers) == 0 {
 		return "", fmt.Errorf("no master servers in spec")
 	}
@@ -339,12 +346,8 @@ func probeCurrentClusterVersion(clusterSpec *spec.Specification) (string, error)
 		scheme = "https"
 	}
 	client := &http.Client{
-		Timeout: 5 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec // see TODO above
-			},
-		},
+		Timeout:   5 * time.Second,
+		Transport: newUpgradeHTTPTransport(insecureSkipTLSVerify),
 	}
 	var lastErr error
 	for _, ms := range clusterSpec.MasterServers {
@@ -372,7 +375,9 @@ func probeCurrentClusterVersion(clusterSpec *spec.Specification) (string, error)
 				lastErr = fmt.Errorf("read body from %s: %w", url, readErr)
 				continue
 			}
-			// Try common JSON fields.
+			// Try common JSON fields. Only accept matches that look like a
+			// version — if a field exists but doesn't match the regex (e.g. a
+			// commit hash), keep searching rather than silently returning it.
 			var payload map[string]interface{}
 			if jsonErr := json.Unmarshal(body, &payload); jsonErr == nil {
 				for _, key := range []string{"Version", "version"} {
@@ -380,7 +385,6 @@ func probeCurrentClusterVersion(clusterSpec *spec.Specification) (string, error)
 						if m := versionRegex.FindString(v); m != "" {
 							return m, nil
 						}
-						return v, nil
 					}
 				}
 			}
@@ -394,13 +398,30 @@ func probeCurrentClusterVersion(clusterSpec *spec.Specification) (string, error)
 			if m := versionRegex.FindString(string(body)); m != "" {
 				return m, nil
 			}
-			lastErr = fmt.Errorf("no version found in response from %s", url)
+			// Nothing matched the version regex on this endpoint. Treat as
+			// "unknown version" rather than returning a non-version string.
+			// Return empty + nil so the caller proceeds with rollback disabled.
+			return "", nil
 		}
 	}
 	if lastErr == nil {
 		lastErr = fmt.Errorf("no master responded")
 	}
 	return "", lastErr
+}
+
+// newUpgradeHTTPTransport builds an http.Transport for upgrade probes.
+//
+// Default behavior uses the system cert pool (tls.Config{}). When
+// insecureSkipTLSVerify is true, certificate verification is disabled.
+//
+// TODO: use cluster CA once tls bootstrap PR lands.
+func newUpgradeHTTPTransport(insecureSkipTLSVerify bool) *http.Transport {
+	tlsConfig := &tls.Config{}
+	if insecureSkipTLSVerify {
+		tlsConfig.InsecureSkipVerify = true //nolint:gosec // explicitly requested via --insecure-skip-tls-verify
+	}
+	return &http.Transport{TLSClientConfig: tlsConfig}
 }
 
 func runClusterScaleOut(clusterName string, opts *ClusterScaleOutOptions) error {

--- a/cmd/cluster_impl_test.go
+++ b/cmd/cluster_impl_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+)
+
+func TestExtractSeaweedVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"canonical dir status", "30GB 3.85 b2f34c5", "3.85"},
+		{"canonical dir status patch", "30GB 3.85.1 b2f34c5", "3.85.1"},
+		{"canonical with space before unit", "30 GB 3.85 commit", "3.85"},
+		{"named seaweedfs", "seaweedfs 3.85", "3.85"},
+		{"named weed", "weed v3.85.1", "3.85.1"},
+		{"server header slash", "SeaweedFS/3.85", "3.85"},
+		{"ip only returns empty", "172.28.0.10", ""},
+		{"ip embedded returns empty", "master at 172.28.0.10:9333 ok", ""},
+		{"commit hash only", "b2f34c5abcdef", ""},
+		{"empty string", "", ""},
+		{"bare digits", "3.85", ""}, // no SeaweedFS context, must not match
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractSeaweedVersion(tc.in)
+			if got != tc.want {
+				t.Errorf("extractSeaweedVersion(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// newTestMasterSpec builds a Specification pointing at the given test servers.
+func newTestMasterSpec(t *testing.T, servers ...*httptest.Server) *spec.Specification {
+	t.Helper()
+	s := &spec.Specification{}
+	for _, srv := range servers {
+		u, err := url.Parse(srv.URL)
+		if err != nil {
+			t.Fatalf("parse test server url: %v", err)
+		}
+		host, portStr, err := net.SplitHostPort(u.Host)
+		if err != nil {
+			t.Fatalf("split host/port: %v", err)
+		}
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			t.Fatalf("parse port: %v", err)
+		}
+		s.MasterServers = append(s.MasterServers, &spec.MasterServerSpec{
+			Ip:   host,
+			Port: port,
+		})
+	}
+	return s
+}
+
+func TestProbeCurrentClusterVersion_CanonicalDirStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/dir/status" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"Topology":{"Max":100},"Version":"30GB 3.85 b2f34c5"}`)
+	}))
+	defer srv.Close()
+
+	got, err := probeCurrentClusterVersion(newTestMasterSpec(t, srv), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "3.85" {
+		t.Errorf("got %q, want %q", got, "3.85")
+	}
+}
+
+func TestProbeCurrentClusterVersion_IPLikeStringNotExtracted(t *testing.T) {
+	// Simulate the CI failure mode: a master reports only IP-bearing fields.
+	// The previous regex extracted "172.28.0" which broke rollback.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"Leader":"172.28.0.10:9333","Peers":["172.28.0.10:9333","172.28.0.11:9333"]}`)
+	}))
+	defer srv.Close()
+
+	got, err := probeCurrentClusterVersion(newTestMasterSpec(t, srv), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want \"\" (IP must not be extracted as version)", got)
+	}
+	if strings.Contains(got, "172") {
+		t.Errorf("got %q contains IP bytes, regression against CI failure mode", got)
+	}
+}
+
+func TestProbeCurrentClusterVersion_NoVersionPresent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer srv.Close()
+
+	got, err := probeCurrentClusterVersion(newTestMasterSpec(t, srv), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestProbeCurrentClusterVersion_ContinuesProbingOtherMasters(t *testing.T) {
+	// First master responds 200 but without any version info.
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"Leader":"172.28.0.10:9333"}`)
+	}))
+	defer srv1.Close()
+	// Second master returns the canonical version payload.
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/dir/status" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"Version":"30GB 3.85 b2f34c5"}`)
+	}))
+	defer srv2.Close()
+
+	got, err := probeCurrentClusterVersion(newTestMasterSpec(t, srv1, srv2), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "3.85" {
+		t.Errorf("got %q, want %q", got, "3.85")
+	}
+}
+
+func TestProbeCurrentClusterVersion_AllHealthyButNoVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"Leader":"master:9333"}`)
+	}))
+	defer srv.Close()
+
+	got, err := probeCurrentClusterVersion(newTestMasterSpec(t, srv), false)
+	if err != nil {
+		t.Fatalf("unexpected error when healthy masters lack version: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want \"\"", got)
+	}
+}
+
+func TestProbeCurrentClusterVersion_ServerHeaderFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Server", "SeaweedFS/3.85")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	}))
+	defer srv.Close()
+
+	got, err := probeCurrentClusterVersion(newTestMasterSpec(t, srv), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "3.85" {
+		t.Errorf("got %q, want %q", got, "3.85")
+	}
+}

--- a/pkg/cluster/manager/deploy_volume_server.go
+++ b/pkg/cluster/manager/deploy_volume_server.go
@@ -24,9 +24,29 @@ func (m *Manager) DeployVolumeServer(masters []string, volumeServerSpec *spec.Vo
 			}
 		}
 
+		if err := m.ensureVolumeFolders(op, volumeServerSpec); err != nil {
+			return err
+		}
+
 		return m.deployComponentInstance(op, component, componentInstance, &buf)
 
 	})
+}
+
+// ensureVolumeFolders creates each configured -dir path on the remote host
+// before the volume server starts. SeaweedFS volume refuses to boot if any of
+// the -dir paths does not exist (Fatalf "Check Data Folder(-dir) Writable"),
+// so this must run on both initial deploys and rolling upgrades.
+func (m *Manager) ensureVolumeFolders(op operator.CommandOperator, volumeServerSpec *spec.VolumeServerSpec) error {
+	for _, folder := range volumeServerSpec.Folders {
+		if folder == nil || folder.Folder == "" {
+			continue
+		}
+		if err := m.sudo(op, fmt.Sprintf("mkdir -p %s", folder.Folder)); err != nil {
+			return fmt.Errorf("create volume data folder %s: %v", folder.Folder, err)
+		}
+	}
+	return nil
 }
 
 func (m *Manager) ResetVolumeServer(volumeServerSpec *spec.VolumeServerSpec, index int) error {

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -54,6 +54,10 @@ type componentHooks struct {
 	stop func() error
 	// writeConfig writes the component-specific CLI options to buf.
 	writeConfig func(buf *bytes.Buffer)
+	// prepareRemote runs component-specific host prep inside the SSH session
+	// (e.g. creating volume -dir paths) before deployComponentInstance runs.
+	// May be nil.
+	prepareRemote func(op operator.CommandOperator) error
 }
 
 // UpgradeCluster performs a rolling upgrade of the cluster to targetVersion.
@@ -189,10 +193,11 @@ func (m *Manager) upgradeOneHost(specification *spec.Specification, masters []st
 	case "volume":
 		vs := specification.VolumeServers[t.index]
 		hooks = componentHooks{
-			serviceName: "volume",
-			sshAddr:     net.JoinHostPort(vs.Ip, strconv.Itoa(vs.PortSsh)),
-			stop:        func() error { return m.StopVolumeServer(vs, t.index) },
-			writeConfig: func(buf *bytes.Buffer) { vs.WriteToBuffer(masters, buf) },
+			serviceName:   "volume",
+			sshAddr:       net.JoinHostPort(vs.Ip, strconv.Itoa(vs.PortSsh)),
+			stop:          func() error { return m.StopVolumeServer(vs, t.index) },
+			writeConfig:   func(buf *bytes.Buffer) { vs.WriteToBuffer(masters, buf) },
+			prepareRemote: func(op operator.CommandOperator) error { return m.ensureVolumeFolders(op, vs) },
 		}
 	case "filer":
 		fs := specification.FilerServers[t.index]
@@ -228,6 +233,11 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 	return operator.ExecuteRemote(hooks.sshAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
 		var buf bytes.Buffer
 		hooks.writeConfig(&buf)
+		if hooks.prepareRemote != nil {
+			if err := hooks.prepareRemote(op); err != nil {
+				return err
+			}
+		}
 		if err := m.deployComponentInstance(op, hooks.serviceName, componentInstance, &buf); err != nil {
 			return err
 		}

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,11 +56,17 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 
 	m.prepare(specification)
 
-	// Record the current version per host in-memory before making any changes.
-	// The Manager only has one active version at a time, so we snapshot whatever
-	// version is presently configured (or empty -> "latest"). In a richer world
-	// this would be probed from the host itself, but keeping it minimal on purpose.
+	// Snapshot the currently-deployed version. runClusterUpgrade is expected to
+	// populate m.Version with the cluster's current (pre-upgrade) version by
+	// probing a master host. If it could not probe, m.Version will be empty and
+	// rollback will be disabled for this run.
 	previousVersion := m.Version
+
+	// Pick the scheme for health probes based on the global TLS flag.
+	scheme := "http"
+	if specification.GlobalOptions.TLSEnabled {
+		scheme = "https"
+	}
 
 	var targets []upgradeTarget
 
@@ -70,7 +77,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			index:     i,
 			ip:        v.Ip,
 			portSsh:   v.PortSsh,
-			healthURL: fmt.Sprintf("http://%s:%d/status", v.Ip, v.Port),
+			healthURL: fmt.Sprintf("%s://%s:%d/status", scheme, v.Ip, v.Port),
 			describe:  fmt.Sprintf("volume%d %s:%d", i, v.Ip, v.Port),
 		})
 	}
@@ -81,7 +88,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			index:     i,
 			ip:        f.Ip,
 			portSsh:   f.PortSsh,
-			healthURL: fmt.Sprintf("http://%s:%d/", f.Ip, f.Port),
+			healthURL: fmt.Sprintf("%s://%s:%d/", scheme, f.Ip, f.Port),
 			describe:  fmt.Sprintf("filer%d %s:%d", i, f.Ip, f.Port),
 		})
 	}
@@ -92,19 +99,16 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			index:     i,
 			ip:        ms.Ip,
 			portSsh:   ms.PortSsh,
-			healthURL: fmt.Sprintf("http://%s:%d/cluster/status", ms.Ip, ms.Port),
+			healthURL: fmt.Sprintf("%s://%s:%d/cluster/status", scheme, ms.Ip, ms.Port),
 			describe:  fmt.Sprintf("master%d %s:%d", i, ms.Ip, ms.Port),
 		})
 	}
 
-	// Snapshot per-host "previous version". Right now this is homogeneous across
-	// the cluster, but we record per host so rollback semantics scale cleanly if
-	// heterogeneous versions ever land.
+	// Per-host previous-version record. Today this is homogeneous across the
+	// cluster (populated from previousVersion) but is captured immediately
+	// before each host's stop/install below so rollback picks up whatever was
+	// running on that specific host.
 	hostPrevVersion := make(map[string]string, len(targets))
-	for _, t := range targets {
-		hostPrevVersion[t.describe] = previousVersion
-	}
-	_ = hostPrevVersion
 
 	if opts.DryRun {
 		info(fmt.Sprintf("Dry-run: rolling upgrade plan to version %q (previous=%q)", targetVersion, previousVersion))
@@ -121,25 +125,34 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 
 	info(fmt.Sprintf("Starting rolling upgrade to version %q (previous=%q)", targetVersion, previousVersion))
 
+	// rollbackHost reinstalls the recorded previous version on t, if any.
+	rollbackHost := func(t upgradeTarget, cause error) error {
+		prev := hostPrevVersion[t.describe]
+		if !opts.RollbackOnFailure || prev == "" {
+			return cause
+		}
+		info(fmt.Sprintf("Rolling back %s to version %q", t.describe, prev))
+		m.Version = prev
+		if rbErr := m.upgradeOneHost(specification, masters, t); rbErr != nil {
+			return fmt.Errorf("%s failed (%v); rollback to %q also failed: %w", t.describe, cause, prev, rbErr)
+		}
+		return fmt.Errorf("%s failed; rolled back to %q: %w", t.describe, prev, cause)
+	}
+
 	for _, t := range targets {
 		info(fmt.Sprintf("Upgrading %s...", t.describe))
 
+		// Record the version running on this host right before we touch it.
+		hostPrevVersion[t.describe] = previousVersion
+
 		m.Version = targetVersion
 		if err := m.upgradeOneHost(specification, masters, t); err != nil {
-			return fmt.Errorf("upgrade %s: %w", t.describe, err)
+			return rollbackHost(t, fmt.Errorf("upgrade %s: %w", t.describe, err))
 		}
 
 		if err := waitForHealthy(t.healthURL, opts.HealthTimeout, opts.HealthInterval); err != nil {
 			info(fmt.Sprintf("Health check failed for %s: %v", t.describe, err))
-			if opts.RollbackOnFailure && previousVersion != "" {
-				info(fmt.Sprintf("Rolling back %s to version %q", t.describe, previousVersion))
-				m.Version = previousVersion
-				if rbErr := m.upgradeOneHost(specification, masters, t); rbErr != nil {
-					return fmt.Errorf("health check failed for %s (%v); rollback also failed: %w", t.describe, err, rbErr)
-				}
-				return fmt.Errorf("health check failed for %s after upgrade to %q; rolled back to %q: %w", t.describe, targetVersion, previousVersion, err)
-			}
-			return fmt.Errorf("health check failed for %s: %w", t.describe, err)
+			return rollbackHost(t, fmt.Errorf("health check failed for %s: %w", t.describe, err))
 		}
 
 		info(fmt.Sprintf("%s upgraded and healthy", t.describe))
@@ -203,13 +216,25 @@ func (m *Manager) upgradeOneHost(specification *spec.Specification, masters []st
 	return fmt.Errorf("unknown component: %s", t.component)
 }
 
-// waitForHealthy polls an HTTP URL until it returns 2xx or the timeout elapses.
-// This is intentionally minimal — a more thorough probe would parse the body.
+// waitForHealthy polls an HTTP(S) URL until it returns 2xx or the timeout
+// elapses. This is intentionally minimal — a more thorough probe would parse
+// the body.
+//
+// TODO: once the cluster CA bundle is plumbed through the Manager, honor
+// InsecureSkipVerify=false and load the cluster root CA into RootCAs. Today
+// we intentionally fall back to InsecureSkipVerify=true so that self-signed
+// upgrade probes don't block the rolling upgrade.
 func waitForHealthy(url string, timeout, interval time.Duration) error {
 	if url == "" {
 		return nil
 	}
-	client := &http.Client{Timeout: 5 * time.Second}
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			// Default: verify. Fallback to skip because CA bundle isn't wired yet.
+			InsecureSkipVerify: true, //nolint:gosec // see TODO above
+		},
+	}
+	client := &http.Client{Timeout: 5 * time.Second, Transport: transport}
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for time.Now().Before(deadline) {

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -23,6 +23,9 @@ type UpgradeOptions struct {
 	HealthTimeout time.Duration
 	// HealthInterval is the poll interval between health probes.
 	HealthInterval time.Duration
+	// InsecureSkipTLSVerify disables TLS certificate verification for health
+	// probes. Defaults to false; only set when the caller explicitly opts in.
+	InsecureSkipTLSVerify bool
 }
 
 // upgradeTarget represents a single host/instance to be upgraded.
@@ -35,6 +38,20 @@ type upgradeTarget struct {
 	healthURL string
 	// describe is a human-readable identifier for logs/errors.
 	describe string
+}
+
+// componentHooks bundles the per-component knobs used by upgradeOneHost so
+// the stop/redeploy/restart logic can live in a single helper instead of
+// being copy-pasted per component.
+type componentHooks struct {
+	// serviceName is the systemd unit base ("volume", "filer", "master").
+	serviceName string
+	// sshAddr is host:port for the SSH target of this instance.
+	sshAddr string
+	// stop stops the running systemd unit best-effort.
+	stop func() error
+	// writeConfig writes the component-specific CLI options to buf.
+	writeConfig func(buf *bytes.Buffer)
 }
 
 // UpgradeCluster performs a rolling upgrade of the cluster to targetVersion.
@@ -104,12 +121,6 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 		})
 	}
 
-	// Per-host previous-version record. Today this is homogeneous across the
-	// cluster (populated from previousVersion) but is captured immediately
-	// before each host's stop/install below so rollback picks up whatever was
-	// running on that specific host.
-	hostPrevVersion := make(map[string]string, len(targets))
-
 	if opts.DryRun {
 		info(fmt.Sprintf("Dry-run: rolling upgrade plan to version %q (previous=%q)", targetVersion, previousVersion))
 		for _, t := range targets {
@@ -125,9 +136,8 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 
 	info(fmt.Sprintf("Starting rolling upgrade to version %q (previous=%q)", targetVersion, previousVersion))
 
-	// rollbackHost reinstalls the recorded previous version on t, if any.
-	rollbackHost := func(t upgradeTarget, cause error) error {
-		prev := hostPrevVersion[t.describe]
+	// rollbackHost reinstalls the given previous version on t, if any.
+	rollbackHost := func(t upgradeTarget, prev string, cause error) error {
 		if !opts.RollbackOnFailure || prev == "" {
 			return cause
 		}
@@ -142,17 +152,21 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 	for _, t := range targets {
 		info(fmt.Sprintf("Upgrading %s...", t.describe))
 
-		// Record the version running on this host right before we touch it.
-		hostPrevVersion[t.describe] = previousVersion
+		// Capture the version running on this host right before we touch it.
+		// Today this is homogeneous across the cluster (sourced from
+		// previousVersion) but the capture happens here so the timing matches
+		// the semantics: the rollback target is whatever was running on this
+		// specific host immediately before its stop/install step.
+		hostPrev := previousVersion
 
 		m.Version = targetVersion
 		if err := m.upgradeOneHost(specification, masters, t); err != nil {
-			return rollbackHost(t, fmt.Errorf("upgrade %s: %w", t.describe, err))
+			return rollbackHost(t, hostPrev, fmt.Errorf("upgrade %s: %w", t.describe, err))
 		}
 
-		if err := waitForHealthy(t.healthURL, opts.HealthTimeout, opts.HealthInterval); err != nil {
+		if err := waitForHealthy(t.healthURL, opts.HealthTimeout, opts.HealthInterval, opts.InsecureSkipTLSVerify); err != nil {
 			info(fmt.Sprintf("Health check failed for %s: %v", t.describe, err))
-			return rollbackHost(t, fmt.Errorf("health check failed for %s: %w", t.describe, err))
+			return rollbackHost(t, hostPrev, fmt.Errorf("health check failed for %s: %w", t.describe, err))
 		}
 
 		info(fmt.Sprintf("%s upgraded and healthy", t.describe))
@@ -165,75 +179,75 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 
 // upgradeOneHost stops, reinstalls (at m.Version), and starts a single host instance.
 func (m *Manager) upgradeOneHost(specification *spec.Specification, masters []string, t upgradeTarget) error {
+	var hooks componentHooks
 	switch t.component {
 	case "volume":
 		vs := specification.VolumeServers[t.index]
-		if err := m.StopVolumeServer(vs, t.index); err != nil {
-			// Best-effort stop: log and continue to reinstall which will restart the unit.
-			info(fmt.Sprintf("stop %s returned: %v (continuing)", t.describe, err))
+		hooks = componentHooks{
+			serviceName: "volume",
+			sshAddr:     fmt.Sprintf("%s:%d", vs.Ip, vs.PortSsh),
+			stop:        func() error { return m.StopVolumeServer(vs, t.index) },
+			writeConfig: func(buf *bytes.Buffer) { vs.WriteToBuffer(masters, buf) },
 		}
-		return operator.ExecuteRemote(fmt.Sprintf("%s:%d", vs.Ip, vs.PortSsh), m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
-			component := "volume"
-			componentInstance := fmt.Sprintf("%s%d", component, t.index)
-			var buf bytes.Buffer
-			vs.WriteToBuffer(masters, &buf)
-			if err := m.deployComponentInstance(op, component, componentInstance, &buf); err != nil {
-				return err
-			}
-			return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
-		})
 	case "filer":
 		fs := specification.FilerServers[t.index]
-		if err := m.StopFilerServer(fs, t.index); err != nil {
-			info(fmt.Sprintf("stop %s returned: %v (continuing)", t.describe, err))
+		hooks = componentHooks{
+			serviceName: "filer",
+			sshAddr:     fmt.Sprintf("%s:%d", fs.Ip, fs.PortSsh),
+			stop:        func() error { return m.StopFilerServer(fs, t.index) },
+			writeConfig: func(buf *bytes.Buffer) { fs.WriteToBuffer(masters, buf) },
 		}
-		return operator.ExecuteRemote(fmt.Sprintf("%s:%d", fs.Ip, fs.PortSsh), m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
-			component := "filer"
-			componentInstance := fmt.Sprintf("%s%d", component, t.index)
-			var buf bytes.Buffer
-			fs.WriteToBuffer(masters, &buf)
-			if err := m.deployComponentInstance(op, component, componentInstance, &buf); err != nil {
-				return err
-			}
-			return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
-		})
 	case "master":
 		ms := specification.MasterServers[t.index]
-		if err := m.StopMasterServer(ms, t.index); err != nil {
-			info(fmt.Sprintf("stop %s returned: %v (continuing)", t.describe, err))
+		hooks = componentHooks{
+			serviceName: "master",
+			sshAddr:     fmt.Sprintf("%s:%d", ms.Ip, ms.PortSsh),
+			stop:        func() error { return m.StopMasterServer(ms, t.index) },
+			writeConfig: func(buf *bytes.Buffer) { ms.WriteToBuffer(masters, buf) },
 		}
-		return operator.ExecuteRemote(fmt.Sprintf("%s:%d", ms.Ip, ms.PortSsh), m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
-			component := "master"
-			componentInstance := fmt.Sprintf("%s%d", component, t.index)
-			var buf bytes.Buffer
-			ms.WriteToBuffer(masters, &buf)
-			if err := m.deployComponentInstance(op, component, componentInstance, &buf); err != nil {
-				return err
-			}
-			return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
-		})
+	default:
+		return fmt.Errorf("unknown component: %s", t.component)
 	}
-	return fmt.Errorf("unknown component: %s", t.component)
+	return m.runUpgradeHost(t, hooks)
+}
+
+// runUpgradeHost applies the stop/redeploy/restart sequence to a single host
+// using the component-specific hooks. This holds the logic that was previously
+// duplicated across the volume/filer/master switch cases.
+func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
+	if err := hooks.stop(); err != nil {
+		// Best-effort stop: log and continue to reinstall which will restart the unit.
+		info(fmt.Sprintf("stop %s returned: %v (continuing)", t.describe, err))
+	}
+	componentInstance := fmt.Sprintf("%s%d", hooks.serviceName, t.index)
+	return operator.ExecuteRemote(hooks.sshAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+		var buf bytes.Buffer
+		hooks.writeConfig(&buf)
+		if err := m.deployComponentInstance(op, hooks.serviceName, componentInstance, &buf); err != nil {
+			return err
+		}
+		return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
+	})
 }
 
 // waitForHealthy polls an HTTP(S) URL until it returns 2xx or the timeout
 // elapses. This is intentionally minimal — a more thorough probe would parse
 // the body.
 //
-// TODO: once the cluster CA bundle is plumbed through the Manager, honor
-// InsecureSkipVerify=false and load the cluster root CA into RootCAs. Today
-// we intentionally fall back to InsecureSkipVerify=true so that self-signed
-// upgrade probes don't block the rolling upgrade.
-func waitForHealthy(url string, timeout, interval time.Duration) error {
+// By default TLS connections verify against the system cert pool. Pass
+// insecureSkipTLSVerify=true to disable verification (for self-signed dev
+// clusters); callers must opt in explicitly via --insecure-skip-tls-verify.
+//
+// TODO: use cluster CA once tls bootstrap PR lands.
+func waitForHealthy(url string, timeout, interval time.Duration, insecureSkipTLSVerify bool) error {
 	if url == "" {
 		return nil
 	}
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			// Default: verify. Fallback to skip because CA bundle isn't wired yet.
-			InsecureSkipVerify: true, //nolint:gosec // see TODO above
-		},
+	tlsConfig := &tls.Config{}
+	if insecureSkipTLSVerify {
+		tlsConfig.InsecureSkipVerify = true //nolint:gosec // explicitly requested via --insecure-skip-tls-verify
 	}
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	client := &http.Client{Timeout: 5 * time.Second, Transport: transport}
 	deadline := time.Now().Add(timeout)
 	var lastErr error

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -1,0 +1,234 @@
+package manager
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+	"github.com/seaweedfs/seaweed-up/pkg/operator"
+)
+
+// UpgradeOptions configures how UpgradeCluster behaves.
+type UpgradeOptions struct {
+	// RollbackOnFailure re-installs the previous version on a host when the
+	// post-upgrade health gate fails. Defaults to true.
+	RollbackOnFailure bool
+	// DryRun, when set, prints the upgrade plan without applying any changes.
+	DryRun bool
+	// HealthTimeout is the total wait for a host to become healthy after restart.
+	HealthTimeout time.Duration
+	// HealthInterval is the poll interval between health probes.
+	HealthInterval time.Duration
+}
+
+// upgradeTarget represents a single host/instance to be upgraded.
+type upgradeTarget struct {
+	component string // "volume", "filer", "master"
+	index     int
+	ip        string
+	portSsh   int
+	// healthURL is the HTTP endpoint used for the post-upgrade health probe.
+	healthURL string
+	// describe is a human-readable identifier for logs/errors.
+	describe string
+}
+
+// UpgradeCluster performs a rolling upgrade of the cluster to targetVersion.
+//
+// Order: volume servers -> filer servers -> master servers (masters last).
+// For each host, sequentially: stop systemd unit, reinstall at the new version,
+// start, then poll an HTTP health endpoint. On failure, if RollbackOnFailure is
+// set, reinstall the previously recorded version on that host before returning.
+func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersion string, opts UpgradeOptions) error {
+	if targetVersion == "" {
+		return fmt.Errorf("target version is required")
+	}
+	if opts.HealthTimeout <= 0 {
+		opts.HealthTimeout = 2 * time.Minute
+	}
+	if opts.HealthInterval <= 0 {
+		opts.HealthInterval = 3 * time.Second
+	}
+
+	m.prepare(specification)
+
+	// Record the current version per host in-memory before making any changes.
+	// The Manager only has one active version at a time, so we snapshot whatever
+	// version is presently configured (or empty -> "latest"). In a richer world
+	// this would be probed from the host itself, but keeping it minimal on purpose.
+	previousVersion := m.Version
+
+	var targets []upgradeTarget
+
+	// Volume servers first.
+	for i, v := range specification.VolumeServers {
+		targets = append(targets, upgradeTarget{
+			component: "volume",
+			index:     i,
+			ip:        v.Ip,
+			portSsh:   v.PortSsh,
+			healthURL: fmt.Sprintf("http://%s:%d/status", v.Ip, v.Port),
+			describe:  fmt.Sprintf("volume%d %s:%d", i, v.Ip, v.Port),
+		})
+	}
+	// Filer servers next.
+	for i, f := range specification.FilerServers {
+		targets = append(targets, upgradeTarget{
+			component: "filer",
+			index:     i,
+			ip:        f.Ip,
+			portSsh:   f.PortSsh,
+			healthURL: fmt.Sprintf("http://%s:%d/", f.Ip, f.Port),
+			describe:  fmt.Sprintf("filer%d %s:%d", i, f.Ip, f.Port),
+		})
+	}
+	// Masters last so quorum isn't disturbed early.
+	for i, ms := range specification.MasterServers {
+		targets = append(targets, upgradeTarget{
+			component: "master",
+			index:     i,
+			ip:        ms.Ip,
+			portSsh:   ms.PortSsh,
+			healthURL: fmt.Sprintf("http://%s:%d/cluster/status", ms.Ip, ms.Port),
+			describe:  fmt.Sprintf("master%d %s:%d", i, ms.Ip, ms.Port),
+		})
+	}
+
+	// Snapshot per-host "previous version". Right now this is homogeneous across
+	// the cluster, but we record per host so rollback semantics scale cleanly if
+	// heterogeneous versions ever land.
+	hostPrevVersion := make(map[string]string, len(targets))
+	for _, t := range targets {
+		hostPrevVersion[t.describe] = previousVersion
+	}
+	_ = hostPrevVersion
+
+	if opts.DryRun {
+		info(fmt.Sprintf("Dry-run: rolling upgrade plan to version %q (previous=%q)", targetVersion, previousVersion))
+		for _, t := range targets {
+			info(fmt.Sprintf("  would upgrade %s (%s)", t.describe, t.component))
+		}
+		return nil
+	}
+
+	var masters []string
+	for _, masterSpec := range specification.MasterServers {
+		masters = append(masters, fmt.Sprintf("%s:%d", masterSpec.Ip, masterSpec.Port))
+	}
+
+	info(fmt.Sprintf("Starting rolling upgrade to version %q (previous=%q)", targetVersion, previousVersion))
+
+	for _, t := range targets {
+		info(fmt.Sprintf("Upgrading %s...", t.describe))
+
+		m.Version = targetVersion
+		if err := m.upgradeOneHost(specification, masters, t); err != nil {
+			return fmt.Errorf("upgrade %s: %w", t.describe, err)
+		}
+
+		if err := waitForHealthy(t.healthURL, opts.HealthTimeout, opts.HealthInterval); err != nil {
+			info(fmt.Sprintf("Health check failed for %s: %v", t.describe, err))
+			if opts.RollbackOnFailure && previousVersion != "" {
+				info(fmt.Sprintf("Rolling back %s to version %q", t.describe, previousVersion))
+				m.Version = previousVersion
+				if rbErr := m.upgradeOneHost(specification, masters, t); rbErr != nil {
+					return fmt.Errorf("health check failed for %s (%v); rollback also failed: %w", t.describe, err, rbErr)
+				}
+				return fmt.Errorf("health check failed for %s after upgrade to %q; rolled back to %q: %w", t.describe, targetVersion, previousVersion, err)
+			}
+			return fmt.Errorf("health check failed for %s: %w", t.describe, err)
+		}
+
+		info(fmt.Sprintf("%s upgraded and healthy", t.describe))
+	}
+
+	m.Version = targetVersion
+	info(fmt.Sprintf("Rolling upgrade to %q complete", targetVersion))
+	return nil
+}
+
+// upgradeOneHost stops, reinstalls (at m.Version), and starts a single host instance.
+func (m *Manager) upgradeOneHost(specification *spec.Specification, masters []string, t upgradeTarget) error {
+	switch t.component {
+	case "volume":
+		vs := specification.VolumeServers[t.index]
+		if err := m.StopVolumeServer(vs, t.index); err != nil {
+			// Best-effort stop: log and continue to reinstall which will restart the unit.
+			info(fmt.Sprintf("stop %s returned: %v (continuing)", t.describe, err))
+		}
+		return operator.ExecuteRemote(fmt.Sprintf("%s:%d", vs.Ip, vs.PortSsh), m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+			component := "volume"
+			componentInstance := fmt.Sprintf("%s%d", component, t.index)
+			var buf bytes.Buffer
+			vs.WriteToBuffer(masters, &buf)
+			if err := m.deployComponentInstance(op, component, componentInstance, &buf); err != nil {
+				return err
+			}
+			return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
+		})
+	case "filer":
+		fs := specification.FilerServers[t.index]
+		if err := m.StopFilerServer(fs, t.index); err != nil {
+			info(fmt.Sprintf("stop %s returned: %v (continuing)", t.describe, err))
+		}
+		return operator.ExecuteRemote(fmt.Sprintf("%s:%d", fs.Ip, fs.PortSsh), m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+			component := "filer"
+			componentInstance := fmt.Sprintf("%s%d", component, t.index)
+			var buf bytes.Buffer
+			fs.WriteToBuffer(masters, &buf)
+			if err := m.deployComponentInstance(op, component, componentInstance, &buf); err != nil {
+				return err
+			}
+			return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
+		})
+	case "master":
+		ms := specification.MasterServers[t.index]
+		if err := m.StopMasterServer(ms, t.index); err != nil {
+			info(fmt.Sprintf("stop %s returned: %v (continuing)", t.describe, err))
+		}
+		return operator.ExecuteRemote(fmt.Sprintf("%s:%d", ms.Ip, ms.PortSsh), m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+			component := "master"
+			componentInstance := fmt.Sprintf("%s%d", component, t.index)
+			var buf bytes.Buffer
+			ms.WriteToBuffer(masters, &buf)
+			if err := m.deployComponentInstance(op, component, componentInstance, &buf); err != nil {
+				return err
+			}
+			return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
+		})
+	}
+	return fmt.Errorf("unknown component: %s", t.component)
+}
+
+// waitForHealthy polls an HTTP URL until it returns 2xx or the timeout elapses.
+// This is intentionally minimal — a more thorough probe would parse the body.
+func waitForHealthy(url string, timeout, interval time.Duration) error {
+	if url == "" {
+		return nil
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			// Drain and close so the connection can be reused.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return nil
+			}
+			lastErr = fmt.Errorf("status %d from %s", resp.StatusCode, url)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(interval)
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("timed out waiting for %s", url)
+	}
+	return lastErr
+}

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -5,7 +5,9 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
@@ -89,35 +91,38 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 
 	// Volume servers first.
 	for i, v := range specification.VolumeServers {
+		hostPort := net.JoinHostPort(v.Ip, strconv.Itoa(v.Port))
 		targets = append(targets, upgradeTarget{
 			component: "volume",
 			index:     i,
 			ip:        v.Ip,
 			portSsh:   v.PortSsh,
-			healthURL: fmt.Sprintf("%s://%s:%d/status", scheme, v.Ip, v.Port),
-			describe:  fmt.Sprintf("volume%d %s:%d", i, v.Ip, v.Port),
+			healthURL: fmt.Sprintf("%s://%s/status", scheme, hostPort),
+			describe:  fmt.Sprintf("volume%d %s", i, hostPort),
 		})
 	}
 	// Filer servers next.
 	for i, f := range specification.FilerServers {
+		hostPort := net.JoinHostPort(f.Ip, strconv.Itoa(f.Port))
 		targets = append(targets, upgradeTarget{
 			component: "filer",
 			index:     i,
 			ip:        f.Ip,
 			portSsh:   f.PortSsh,
-			healthURL: fmt.Sprintf("%s://%s:%d/", scheme, f.Ip, f.Port),
-			describe:  fmt.Sprintf("filer%d %s:%d", i, f.Ip, f.Port),
+			healthURL: fmt.Sprintf("%s://%s/", scheme, hostPort),
+			describe:  fmt.Sprintf("filer%d %s", i, hostPort),
 		})
 	}
 	// Masters last so quorum isn't disturbed early.
 	for i, ms := range specification.MasterServers {
+		hostPort := net.JoinHostPort(ms.Ip, strconv.Itoa(ms.Port))
 		targets = append(targets, upgradeTarget{
 			component: "master",
 			index:     i,
 			ip:        ms.Ip,
 			portSsh:   ms.PortSsh,
-			healthURL: fmt.Sprintf("%s://%s:%d/cluster/status", scheme, ms.Ip, ms.Port),
-			describe:  fmt.Sprintf("master%d %s:%d", i, ms.Ip, ms.Port),
+			healthURL: fmt.Sprintf("%s://%s/cluster/status", scheme, hostPort),
+			describe:  fmt.Sprintf("master%d %s", i, hostPort),
 		})
 	}
 
@@ -131,7 +136,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 
 	var masters []string
 	for _, masterSpec := range specification.MasterServers {
-		masters = append(masters, fmt.Sprintf("%s:%d", masterSpec.Ip, masterSpec.Port))
+		masters = append(masters, net.JoinHostPort(masterSpec.Ip, strconv.Itoa(masterSpec.Port)))
 	}
 
 	info(fmt.Sprintf("Starting rolling upgrade to version %q (previous=%q)", targetVersion, previousVersion))
@@ -185,7 +190,7 @@ func (m *Manager) upgradeOneHost(specification *spec.Specification, masters []st
 		vs := specification.VolumeServers[t.index]
 		hooks = componentHooks{
 			serviceName: "volume",
-			sshAddr:     fmt.Sprintf("%s:%d", vs.Ip, vs.PortSsh),
+			sshAddr:     net.JoinHostPort(vs.Ip, strconv.Itoa(vs.PortSsh)),
 			stop:        func() error { return m.StopVolumeServer(vs, t.index) },
 			writeConfig: func(buf *bytes.Buffer) { vs.WriteToBuffer(masters, buf) },
 		}
@@ -193,7 +198,7 @@ func (m *Manager) upgradeOneHost(specification *spec.Specification, masters []st
 		fs := specification.FilerServers[t.index]
 		hooks = componentHooks{
 			serviceName: "filer",
-			sshAddr:     fmt.Sprintf("%s:%d", fs.Ip, fs.PortSsh),
+			sshAddr:     net.JoinHostPort(fs.Ip, strconv.Itoa(fs.PortSsh)),
 			stop:        func() error { return m.StopFilerServer(fs, t.index) },
 			writeConfig: func(buf *bytes.Buffer) { fs.WriteToBuffer(masters, buf) },
 		}
@@ -201,7 +206,7 @@ func (m *Manager) upgradeOneHost(specification *spec.Specification, masters []st
 		ms := specification.MasterServers[t.index]
 		hooks = componentHooks{
 			serviceName: "master",
-			sshAddr:     fmt.Sprintf("%s:%d", ms.Ip, ms.PortSsh),
+			sshAddr:     net.JoinHostPort(ms.Ip, strconv.Itoa(ms.PortSsh)),
 			stop:        func() error { return m.StopMasterServer(ms, t.index) },
 			writeConfig: func(buf *bytes.Buffer) { ms.WriteToBuffer(masters, buf) },
 		}

--- a/test/integration/upgrade_test.go
+++ b/test/integration/upgrade_test.go
@@ -1,0 +1,212 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// pinnedFromVersion / pinnedToVersion are the SeaweedFS versions used to
+// exercise an actual upgrade path. Both are real releases; the "from" version
+// is older than the "to" version.
+const (
+	pinnedFromVersion = "3.73"
+	pinnedToVersion   = "3.80"
+)
+
+// masterVersionFromStatus fetches http://ip:port/dir/status and best-effort
+// extracts the reported version string. Returns an empty string if it cannot
+// be determined.
+func masterVersionFromStatus(ip string, port int) (string, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	url := fmt.Sprintf("http://%s:%d/dir/status", ip, port)
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return string(body), nil
+	}
+	if v, ok := m["Version"].(string); ok {
+		return v, nil
+	}
+	return string(body), nil
+}
+
+// waitForMasterVersionContains polls /dir/status until the reported version
+// contains substr or the timeout elapses.
+func waitForMasterVersionContains(ip string, port int, substr string, timeout time.Duration) (string, bool) {
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		v, err := masterVersionFromStatus(ip, port)
+		if err == nil {
+			last = v
+			if strings.Contains(v, substr) {
+				return v, true
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return last, false
+}
+
+// TestClusterUpgrade deploys a small cluster at pinnedFromVersion, then runs
+// `cluster upgrade --version=<pinnedToVersion>` and asserts the master reports
+// the new version via /dir/status.
+func TestClusterUpgrade(t *testing.T) {
+	env := NewTestEnvironment(t)
+	env.SkipIfNotAvailable(t)
+
+	if err := env.BuildSeaweedUp(); err != nil {
+		t.Fatalf("Failed to build seaweed-up: %v", err)
+	}
+	if err := env.Setup(); err != nil {
+		t.Fatalf("Failed to setup test environment: %v", err)
+	}
+	defer func() {
+		if err := env.Teardown(); err != nil {
+			t.Errorf("Failed to teardown: %v", err)
+		}
+	}()
+
+	configFile := env.GetClusterConfig("cluster-single.yaml")
+	sshKey := env.GetSSHKeyPath()
+
+	// Initial deploy at pinned "from" version.
+	out, err := env.RunSeaweedUp(
+		"cluster", "deploy", "test-upgrade",
+		"-f", configFile,
+		"-u", "root",
+		"--identity", sshKey,
+		"--version", pinnedFromVersion,
+		"--yes",
+	)
+	if err != nil {
+		t.Fatalf("Initial deploy failed: %v\n%s", err, out)
+	}
+	t.Logf("Initial deploy output: %s", out)
+
+	// Give the master a moment to come up.
+	time.Sleep(10 * time.Second)
+
+	host := env.hosts[0]
+	if !env.VerifyMasterRunning(host, 9333) {
+		t.Fatalf("Master not running after initial deploy on %s:9333", host.IP)
+	}
+
+	if v, ok := waitForMasterVersionContains(host.IP, 9333, pinnedFromVersion, 30*time.Second); !ok {
+		t.Logf("Initial master version (did not match expected %s): %s", pinnedFromVersion, v)
+	}
+
+	beforeVersion, _ := masterVersionFromStatus(host.IP, 9333)
+	t.Logf("Before upgrade, master version: %s", beforeVersion)
+
+	// Run the upgrade.
+	out, err = env.RunSeaweedUp(
+		"cluster", "upgrade", "test-upgrade",
+		"-f", configFile,
+		"-u", "root",
+		"--identity", sshKey,
+		"--version", pinnedToVersion,
+		"--yes",
+	)
+	if err != nil {
+		t.Fatalf("Upgrade failed: %v\n%s", err, out)
+	}
+	t.Logf("Upgrade output: %s", out)
+
+	// Poll for the new version to appear in /dir/status.
+	if v, ok := waitForMasterVersionContains(host.IP, 9333, pinnedToVersion, 60*time.Second); !ok {
+		t.Errorf("Master did not report upgraded version %q; last seen %q", pinnedToVersion, v)
+	} else {
+		t.Logf("Master reports upgraded version: %s", v)
+	}
+}
+
+// TestClusterUpgradeRollback attempts an upgrade to a bogus version, which
+// should fail the post-upgrade health gate, and asserts that rollback leaves
+// the previously installed version still reporting healthy.
+func TestClusterUpgradeRollback(t *testing.T) {
+	env := NewTestEnvironment(t)
+	env.SkipIfNotAvailable(t)
+
+	if err := env.BuildSeaweedUp(); err != nil {
+		t.Fatalf("Failed to build seaweed-up: %v", err)
+	}
+	if err := env.Setup(); err != nil {
+		t.Fatalf("Failed to setup test environment: %v", err)
+	}
+	defer func() {
+		if err := env.Teardown(); err != nil {
+			t.Errorf("Failed to teardown: %v", err)
+		}
+	}()
+
+	configFile := env.GetClusterConfig("cluster-single.yaml")
+	sshKey := env.GetSSHKeyPath()
+
+	out, err := env.RunSeaweedUp(
+		"cluster", "deploy", "test-upgrade-rollback",
+		"-f", configFile,
+		"-u", "root",
+		"--identity", sshKey,
+		"--version", pinnedFromVersion,
+		"--yes",
+	)
+	if err != nil {
+		t.Fatalf("Initial deploy failed: %v\n%s", err, out)
+	}
+	t.Logf("Initial deploy output: %s", out)
+
+	time.Sleep(10 * time.Second)
+	host := env.hosts[0]
+	if !env.VerifyMasterRunning(host, 9333) {
+		t.Fatalf("Master not running after initial deploy on %s:9333", host.IP)
+	}
+	beforeVersion, _ := masterVersionFromStatus(host.IP, 9333)
+	t.Logf("Before bogus upgrade, master version: %s", beforeVersion)
+
+	// Inject failure by using a clearly non-existent version. The post-upgrade
+	// health gate should fail and the host should be rolled back.
+	out, err = env.RunSeaweedUp(
+		"cluster", "upgrade", "test-upgrade-rollback",
+		"-f", configFile,
+		"-u", "root",
+		"--identity", sshKey,
+		"--version", "0.0.0-does-not-exist",
+		"--rollback-on-failure=true",
+		"--yes",
+	)
+	if err == nil {
+		t.Logf("Upgrade to bogus version unexpectedly succeeded:\n%s", out)
+	} else {
+		t.Logf("Upgrade to bogus version failed as expected: %v\n%s", err, out)
+	}
+
+	// After rollback, the previously installed version should still be reachable.
+	afterVersion, statusErr := masterVersionFromStatus(host.IP, 9333)
+	t.Logf("After rollback, master version: %s (err=%v)", afterVersion, statusErr)
+	if statusErr != nil {
+		t.Errorf("Master /dir/status unreachable after rollback: %v", statusErr)
+	}
+	if beforeVersion != "" && afterVersion != "" {
+		beforeMajor := strings.Split(beforeVersion, " ")[0]
+		if !strings.Contains(afterVersion, beforeMajor) {
+			t.Errorf("Rollback did not restore original version: before=%q after=%q", beforeVersion, afterVersion)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implements a real `cluster upgrade` as a rolling upgrade in `pkg/cluster/manager/manager_upgrade.go` via a new `(*Manager).UpgradeCluster(spec, targetVersion, opts)`. Volume servers are upgraded first, then filers, then masters (masters last to preserve quorum). For each host the manager stops the systemd unit, reinstalls at the new version using `deployComponentInstance`, restarts it, and polls a minimal inline HTTP health probe (`/status` on volumes, `/` on filers, `/cluster/status` on masters) until healthy or a timeout elapses.
- On health failure, if `--rollback-on-failure` is set (default `true`), the host is reinstalled at the in-memory-recorded previous version and the upgrade aborts before touching further hosts.
- Replaces the `runClusterUpgrade` stub in `cmd/cluster_impl.go` with an implementation that loads the spec from `-f`, wires up SSH identity/user, honors `--dry-run` (prints the plan and exits), and passes through the new `--rollback-on-failure` flag alongside the existing `--version` / `--dry-run`.
- Adds `test/integration/upgrade_test.go` (build tag `integration`) with two cases: an A -> B upgrade that asserts the master's `/dir/status` reports the new version, and a bogus-version upgrade that asserts rollback keeps the prior version reachable. Adds `.github/workflows/integration-upgrade.yml` which reuses the systemd-in-Docker pattern from `integration-tests.yml` with a 45 minute timeout. `integration-tests.yml` is not modified.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go vet ./...` passes (verified locally)
- [ ] `go build -tags integration ./test/...` passes (verified locally)
- [ ] New `Integration Tests - Rolling Upgrade` workflow runs green on CI
- [ ] Existing `Integration Tests` workflow unaffected