### PR TITLE
feat(status): real cluster status via HTTP probes

### DIFF
--- a/.github/workflows/integration-status.yml
+++ b/.github/workflows/integration-status.yml
@@ -39,7 +39,10 @@ jobs:
 
       - name: Create Docker network
         run: |
-          docker network create --driver bridge --subnet 172.28.0.0/16 seaweed-up-net
+          # Use a unique subnet (10.201.39.0/24) to avoid overlap with the
+          # default GitHub Actions docker bridge address pool and with the
+          # 172.28.0.0/16 subnet used by the main integration-tests workflow.
+          docker network create --driver bridge --subnet 10.201.39.0/24 seaweed-up-net
 
       - name: Start containers with docker run
         run: |
@@ -50,7 +53,7 @@ jobs:
             --privileged \
             --cgroupns=host \
             --network seaweed-up-net \
-            --ip 172.28.0.10 \
+            --ip 10.201.39.10 \
             -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
             geerlingguy/docker-ubuntu2204-ansible:latest
 
@@ -97,8 +100,8 @@ jobs:
           # Wait for SSH
           sleep 5
           for j in {1..30}; do
-            if nc -z 172.28.0.10 22 2>/dev/null; then
-              echo "SSH ready on 172.28.0.10"
+            if nc -z 10.201.39.10 22 2>/dev/null; then
+              echo "SSH ready on 10.201.39.10"
               break
             fi
             if [ $j -eq 30 ]; then
@@ -120,12 +123,12 @@ jobs:
 
       - name: Verify SSH connectivity
         run: |
-          ssh -i .ssh/id_rsa_test -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 root@172.28.0.10 "echo 'SSH OK'"
+          ssh -i .ssh/id_rsa_test -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 root@10.201.39.10 "echo 'SSH OK'"
 
       - name: Deploy single-node cluster
         run: |
           ../../seaweed-up cluster deploy test-status \
-            -f testdata/cluster-single.yaml \
+            -f testdata/cluster-single-status.yaml \
             -u root \
             --identity .ssh/id_rsa_test \
             --yes
@@ -138,20 +141,22 @@ jobs:
           docker exec seaweed-up-host1 ss -tlnp 2>&1 || true
 
           # Sanity checks
-          nc -z 172.28.0.10 9333 || (echo "Master not running" && exit 1)
-          nc -z 172.28.0.10 8382 || (echo "Volume not running" && exit 1)
-          nc -z 172.28.0.10 8888 || (echo "Filer not running" && exit 1)
+          nc -z 10.201.39.10 9333 || (echo "Master not running" && exit 1)
+          nc -z 10.201.39.10 8382 || (echo "Volume not running" && exit 1)
+          nc -z 10.201.39.10 8888 || (echo "Filer not running" && exit 1)
           echo "All ports listening"
 
       - name: Run cluster status (table)
         run: |
-          ../../seaweed-up cluster status -f testdata/cluster-single.yaml
+          ../../seaweed-up cluster status -f testdata/cluster-single-status.yaml
 
       - name: Run cluster status (JSON)
         run: |
-          ../../seaweed-up cluster status -f testdata/cluster-single.yaml --json
+          ../../seaweed-up cluster status -f testdata/cluster-single-status.yaml --json
 
       - name: Run integration status Go test
+        env:
+          SEAWEED_UP_EXTERNAL_ENV: "1"
         run: |
           go test -tags integration -run TestClusterStatusReal -v -timeout 20m ./...
 

--- a/.github/workflows/integration-status.yml
+++ b/.github/workflows/integration-status.yml
@@ -1,0 +1,182 @@
+name: Integration Status Test
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: test/integration
+
+jobs:
+  status-test:
+    name: Cluster Status HTTP Probe Test
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Build seaweed-up binary
+        working-directory: .
+        run: go build -v -o seaweed-up .
+
+      - name: Create Docker network
+        run: |
+          docker network create --driver bridge --subnet 172.28.0.0/16 seaweed-up-net
+
+      - name: Start containers with docker run
+        run: |
+          # systemd-in-docker pattern mirrored from integration-tests.yml
+          docker run -d \
+            --name seaweed-up-host1 \
+            --hostname host1 \
+            --privileged \
+            --cgroupns=host \
+            --network seaweed-up-net \
+            --ip 172.28.0.10 \
+            -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+            geerlingguy/docker-ubuntu2204-ansible:latest
+
+          echo "Waiting for containers to start..."
+          sleep 10
+
+          echo "=== Container Status ==="
+          docker ps -a
+
+          status=$(docker inspect -f '{{.State.Status}}' seaweed-up-host1 2>/dev/null || echo "not found")
+          echo "Container seaweed-up-host1 status: $status"
+          if [ "$status" != "running" ]; then
+            echo "=== Logs ==="
+            docker logs seaweed-up-host1 2>&1 || true
+            exit 1
+          fi
+
+          # Wait for systemd to be ready
+          echo "Waiting for systemd to initialize..."
+          for i in {1..60}; do
+            state=$(docker exec seaweed-up-host1 systemctl is-system-running 2>/dev/null || echo "starting")
+            if [ "$state" = "running" ] || [ "$state" = "degraded" ]; then
+              echo "Systemd ready (state: $state)"
+              break
+            fi
+            if [ $i -eq 60 ]; then
+              echo "Timeout waiting for systemd"
+              docker logs seaweed-up-host1 2>&1 || true
+              docker exec seaweed-up-host1 journalctl -xe --no-pager 2>&1 | tail -100 || true
+              exit 1
+            fi
+            echo "Waiting for systemd... ($i/60, state: $state)"
+            sleep 2
+          done
+
+      - name: Install SSH on container
+        run: |
+          docker exec seaweed-up-host1 bash -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server curl netcat-openbsd"
+          docker exec seaweed-up-host1 bash -c "mkdir -p /run/sshd"
+          docker exec seaweed-up-host1 bash -c "sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config"
+          docker exec seaweed-up-host1 bash -c "sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config"
+          docker exec seaweed-up-host1 bash -c "systemctl enable ssh && systemctl start ssh"
+
+          # Wait for SSH
+          sleep 5
+          for j in {1..30}; do
+            if nc -z 172.28.0.10 22 2>/dev/null; then
+              echo "SSH ready on 172.28.0.10"
+              break
+            fi
+            if [ $j -eq 30 ]; then
+              echo "SSH not ready"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Setup SSH keys
+        run: |
+          mkdir -p .ssh
+          ssh-keygen -t rsa -b 2048 -f .ssh/id_rsa_test -N "" -q
+          PUB_KEY=$(cat .ssh/id_rsa_test.pub)
+
+          docker exec seaweed-up-host1 bash -c "mkdir -p /root/.ssh && chmod 700 /root/.ssh"
+          docker exec seaweed-up-host1 bash -c "echo '$PUB_KEY' > /root/.ssh/authorized_keys"
+          docker exec seaweed-up-host1 bash -c "chmod 600 /root/.ssh/authorized_keys && chown root:root /root/.ssh/authorized_keys"
+
+      - name: Verify SSH connectivity
+        run: |
+          ssh -i .ssh/id_rsa_test -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 root@172.28.0.10 "echo 'SSH OK'"
+
+      - name: Deploy single-node cluster
+        run: |
+          ../../seaweed-up cluster deploy test-status \
+            -f testdata/cluster-single.yaml \
+            -u root \
+            --identity .ssh/id_rsa_test \
+            --yes
+
+          # Wait for services to start
+          echo "Waiting for SeaweedFS services to initialize..."
+          sleep 30
+
+          # Show listening ports for debug
+          docker exec seaweed-up-host1 ss -tlnp 2>&1 || true
+
+          # Sanity checks
+          nc -z 172.28.0.10 9333 || (echo "Master not running" && exit 1)
+          nc -z 172.28.0.10 8382 || (echo "Volume not running" && exit 1)
+          nc -z 172.28.0.10 8888 || (echo "Filer not running" && exit 1)
+          echo "All ports listening"
+
+      - name: Run cluster status (table)
+        run: |
+          ../../seaweed-up cluster status -f testdata/cluster-single.yaml
+
+      - name: Run cluster status (JSON)
+        run: |
+          ../../seaweed-up cluster status -f testdata/cluster-single.yaml --json
+
+      - name: Run integration status Go test
+        run: |
+          go test -tags integration -run TestClusterStatusReal -v -timeout 20m ./...
+
+      - name: Save logs
+        if: always()
+        run: |
+          echo "=== Container Status ===" > status.log
+          docker ps -a >> status.log
+          echo "=== Host1 Logs ===" >> status.log
+          docker logs seaweed-up-host1 >> status.log 2>&1 || true
+          echo "=== Host1 SeaweedFS Logs ===" >> status.log
+          docker exec seaweed-up-host1 bash -c "cat /opt/seaweed/*/*.log 2>/dev/null" >> status.log 2>&1 || true
+
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-status-logs
+          path: test/integration/status.log
+          retention-days: 7
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker stop seaweed-up-host1 || true
+          docker rm seaweed-up-host1 || true
+          docker network rm seaweed-up-net || true
+          rm -rf .ssh

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -121,7 +121,7 @@ Shows real-time information about cluster components including:
 			if opts.ConfigFile == "" && len(args) == 0 {
 				return fmt.Errorf("either a cluster-name positional argument or -f/--file is required")
 			}
-			return runClusterStatus(args, opts)
+			return runClusterStatus(cmd, args, opts)
 		},
 	}
 

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -117,6 +117,7 @@ Shows real-time information about cluster components including:
 		},
 	}
 	
+	cmd.Flags().StringVarP(&opts.ConfigFile, "file", "f", "", "cluster configuration file")
 	cmd.Flags().BoolVar(&opts.JSONOutput, "json", false, "output in JSON format")
 	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "show detailed information")
 	cmd.Flags().StringVar(&opts.Timeout, "timeout", "30s", "timeout for status collection")

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -111,13 +113,19 @@ Shows real-time information about cluster components including:
   
   # Auto-refresh status every 5 seconds
   seaweed-up cluster status prod-cluster --refresh=5`,
-		
+
+		// Accept at most one positional cluster-name. When no positional is
+		// given, -f/--file must be provided (enforced in resolveStatusSpec).
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.ConfigFile == "" && len(args) == 0 {
+				return fmt.Errorf("either a cluster-name positional argument or -f/--file is required")
+			}
 			return runClusterStatus(args, opts)
 		},
 	}
-	
-	cmd.Flags().StringVarP(&opts.ConfigFile, "file", "f", "", "cluster configuration file")
+
+	cmd.Flags().StringVarP(&opts.ConfigFile, "file", "f", "", "cluster configuration file (required if no cluster-name positional)")
 	cmd.Flags().BoolVar(&opts.JSONOutput, "json", false, "output in JSON format")
 	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "show detailed information")
 	cmd.Flags().StringVar(&opts.Timeout, "timeout", "30s", "timeout for status collection")

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -159,11 +159,13 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 	return nil
 }
 
-func runClusterStatus(args []string, opts *ClusterStatusOptions) error {
+func runClusterStatus(cmd *cobra.Command, args []string, opts *ClusterStatusOptions) error {
 	clusterSpec, err := resolveStatusSpec(args, opts)
 	if err != nil {
 		return err
 	}
+
+	ctx := cmd.Context()
 
 	// Handle auto-refresh mode with proper signal handling
 	if opts.Refresh > 0 {
@@ -177,7 +179,7 @@ func runClusterStatus(args []string, opts *ClusterStatusOptions) error {
 
 		// Show initial status
 		clearScreen()
-		if _, derr := displayClusterStatus(clusterSpec, opts); derr != nil {
+		if _, derr := displayClusterStatus(ctx, clusterSpec, opts); derr != nil {
 			return derr
 		}
 		color.Cyan("Refreshing every %d seconds (Press Ctrl+C to stop)", opts.Refresh)
@@ -190,7 +192,7 @@ func runClusterStatus(args []string, opts *ClusterStatusOptions) error {
 				return nil
 			case <-ticker.C:
 				clearScreen()
-				if _, derr := displayClusterStatus(clusterSpec, opts); derr != nil {
+				if _, derr := displayClusterStatus(ctx, clusterSpec, opts); derr != nil {
 					return derr
 				}
 				color.Cyan("Refreshing every %d seconds (Press Ctrl+C to stop)", opts.Refresh)
@@ -198,7 +200,7 @@ func runClusterStatus(args []string, opts *ClusterStatusOptions) error {
 		}
 	}
 
-	ch, err := displayClusterStatus(clusterSpec, opts)
+	ch, err := displayClusterStatus(ctx, clusterSpec, opts)
 	if err != nil {
 		return err
 	}
@@ -253,7 +255,7 @@ func clearScreen() {
 
 // displayClusterStatus probes the cluster and prints the result, returning
 // the aggregated health so callers can decide on process exit status.
-func displayClusterStatus(clusterSpec *spec.Specification, opts *ClusterStatusOptions) (*health.ClusterHealth, error) {
+func displayClusterStatus(ctx context.Context, clusterSpec *spec.Specification, opts *ClusterStatusOptions) (*health.ClusterHealth, error) {
 	// Parse the user-configured timeout (Cobra flag, default "30s"). Fall
 	// back to a 5s safety default only if parsing fails or the value is
 	// empty / non-positive.
@@ -262,11 +264,11 @@ func displayClusterStatus(clusterSpec *spec.Specification, opts *ClusterStatusOp
 		timeout = d
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Second)
+	probeCtx, cancel := context.WithTimeout(ctx, timeout+2*time.Second)
 	defer cancel()
 
 	prober := health.NewProber(timeout)
-	ch := prober.Probe(ctx, clusterSpec)
+	ch := prober.Probe(probeCtx, clusterSpec)
 
 	if opts.JSONOutput {
 		enc := json.NewEncoder(os.Stdout)

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -203,7 +203,8 @@ func runClusterStatus(args []string, opts *ClusterStatusOptions) error {
 		return err
 	}
 	if !ch.AllHealthy() {
-		os.Exit(1)
+		unhealthy := ch.UnhealthyCount()
+		return fmt.Errorf("%d component(s) unhealthy", unhealthy)
 	}
 	return nil
 }
@@ -275,11 +276,13 @@ func displayClusterStatus(clusterSpec *spec.Specification, opts *ClusterStatusOp
 		return ch, nil
 	}
 
-	renderStatusTable(clusterSpec, ch, opts.Verbose)
+	if err := renderStatusTable(clusterSpec, ch, opts.Verbose); err != nil {
+		return ch, err
+	}
 	return ch, nil
 }
 
-func renderStatusTable(s *spec.Specification, ch *health.ClusterHealth, verbose bool) {
+func renderStatusTable(s *spec.Specification, ch *health.ClusterHealth, verbose bool) error {
 	name := s.Name
 	if name == "" {
 		name = "(unnamed)"
@@ -313,13 +316,16 @@ func renderStatusTable(s *spec.Specification, ch *health.ClusterHealth, verbose 
 	for _, r := range ch.Filers {
 		writeRow(r)
 	}
-	_ = tw.Flush()
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("flush status table: %w", err)
+	}
 
 	if !ch.AllHealthy() {
 		color.Red("Cluster is UNHEALTHY")
 	} else {
 		color.Green("Cluster is healthy")
 	}
+	return nil
 }
 
 func orDash(s string) string {

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -293,8 +293,10 @@ func renderStatusTable(s *spec.Specification, ch *health.ClusterHealth, verbose 
 	color.Green("Cluster Status: %s", name)
 
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "COMPONENT\tADDRESS\tHEALTHY\tVERSION\tDETAIL")
-	writeRow := func(r health.ProbeResult) {
+	if _, err := fmt.Fprintln(tw, "COMPONENT\tADDRESS\tHEALTHY\tVERSION\tDETAIL"); err != nil {
+		return fmt.Errorf("write status header: %w", err)
+	}
+	writeRow := func(r health.ProbeResult) error {
 		healthy := "NO"
 		if r.Healthy {
 			healthy = "OK"
@@ -315,16 +317,25 @@ func renderStatusTable(s *spec.Specification, ch *health.ClusterHealth, verbose 
 		if detail == "" {
 			detail = "-"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", r.Kind, r.Address, healthy, orDash(r.Version), detail)
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", r.Kind, r.Address, healthy, orDash(r.Version), detail); err != nil {
+			return fmt.Errorf("write status row: %w", err)
+		}
+		return nil
 	}
 	for _, r := range ch.Masters {
-		writeRow(r)
+		if err := writeRow(r); err != nil {
+			return err
+		}
 	}
 	for _, r := range ch.Volumes {
-		writeRow(r)
+		if err := writeRow(r); err != nil {
+			return err
+		}
 	}
 	for _, r := range ch.Filers {
-		writeRow(r)
+		if err := writeRow(r); err != nil {
+			return err
+		}
 	}
 	if err := tw.Flush(); err != nil {
 		return fmt.Errorf("flush status table: %w", err)

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -8,9 +10,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"syscall"
+	"text/tabwriter"
 	"time"
 
 	"github.com/fatih/color"
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/health"
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/manager"
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
 	"github.com/seaweedfs/seaweed-up/pkg/config"
@@ -34,6 +38,7 @@ type ClusterDeployOptions struct {
 }
 
 type ClusterStatusOptions struct {
+	ConfigFile string
 	JSONOutput bool
 	Verbose    bool
 	Timeout    string
@@ -155,6 +160,11 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 }
 
 func runClusterStatus(args []string, opts *ClusterStatusOptions) error {
+	clusterSpec, err := resolveStatusSpec(args, opts)
+	if err != nil {
+		return err
+	}
+
 	// Handle auto-refresh mode with proper signal handling
 	if opts.Refresh > 0 {
 		ticker := time.NewTicker(time.Duration(opts.Refresh) * time.Second)
@@ -167,29 +177,62 @@ func runClusterStatus(args []string, opts *ClusterStatusOptions) error {
 
 		// Show initial status
 		clearScreen()
-		if err := displayClusterStatus(args, opts); err != nil {
-			return err
+		if _, derr := displayClusterStatus(clusterSpec, opts); derr != nil {
+			return derr
 		}
-		color.Cyan("🔄 Refreshing every %d seconds (Press Ctrl+C to stop)", opts.Refresh)
+		color.Cyan("Refreshing every %d seconds (Press Ctrl+C to stop)", opts.Refresh)
 
 		for {
 			select {
 			case <-sigChan:
-				// Graceful shutdown on interrupt
 				fmt.Println()
-				color.Yellow("⏹️  Refresh stopped by user")
+				color.Yellow("Refresh stopped by user")
 				return nil
 			case <-ticker.C:
 				clearScreen()
-				if err := displayClusterStatus(args, opts); err != nil {
-					return err
+				if _, derr := displayClusterStatus(clusterSpec, opts); derr != nil {
+					return derr
 				}
-				color.Cyan("🔄 Refreshing every %d seconds (Press Ctrl+C to stop)", opts.Refresh)
+				color.Cyan("Refreshing every %d seconds (Press Ctrl+C to stop)", opts.Refresh)
 			}
 		}
 	}
 
-	return displayClusterStatus(args, opts)
+	ch, err := displayClusterStatus(clusterSpec, opts)
+	if err != nil {
+		return err
+	}
+	if !ch.AllHealthy() {
+		os.Exit(1)
+	}
+	return nil
+}
+
+// resolveStatusSpec loads the topology either from -f or by looking up a
+// positional cluster-name file next to the binary's working directory.
+func resolveStatusSpec(args []string, opts *ClusterStatusOptions) (*spec.Specification, error) {
+	configFile := opts.ConfigFile
+	if configFile == "" && len(args) > 0 {
+		// Positional-name fallback: try <name>.yaml / <name>.yml
+		candidates := []string{args[0] + ".yaml", args[0] + ".yml", args[0]}
+		for _, c := range candidates {
+			if _, err := os.Stat(c); err == nil {
+				configFile = c
+				break
+			}
+		}
+	}
+	if configFile == "" {
+		return nil, fmt.Errorf("cluster configuration file is required (use -f)")
+	}
+	s, err := loadClusterSpec(configFile)
+	if err != nil {
+		return nil, err
+	}
+	if s.Name == "" && len(args) > 0 {
+		s.Name = args[0]
+	}
+	return s, nil
 }
 
 // clearScreen clears the terminal screen in a cross-platform way
@@ -207,22 +250,83 @@ func clearScreen() {
 	}
 }
 
-// displayClusterStatus shows the actual cluster status
-func displayClusterStatus(args []string, opts *ClusterStatusOptions) error {
-	// TODO: Implement actual status collection
-	color.Green("📊 Cluster Status")
-	
-	if len(args) == 0 {
-		color.Yellow("📋 All Clusters:")
-		// Show all clusters
-		fmt.Println("No clusters found. Deploy a cluster first with 'seaweed-up cluster deploy'")
-	} else {
-		clusterName := args[0]
-		color.Yellow("📋 Cluster: %s", clusterName)
-		fmt.Println("Status collection not yet implemented")
+// displayClusterStatus probes the cluster and prints the result, returning
+// the aggregated health so callers can decide on process exit status.
+func displayClusterStatus(clusterSpec *spec.Specification, opts *ClusterStatusOptions) (*health.ClusterHealth, error) {
+	timeout := 5 * time.Second
+	if opts.Timeout != "" {
+		if d, err := time.ParseDuration(opts.Timeout); err == nil && d > 0 {
+			timeout = d
+		}
 	}
-	
-	return nil
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Second)
+	defer cancel()
+
+	prober := health.NewProber(timeout)
+	ch := prober.Probe(ctx, clusterSpec)
+
+	if opts.JSONOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(ch); err != nil {
+			return ch, err
+		}
+		return ch, nil
+	}
+
+	renderStatusTable(clusterSpec, ch, opts.Verbose)
+	return ch, nil
+}
+
+func renderStatusTable(s *spec.Specification, ch *health.ClusterHealth, verbose bool) {
+	name := s.Name
+	if name == "" {
+		name = "(unnamed)"
+	}
+	color.Green("Cluster Status: %s", name)
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "COMPONENT\tADDRESS\tHEALTHY\tVERSION\tDETAIL")
+	writeRow := func(r health.ProbeResult) {
+		healthy := "NO"
+		if r.Healthy {
+			healthy = "OK"
+		}
+		detail := r.Err
+		if detail == "" && verbose && r.Raw != nil {
+			if b, err := json.Marshal(r.Raw); err == nil {
+				detail = string(b)
+			}
+		}
+		if detail == "" {
+			detail = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", r.Kind, r.Address, healthy, orDash(r.Version), detail)
+	}
+	for _, r := range ch.Masters {
+		writeRow(r)
+	}
+	for _, r := range ch.Volumes {
+		writeRow(r)
+	}
+	for _, r := range ch.Filers {
+		writeRow(r)
+	}
+	_ = tw.Flush()
+
+	if !ch.AllHealthy() {
+		color.Red("Cluster is UNHEALTHY")
+	} else {
+		color.Green("Cluster is healthy")
+	}
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
 }
 
 func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -77,7 +77,7 @@ type ClusterListOptions struct {
 }
 
 func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOptions) error {
-	color.Green("🚀 Deploying SeaweedFS cluster...")
+	color.Green("Deploying SeaweedFS cluster...")
 	
 	// Load cluster specification
 	clusterSpec, err := loadClusterSpec(opts.ConfigFile)
@@ -132,7 +132,7 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 	
 	// Confirm deployment if not skipped
 	if !opts.SkipConfirm {
-		color.Yellow("📋 Deployment Summary:")
+		color.Yellow("Deployment Summary:")
 		fmt.Printf("  Cluster: %s\n", clusterSpec.Name)
 		fmt.Printf("  Version: %s\n", mgr.Version)
 		fmt.Printf("  Masters: %d\n", len(clusterSpec.MasterServers))
@@ -140,19 +140,19 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 		fmt.Printf("  Filers:  %d\n", len(clusterSpec.FilerServers))
 		
 		if !utils.PromptForConfirmation("Proceed with deployment?") {
-			color.Yellow("⚠️  Deployment cancelled by user")
+			color.Yellow("Deployment cancelled by user")
 			return nil
 		}
 	}
 	
 	// Deploy cluster
 	if err := mgr.DeployCluster(clusterSpec); err != nil {
-		color.Red("❌ Deployment failed: %v", err)
+		color.Red("Deployment failed: %v", err)
 		return err
 	}
 	
-	color.Green("✅ Cluster deployed successfully!")
-	color.Cyan("💡 Next steps:")
+	color.Green("Cluster deployed successfully!")
+	color.Cyan("Next steps:")
 	fmt.Println("  - Check cluster status: seaweed-up cluster status", clusterSpec.Name)
 	fmt.Println("  - View logs: seaweed-up cluster logs", clusterSpec.Name)
 	
@@ -357,10 +357,10 @@ func orDash(s string) string {
 }
 
 func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
-	color.Green("⬆️  Upgrading cluster: %s to version %s", clusterName, opts.Version)
-	
+	color.Green("Upgrading cluster: %s to version %s", clusterName, opts.Version)
+
 	if opts.DryRun {
-		color.Yellow("🔍 Dry run mode - no changes will be made")
+		color.Yellow("Dry run mode - no changes will be made")
 	}
 	
 	// TODO: Implement upgrade logic
@@ -370,7 +370,7 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 }
 
 func runClusterScaleOut(clusterName string, opts *ClusterScaleOutOptions) error {
-	color.Green("📈 Scaling out cluster: %s", clusterName)
+	color.Green("Scaling out cluster: %s", clusterName)
 	
 	if opts.AddVolume > 0 {
 		fmt.Printf("Adding %d volume servers\n", opts.AddVolume)
@@ -386,7 +386,7 @@ func runClusterScaleOut(clusterName string, opts *ClusterScaleOutOptions) error 
 }
 
 func runClusterScaleIn(clusterName string, opts *ClusterScaleInOptions) error {
-	color.Green("📉 Scaling in cluster: %s", clusterName)
+	color.Green("Scaling in cluster: %s", clusterName)
 	
 	if len(opts.RemoveNodes) > 0 {
 		fmt.Printf("Removing nodes: %v\n", opts.RemoveNodes)
@@ -399,17 +399,17 @@ func runClusterScaleIn(clusterName string, opts *ClusterScaleInOptions) error {
 }
 
 func runClusterDestroy(clusterName string, opts *ClusterDestroyOptions) error {
-	color.Red("💥 WARNING: This will destroy cluster '%s'", clusterName)
-	
+	color.Red("WARNING: This will destroy cluster '%s'", clusterName)
+
 	if opts.RemoveData {
-		color.Red("⚠️  ALL DATA WILL BE PERMANENTLY DELETED!")
+		color.Red("ALL DATA WILL BE PERMANENTLY DELETED!")
 	}
 	
 	if !opts.SkipConfirm {
 		confirmation := utils.PromptForInput("Type the cluster name to confirm destruction: ")
 		
 		if confirmation != clusterName {
-			color.Yellow("⚠️  Destruction cancelled - cluster name didn't match")
+			color.Yellow("Destruction cancelled - cluster name didn't match")
 			return nil
 		}
 	}
@@ -421,7 +421,7 @@ func runClusterDestroy(clusterName string, opts *ClusterDestroyOptions) error {
 }
 
 func runClusterList(opts *ClusterListOptions) error {
-	color.Green("📋 Managed Clusters")
+	color.Green("Managed Clusters")
 	
 	// TODO: Implement cluster listing
 	fmt.Println("No clusters found. Deploy a cluster first with 'seaweed-up cluster deploy'")

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -254,11 +254,12 @@ func clearScreen() {
 // displayClusterStatus probes the cluster and prints the result, returning
 // the aggregated health so callers can decide on process exit status.
 func displayClusterStatus(clusterSpec *spec.Specification, opts *ClusterStatusOptions) (*health.ClusterHealth, error) {
+	// Parse the user-configured timeout (Cobra flag, default "30s"). Fall
+	// back to a 5s safety default only if parsing fails or the value is
+	// empty / non-positive.
 	timeout := 5 * time.Second
-	if opts.Timeout != "" {
-		if d, err := time.ParseDuration(opts.Timeout); err == nil && d > 0 {
-			timeout = d
-		}
+	if d, err := time.ParseDuration(opts.Timeout); err == nil && d > 0 {
+		timeout = d
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Second)
@@ -296,10 +297,17 @@ func renderStatusTable(s *spec.Specification, ch *health.ClusterHealth, verbose 
 		if r.Healthy {
 			healthy = "OK"
 		}
+		// In verbose mode show the error (if any) followed by the raw
+		// response body, so users can diagnose failures without losing
+		// context. In non-verbose mode we only surface the error string.
 		detail := r.Err
-		if detail == "" && verbose && r.Raw != nil {
+		if verbose && r.Raw != nil {
 			if b, err := json.Marshal(r.Raw); err == nil {
-				detail = string(b)
+				if detail != "" {
+					detail = detail + " | " + string(b)
+				} else {
+					detail = string(b)
+				}
 			}
 		}
 		if detail == "" {

--- a/pkg/cluster/health/health.go
+++ b/pkg/cluster/health/health.go
@@ -129,7 +129,7 @@ func (p *Prober) fetchJSON(ctx context.Context, url string) (map[string]any, err
 		return nil, fmt.Errorf("response body exceeded %d bytes limit", maxResponseBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("status %d: %s...", resp.StatusCode, string(body[:min(len(body), 1024)]))
+		return nil, fmt.Errorf("status %d: %s (truncated)", resp.StatusCode, string(body[:min(len(body), 1024)]))
 	}
 	var out map[string]any
 	if len(body) == 0 {

--- a/pkg/cluster/health/health.go
+++ b/pkg/cluster/health/health.go
@@ -1,0 +1,237 @@
+// Package health provides HTTP-based health probing for SeaweedFS cluster components.
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+)
+
+// ComponentKind identifies the kind of SeaweedFS component probed.
+type ComponentKind string
+
+const (
+	KindMaster ComponentKind = "master"
+	KindVolume ComponentKind = "volume"
+	KindFiler  ComponentKind = "filer"
+)
+
+// ProbeResult is the result of probing a single component endpoint.
+type ProbeResult struct {
+	Kind    ComponentKind  `json:"kind"`
+	Address string         `json:"address"`
+	Healthy bool           `json:"healthy"`
+	Version string         `json:"version,omitempty"`
+	Raw     map[string]any `json:"raw,omitempty"`
+	Err     string         `json:"error,omitempty"`
+	// Extra holds supplemental probes (e.g. /dir/status for masters).
+	Extra map[string]map[string]any `json:"extra,omitempty"`
+}
+
+// ClusterHealth aggregates probe results for a cluster.
+type ClusterHealth struct {
+	Masters []ProbeResult `json:"masters"`
+	Volumes []ProbeResult `json:"volumes"`
+	Filers  []ProbeResult `json:"filers"`
+}
+
+// AllHealthy returns true when every probed component is healthy.
+func (c *ClusterHealth) AllHealthy() bool {
+	for _, r := range c.Masters {
+		if !r.Healthy {
+			return false
+		}
+	}
+	for _, r := range c.Volumes {
+		if !r.Healthy {
+			return false
+		}
+	}
+	for _, r := range c.Filers {
+		if !r.Healthy {
+			return false
+		}
+	}
+	return true
+}
+
+// Prober issues HTTP probes with a shared timeout and http.Client.
+type Prober struct {
+	Timeout time.Duration
+	Client  *http.Client
+}
+
+// NewProber returns a Prober with sensible defaults.
+func NewProber(timeout time.Duration) *Prober {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &Prober{
+		Timeout: timeout,
+		Client: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+// fetchJSON GETs the URL and decodes the response body as a JSON object.
+func (p *Prober) fetchJSON(ctx context.Context, url string) (map[string]any, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("http %d: %s", resp.StatusCode, string(body))
+	}
+	var out map[string]any
+	if len(body) == 0 {
+		return map[string]any{}, nil
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return out, nil
+}
+
+// extractVersion hunts for common version keys in a SeaweedFS response.
+func extractVersion(m map[string]any) string {
+	if m == nil {
+		return ""
+	}
+	for _, k := range []string{"Version", "version"} {
+		if v, ok := m[k]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	// Some endpoints nest version under a sub-object.
+	for _, k := range []string{"Topology", "topology"} {
+		if sub, ok := m[k].(map[string]any); ok {
+			if v := extractVersion(sub); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+// ProbeMaster probes master /cluster/status and /dir/status.
+func (p *Prober) ProbeMaster(ctx context.Context, ip string, port int) ProbeResult {
+	addr := fmt.Sprintf("%s:%d", ip, port)
+	res := ProbeResult{Kind: KindMaster, Address: addr, Extra: map[string]map[string]any{}}
+
+	clusterURL := fmt.Sprintf("http://%s/cluster/status", addr)
+	data, err := p.fetchJSON(ctx, clusterURL)
+	if err != nil {
+		res.Err = err.Error()
+		return res
+	}
+	res.Raw = data
+	res.Version = extractVersion(data)
+
+	dirURL := fmt.Sprintf("http://%s/dir/status", addr)
+	if dirData, derr := p.fetchJSON(ctx, dirURL); derr == nil {
+		res.Extra["dir_status"] = dirData
+		if res.Version == "" {
+			res.Version = extractVersion(dirData)
+		}
+	} else {
+		res.Err = fmt.Sprintf("dir/status: %v", derr)
+		return res
+	}
+
+	res.Healthy = true
+	return res
+}
+
+// ProbeVolume probes volume /status.
+func (p *Prober) ProbeVolume(ctx context.Context, ip string, port int) ProbeResult {
+	addr := fmt.Sprintf("%s:%d", ip, port)
+	res := ProbeResult{Kind: KindVolume, Address: addr}
+	data, err := p.fetchJSON(ctx, fmt.Sprintf("http://%s/status", addr))
+	if err != nil {
+		res.Err = err.Error()
+		return res
+	}
+	res.Raw = data
+	res.Version = extractVersion(data)
+	res.Healthy = true
+	return res
+}
+
+// ProbeFiler probes filer /status.
+func (p *Prober) ProbeFiler(ctx context.Context, ip string, port int) ProbeResult {
+	addr := fmt.Sprintf("%s:%d", ip, port)
+	res := ProbeResult{Kind: KindFiler, Address: addr}
+	data, err := p.fetchJSON(ctx, fmt.Sprintf("http://%s/status", addr))
+	if err != nil {
+		res.Err = err.Error()
+		return res
+	}
+	res.Raw = data
+	res.Version = extractVersion(data)
+	res.Healthy = true
+	return res
+}
+
+// Probe runs probes for every component in the cluster spec in parallel.
+func (p *Prober) Probe(ctx context.Context, s *spec.Specification) *ClusterHealth {
+	health := &ClusterHealth{
+		Masters: make([]ProbeResult, len(s.MasterServers)),
+		Volumes: make([]ProbeResult, len(s.VolumeServers)),
+		Filers:  make([]ProbeResult, len(s.FilerServers)),
+	}
+
+	var wg sync.WaitGroup
+	for i, m := range s.MasterServers {
+		wg.Add(1)
+		go func(i int, m *spec.MasterServerSpec) {
+			defer wg.Done()
+			port := m.Port
+			if port == 0 {
+				port = 9333
+			}
+			health.Masters[i] = p.ProbeMaster(ctx, m.Ip, port)
+		}(i, m)
+	}
+	for i, v := range s.VolumeServers {
+		wg.Add(1)
+		go func(i int, v *spec.VolumeServerSpec) {
+			defer wg.Done()
+			port := v.Port
+			if port == 0 {
+				port = 8080
+			}
+			health.Volumes[i] = p.ProbeVolume(ctx, v.Ip, port)
+		}(i, v)
+	}
+	for i, f := range s.FilerServers {
+		wg.Add(1)
+		go func(i int, f *spec.FilerServerSpec) {
+			defer wg.Done()
+			port := f.Port
+			if port == 0 {
+				port = 8888
+			}
+			health.Filers[i] = p.ProbeFiler(ctx, f.Ip, port)
+		}(i, f)
+	}
+	wg.Wait()
+	return health
+}

--- a/pkg/cluster/health/health.go
+++ b/pkg/cluster/health/health.go
@@ -7,11 +7,30 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"sync"
 	"time"
 
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
 )
+
+// serverHeaderVersionRe matches "SeaweedFS <version>" in an HTTP Server header,
+// e.g. "SeaweedFS 3.75". The filer root response carries this header but has
+// no JSON body, so it is our only version signal.
+var serverHeaderVersionRe = regexp.MustCompile(`SeaweedFS[\s/]+([0-9][0-9A-Za-z._+\-]*)`)
+
+// parseServerHeaderVersion extracts a SeaweedFS version from a Server header
+// value. Returns "" when the header is absent or does not match.
+func parseServerHeaderVersion(h string) string {
+	if h == "" {
+		return ""
+	}
+	m := serverHeaderVersionRe.FindStringSubmatch(h)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
 
 // ComponentKind identifies the kind of SeaweedFS component probed.
 type ComponentKind string
@@ -208,17 +227,34 @@ func (p *Prober) ProbeVolume(ctx context.Context, ip string, port int) ProbeResu
 	return res
 }
 
-// ProbeFiler probes filer /status.
+// ProbeFiler probes the filer root endpoint. The SeaweedFS filer has no
+// /status endpoint; instead we GET / (which returns a directory listing) and
+// treat any 2xx as healthy. Version, when available, is parsed from the
+// "Server" response header (e.g. "SeaweedFS 3.75").
 func (p *Prober) ProbeFiler(ctx context.Context, ip string, port int) ProbeResult {
 	addr := fmt.Sprintf("%s:%d", ip, port)
 	res := ProbeResult{Kind: KindFiler, Address: addr}
-	data, err := p.fetchJSON(ctx, fmt.Sprintf("http://%s/status", addr))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s/", addr), nil)
 	if err != nil {
 		res.Err = err.Error()
 		return res
 	}
-	res.Raw = data
-	res.Version = extractVersion(data)
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		res.Err = err.Error()
+		return res
+	}
+	defer resp.Body.Close()
+	// Drain (bounded) so the connection can be reused, but we don't require
+	// or parse the body — the filer root returns HTML/JSON directory listings
+	// that aren't relevant to health.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxResponseBytes))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		res.Err = fmt.Sprintf("status %d", resp.StatusCode)
+		return res
+	}
+	res.Version = parseServerHeaderVersion(resp.Header.Get("Server"))
 	res.Healthy = true
 	return res
 }

--- a/pkg/cluster/health/health.go
+++ b/pkg/cluster/health/health.go
@@ -61,6 +61,28 @@ func (c *ClusterHealth) AllHealthy() bool {
 	return true
 }
 
+// UnhealthyCount returns the total number of unhealthy components across
+// masters, volumes, and filers.
+func (c *ClusterHealth) UnhealthyCount() int {
+	n := 0
+	for _, r := range c.Masters {
+		if !r.Healthy {
+			n++
+		}
+	}
+	for _, r := range c.Volumes {
+		if !r.Healthy {
+			n++
+		}
+	}
+	for _, r := range c.Filers {
+		if !r.Healthy {
+			n++
+		}
+	}
+	return n
+}
+
 // Prober issues HTTP probes with a shared timeout and http.Client.
 type Prober struct {
 	Timeout time.Duration

--- a/pkg/cluster/health/health.go
+++ b/pkg/cluster/health/health.go
@@ -22,6 +22,14 @@ const (
 	KindFiler  ComponentKind = "filer"
 )
 
+// maxResponseBytes caps the amount of data we will read from a probed
+// component's HTTP response. The SeaweedFS master /cluster/status and
+// /dir/status endpoints can return sizable topology documents on large
+// clusters (many volume servers, thousands of volumes), so we pick a
+// generous 10 MiB ceiling: large enough for realistic production clusters
+// while still bounding memory usage from a single misbehaving endpoint.
+const maxResponseBytes int64 = 10 << 20
+
 // ProbeResult is the result of probing a single component endpoint.
 type ProbeResult struct {
 	Kind    ComponentKind  `json:"kind"`
@@ -113,7 +121,7 @@ func (p *Prober) fetchJSON(ctx context.Context, url string) (map[string]any, err
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/health/health.go
+++ b/pkg/cluster/health/health.go
@@ -121,12 +121,15 @@ func (p *Prober) fetchJSON(ctx context.Context, url string) (map[string]any, err
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
 		return nil, err
 	}
+	if int64(len(body)) > maxResponseBytes {
+		return nil, fmt.Errorf("response body exceeded %d bytes limit", maxResponseBytes)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("http %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("status %d: %s...", resp.StatusCode, string(body[:min(len(body), 1024)]))
 	}
 	var out map[string]any
 	if len(body) == 0 {
@@ -222,7 +225,7 @@ func (p *Prober) ProbeFiler(ctx context.Context, ip string, port int) ProbeResul
 
 // Probe runs probes for every component in the cluster spec in parallel.
 func (p *Prober) Probe(ctx context.Context, s *spec.Specification) *ClusterHealth {
-	health := &ClusterHealth{
+	h := &ClusterHealth{
 		Masters: make([]ProbeResult, len(s.MasterServers)),
 		Volumes: make([]ProbeResult, len(s.VolumeServers)),
 		Filers:  make([]ProbeResult, len(s.FilerServers)),
@@ -237,7 +240,7 @@ func (p *Prober) Probe(ctx context.Context, s *spec.Specification) *ClusterHealt
 			if port == 0 {
 				port = 9333
 			}
-			health.Masters[i] = p.ProbeMaster(ctx, m.Ip, port)
+			h.Masters[i] = p.ProbeMaster(ctx, m.Ip, port)
 		}(i, m)
 	}
 	for i, v := range s.VolumeServers {
@@ -248,7 +251,7 @@ func (p *Prober) Probe(ctx context.Context, s *spec.Specification) *ClusterHealt
 			if port == 0 {
 				port = 8080
 			}
-			health.Volumes[i] = p.ProbeVolume(ctx, v.Ip, port)
+			h.Volumes[i] = p.ProbeVolume(ctx, v.Ip, port)
 		}(i, v)
 	}
 	for i, f := range s.FilerServers {
@@ -259,9 +262,9 @@ func (p *Prober) Probe(ctx context.Context, s *spec.Specification) *ClusterHealt
 			if port == 0 {
 				port = 8888
 			}
-			health.Filers[i] = p.ProbeFiler(ctx, f.Ip, port)
+			h.Filers[i] = p.ProbeFiler(ctx, f.Ip, port)
 		}(i, f)
 	}
 	wg.Wait()
-	return health
+	return h
 }

--- a/pkg/cluster/health/health_test.go
+++ b/pkg/cluster/health/health_test.go
@@ -1,0 +1,183 @@
+package health
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+)
+
+// parseHostPort extracts ip + port from an httptest.Server URL.
+func parseHostPort(t *testing.T, raw string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	host, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("split host/port: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+	return host, port
+}
+
+func newMasterServer(t *testing.T) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cluster/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"IsLeader":true,"Leader":"127.0.0.1:9333","Version":"3.75"}`))
+	})
+	mux.HandleFunc("/dir/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Version":"3.75","Topology":{"Free":10}}`))
+	})
+	return httptest.NewServer(mux)
+}
+
+func newVolumeServer(t *testing.T) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"Version":"3.75","Volumes":[]}`))
+	})
+	return httptest.NewServer(mux)
+}
+
+func newFilerServer(t *testing.T) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"Version":"3.75"}`))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestProbeMaster(t *testing.T) {
+	srv := newMasterServer(t)
+	defer srv.Close()
+	ip, port := parseHostPort(t, srv.URL)
+
+	p := NewProber(2 * time.Second)
+	res := p.ProbeMaster(context.Background(), ip, port)
+	if !res.Healthy {
+		t.Fatalf("expected healthy, got err=%s", res.Err)
+	}
+	if res.Version != "3.75" {
+		t.Errorf("expected version 3.75, got %q", res.Version)
+	}
+	if res.Extra["dir_status"] == nil {
+		t.Errorf("expected dir_status extra data")
+	}
+}
+
+func TestProbeMasterUnhealthyOnDirStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cluster/status", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"Version":"3.75"}`))
+	})
+	mux.HandleFunc("/dir/status", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	ip, port := parseHostPort(t, srv.URL)
+
+	p := NewProber(2 * time.Second)
+	res := p.ProbeMaster(context.Background(), ip, port)
+	if res.Healthy {
+		t.Fatalf("expected unhealthy")
+	}
+	if !strings.Contains(res.Err, "dir/status") {
+		t.Errorf("expected dir/status error, got %q", res.Err)
+	}
+}
+
+func TestProbeVolume(t *testing.T) {
+	srv := newVolumeServer(t)
+	defer srv.Close()
+	ip, port := parseHostPort(t, srv.URL)
+	p := NewProber(2 * time.Second)
+	res := p.ProbeVolume(context.Background(), ip, port)
+	if !res.Healthy {
+		t.Fatalf("unhealthy: %s", res.Err)
+	}
+	if res.Version != "3.75" {
+		t.Errorf("version = %q", res.Version)
+	}
+}
+
+func TestProbeFiler(t *testing.T) {
+	srv := newFilerServer(t)
+	defer srv.Close()
+	ip, port := parseHostPort(t, srv.URL)
+	p := NewProber(2 * time.Second)
+	res := p.ProbeFiler(context.Background(), ip, port)
+	if !res.Healthy {
+		t.Fatalf("unhealthy: %s", res.Err)
+	}
+}
+
+func TestProbeUnreachable(t *testing.T) {
+	p := NewProber(500 * time.Millisecond)
+	// Use 127.0.0.1:1 which should refuse.
+	res := p.ProbeVolume(context.Background(), "127.0.0.1", 1)
+	if res.Healthy {
+		t.Fatal("expected unhealthy for unreachable endpoint")
+	}
+	if res.Err == "" {
+		t.Fatal("expected error message")
+	}
+}
+
+func TestProbeAggregation(t *testing.T) {
+	master := newMasterServer(t)
+	defer master.Close()
+	volume := newVolumeServer(t)
+	defer volume.Close()
+	filer := newFilerServer(t)
+	defer filer.Close()
+
+	mip, mport := parseHostPort(t, master.URL)
+	vip, vport := parseHostPort(t, volume.URL)
+	fip, fport := parseHostPort(t, filer.URL)
+
+	s := &spec.Specification{
+		MasterServers: []*spec.MasterServerSpec{{Ip: mip, Port: mport}},
+		VolumeServers: []*spec.VolumeServerSpec{{Ip: vip, Port: vport}},
+		FilerServers:  []*spec.FilerServerSpec{{Ip: fip, Port: fport}},
+	}
+
+	p := NewProber(2 * time.Second)
+	ch := p.Probe(context.Background(), s)
+	if !ch.AllHealthy() {
+		t.Fatalf("expected all healthy: %+v", ch)
+	}
+	if len(ch.Masters) != 1 || len(ch.Volumes) != 1 || len(ch.Filers) != 1 {
+		t.Fatalf("wrong counts: %+v", ch)
+	}
+}
+
+func TestProbeAggregationUnhealthy(t *testing.T) {
+	master := newMasterServer(t)
+	defer master.Close()
+	mip, mport := parseHostPort(t, master.URL)
+
+	s := &spec.Specification{
+		MasterServers: []*spec.MasterServerSpec{{Ip: mip, Port: mport}},
+		VolumeServers: []*spec.VolumeServerSpec{{Ip: "127.0.0.1", Port: 1}},
+	}
+	p := NewProber(500 * time.Millisecond)
+	ch := p.Probe(context.Background(), s)
+	if ch.AllHealthy() {
+		t.Fatal("expected unhealthy cluster")
+	}
+}

--- a/pkg/cluster/health/health_test.go
+++ b/pkg/cluster/health/health_test.go
@@ -55,8 +55,12 @@ func newVolumeServer(t *testing.T) *httptest.Server {
 
 func newFilerServer(t *testing.T) *httptest.Server {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"Version":"3.75"}`))
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Real SeaweedFS filer has no /status endpoint; the root returns a
+		// directory listing with a "Server: SeaweedFS <version>" header.
+		w.Header().Set("Server", "SeaweedFS 3.75")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Path":"/","Entries":[]}`))
 	})
 	return httptest.NewServer(mux)
 }
@@ -123,6 +127,60 @@ func TestProbeFiler(t *testing.T) {
 	res := p.ProbeFiler(context.Background(), ip, port)
 	if !res.Healthy {
 		t.Fatalf("unhealthy: %s", res.Err)
+	}
+	if res.Version != "3.75" {
+		t.Errorf("expected version 3.75 from Server header, got %q", res.Version)
+	}
+}
+
+func TestProbeFilerNoServerHeader(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`ok`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	ip, port := parseHostPort(t, srv.URL)
+	p := NewProber(2 * time.Second)
+	res := p.ProbeFiler(context.Background(), ip, port)
+	if !res.Healthy {
+		t.Fatalf("unhealthy: %s", res.Err)
+	}
+	if res.Version != "" {
+		t.Errorf("expected empty version, got %q", res.Version)
+	}
+}
+
+func TestProbeFilerNon2xx(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	ip, port := parseHostPort(t, srv.URL)
+	p := NewProber(2 * time.Second)
+	res := p.ProbeFiler(context.Background(), ip, port)
+	if res.Healthy {
+		t.Fatalf("expected unhealthy")
+	}
+	if !strings.Contains(res.Err, "500") {
+		t.Errorf("expected status 500 in err, got %q", res.Err)
+	}
+}
+
+func TestParseServerHeaderVersion(t *testing.T) {
+	cases := map[string]string{
+		"":                     "",
+		"nginx":                "",
+		"SeaweedFS 3.75":       "3.75",
+		"SeaweedFS/3.80":       "3.80",
+		"SeaweedFS 3.75-beta1": "3.75-beta1",
+	}
+	for in, want := range cases {
+		if got := parseServerHeaderVersion(in); got != want {
+			t.Errorf("parseServerHeaderVersion(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/test/integration/framework.go
+++ b/test/integration/framework.go
@@ -56,6 +56,17 @@ func (e *TestEnvironment) SkipIfNotAvailable(t *testing.T) {
 
 // Setup starts the Docker environment
 func (e *TestEnvironment) Setup() error {
+	// When the test environment is managed externally (e.g. by a CI
+	// workflow that has already created the network, started containers,
+	// installed SSH and provisioned keys), skip the docker-compose path
+	// entirely. This lets CI jobs use a unique docker subnet without
+	// touching the shared docker-compose.yml file.
+	if os.Getenv("SEAWEED_UP_EXTERNAL_ENV") == "1" {
+		e.t.Log("SEAWEED_UP_EXTERNAL_ENV=1: using externally managed test environment")
+		e.dockerRunning = false
+		return nil
+	}
+
 	e.t.Log("Setting up Docker test environment...")
 
 	composeFile := filepath.Join(e.projectRoot, "test", "integration", "docker-compose.yml")

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestClusterStatusReal verifies the `cluster status` command against a real
+// deployed 1-master + 1-volume + 1-filer topology and expects exit code 0.
+func TestClusterStatusReal(t *testing.T) {
+	env := NewTestEnvironment(t)
+	env.SkipIfNotAvailable(t)
+
+	if err := env.BuildSeaweedUp(); err != nil {
+		t.Fatalf("Failed to build seaweed-up: %v", err)
+	}
+
+	if err := env.Setup(); err != nil {
+		t.Fatalf("Failed to setup test environment: %v", err)
+	}
+	defer func() {
+		if err := env.Teardown(); err != nil {
+			t.Errorf("Failed to teardown test environment: %v", err)
+		}
+	}()
+
+	configFile := env.GetClusterConfig("cluster-single.yaml")
+	sshKey := env.GetSSHKeyPath()
+
+	output, err := env.RunSeaweedUp(
+		"cluster", "deploy", "test-status",
+		"-f", configFile,
+		"-u", "root",
+		"--identity", sshKey,
+		"--yes",
+	)
+	if err != nil {
+		t.Logf("Deploy output: %s", output)
+		t.Fatalf("Failed to deploy cluster: %v", err)
+	}
+
+	// Give services time to come up fully.
+	time.Sleep(20 * time.Second)
+
+	t.Run("StatusTable", func(t *testing.T) {
+		output, err := env.RunSeaweedUp("cluster", "status", "-f", configFile)
+		t.Logf("Status output: %s", output)
+		if err != nil {
+			t.Fatalf("cluster status returned non-zero: %v", err)
+		}
+		if !strings.Contains(output, "OK") {
+			t.Errorf("expected healthy OK row in status output")
+		}
+	})
+
+	t.Run("StatusJSON", func(t *testing.T) {
+		output, err := env.RunSeaweedUp("cluster", "status", "-f", configFile, "--json")
+		t.Logf("JSON status: %s", output)
+		if err != nil {
+			t.Fatalf("cluster status --json failed: %v", err)
+		}
+		if !strings.Contains(output, "\"masters\"") {
+			t.Errorf("expected masters key in JSON output")
+		}
+	})
+}

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -43,8 +43,32 @@ func TestClusterStatusReal(t *testing.T) {
 		t.Fatalf("Failed to deploy cluster: %v", err)
 	}
 
-	// Give services time to come up fully.
-	time.Sleep(20 * time.Second)
+	// Poll `cluster status` until every component reports healthy, rather
+	// than sleeping for a fixed duration. This is faster on a happy path
+	// and avoids flakiness when services take longer than expected to
+	// come up.
+	const (
+		pollInterval = 2 * time.Second
+		pollTimeout  = 60 * time.Second
+	)
+	var (
+		lastOutput string
+		lastErr    error
+		healthy    bool
+		deadline   = time.Now().Add(pollTimeout)
+	)
+	for time.Now().Before(deadline) {
+		lastOutput, lastErr = env.RunSeaweedUp("cluster", "status", "-f", configFile)
+		if lastErr == nil && strings.Contains(lastOutput, "OK") && !strings.Contains(lastOutput, "UNHEALTHY") {
+			healthy = true
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+	if !healthy {
+		t.Logf("Final status output: %s", lastOutput)
+		t.Fatalf("cluster did not become healthy within %s: %v", pollTimeout, lastErr)
+	}
 
 	t.Run("StatusTable", func(t *testing.T) {
 		output, err := env.RunSeaweedUp("cluster", "status", "-f", configFile)

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -28,7 +29,14 @@ func TestClusterStatusReal(t *testing.T) {
 		}
 	}()
 
-	configFile := env.GetClusterConfig("cluster-single.yaml")
+	// Use a status-specific cluster config so this test can run with a
+	// unique docker subnet in CI without touching the shared single-node
+	// testdata used by the main integration-tests workflow.
+	configName := "cluster-single.yaml"
+	if os.Getenv("SEAWEED_UP_EXTERNAL_ENV") == "1" {
+		configName = "cluster-single-status.yaml"
+	}
+	configFile := env.GetClusterConfig(configName)
 	sshKey := env.GetSSHKeyPath()
 
 	output, err := env.RunSeaweedUp(

--- a/test/integration/testdata/cluster-single-status.yaml
+++ b/test/integration/testdata/cluster-single-status.yaml
@@ -1,0 +1,23 @@
+# Single-node test cluster configuration for the cluster status CI job.
+# Uses a unique docker subnet (10.201.39.0/24) to avoid pool overlap with
+# the default GitHub Actions docker bridge address pool.
+global:
+  dir.conf: "/etc/seaweed"
+  dir.data: "/opt/seaweed"
+  volumeSizeLimitMB: 100
+  replication: "000"
+
+master_servers:
+  - ip: 10.201.39.10
+    port: 9333
+
+volume_servers:
+  - ip: 10.201.39.10
+    port: 8382
+    folders:
+      - folder: /opt/seaweed/volume0
+        disk: ""
+
+filer_servers:
+  - ip: 10.201.39.10
+    port: 8888

--- a/test/integration/testdata/cluster-single.yaml
+++ b/test/integration/testdata/cluster-single.yaml
@@ -13,7 +13,7 @@ volume_servers:
   - ip: 172.28.0.10
     port: 8382
     folders:
-      - folder: /opt/seaweed/vol1
+      - folder: /opt/seaweed/volume0
         disk: ""
 
 filer_servers:

--- a/test/integration/testdata/cluster-single.yaml
+++ b/test/integration/testdata/cluster-single.yaml
@@ -13,7 +13,7 @@ volume_servers:
   - ip: 172.28.0.10
     port: 8382
     folders:
-      - folder: /opt/seaweed/volume0
+      - folder: /opt/seaweed/vol1
         disk: ""
 
 filer_servers:


### PR DESCRIPTION
## Summary

- Adds a new `pkg/cluster/health` package with a `Prober` that probes master (`/cluster/status`, `/dir/status`), volume (`/status`), and filer (`/status`) over HTTP in parallel. Unit tests cover each probe plus aggregate health using `httptest.Server`.
- Replaces the `cluster status` stub in `cmd/cluster_impl.go` with a real implementation that loads the topology from `-f` (with positional cluster-name fallback), renders a tabwriter table by default, supports `--json` and `--refresh=N`, and exits with code 1 when any component is unhealthy.
- Adds a build-tagged integration test (`test/integration/status_test.go`) that deploys a 1 master + 1 volume + 1 filer cluster and asserts `cluster status` succeeds in both table and JSON modes, plus a new `.github/workflows/integration-status.yml` workflow that runs it using the same systemd-in-docker pattern as `integration-tests.yml`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/cluster/health/...`
- [x] `go build -tags integration ./test/integration/...`
- [ ] CI: `Integration Status Test` workflow passes end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-f/--file` flag to `cluster status` command for specifying configuration files.
  * Added health probing for cluster components (masters, volumes, filers).
  * Added JSON output support to `cluster status` command.

* **Improvements**
  * Enhanced `cluster status` validation to require either a cluster name or config file.
  * Improved error reporting when cluster components are unhealthy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->