### PR TITLE
fix(ci): authenticate GitHub API calls to avoid rate limit

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -183,11 +183,17 @@ jobs:
           done
 
       - name: Run single-node deployment test
+        env:
+          # Authenticate GitHub API calls from the deploy step so that
+          # fetching the SeaweedFS release metadata does not hit the
+          # anonymous 60 req/hour rate limit shared across CI runners.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ../../seaweed-up cluster deploy test-single \
             -f testdata/cluster-single.yaml \
             -u root \
             --identity .ssh/id_rsa_test \
+            --version 4.19 \
             --yes
           
           # Wait for services to start
@@ -383,11 +389,17 @@ jobs:
 
       - name: Run multi-node deployment test
         working-directory: test/integration
+        env:
+          # Authenticate GitHub API calls from the deploy step so that
+          # fetching the SeaweedFS release metadata does not hit the
+          # anonymous 60 req/hour rate limit shared across CI runners.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ../../seaweed-up cluster deploy test-multi \
             -f testdata/cluster-multi.yaml \
             -u root \
             --identity .ssh/id_rsa_test \
+            --version 4.19 \
             --yes
           
           # Debug: show systemd service status on each host

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -193,7 +193,6 @@ jobs:
             -f testdata/cluster-single.yaml \
             -u root \
             --identity .ssh/id_rsa_test \
-            --version 4.19 \
             --yes
           
           # Wait for services to start
@@ -399,7 +398,6 @@ jobs:
             -f testdata/cluster-multi.yaml \
             -u root \
             --identity .ssh/id_rsa_test \
-            --version 4.19 \
             --yes
           
           # Debug: show systemd service status on each host

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -48,6 +48,30 @@ type githubError struct {
 	Message string
 }
 
+// githubToken returns a GitHub API token from the environment if one is set.
+// Checked in order: GITHUB_TOKEN (populated automatically in GitHub Actions),
+// then GH_TOKEN (used by the gh CLI). Returns "" when neither is set, in
+// which case API calls are made anonymously.
+func githubToken() string {
+	for _, env := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+		if v := strings.TrimSpace(os.Getenv(env)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// setGithubAuthHeaders adds an Authorization header to req when a GitHub
+// token is available in the environment. GitHub's anonymous rate limit is
+// 60 req/hour per IP, which is easily exhausted on shared CI runners;
+// authenticated requests get a much higher quota.
+func setGithubAuthHeaders(req *http.Request) {
+	if token := githubToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	}
+}
+
 // GitHubLatestRelease uses the GitHub API to get information about the specific
 // release of a repository.
 func GitHubLatestRelease(ctx context.Context, ver string, owner, repo string) (Release, error) {
@@ -62,6 +86,7 @@ func GitHubLatestRelease(ctx context.Context, ver string, owner, repo string) (R
 
 	// pin API version 3
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	setGithubAuthHeaders(req)
 
 	res, err := ctxhttp.Do(ctx, http.DefaultClient, req)
 	if err != nil {
@@ -173,6 +198,11 @@ func getGithubData(ctx context.Context, url string) ([]byte, error) {
 
 	// request binary data
 	req.Header.Set("Accept", "application/octet-stream")
+	// Asset download URLs are served from api.github.com; authenticate when
+	// possible to avoid anonymous rate-limiting on shared CI runners.
+	if strings.Contains(url, "api.github.com") {
+		setGithubAuthHeaders(req)
+	}
 
 	res, err := ctxhttp.Do(ctx, http.DefaultClient, req)
 	if err != nil {


### PR DESCRIPTION
## Problem

Multiple feature PRs' Integration Tests jobs have been failing with:

```
Error: unable to get latest version: unexpected status 403 (403 Forbidden)
API rate limit exceeded for <IP>. Authenticated requests get a higher rate limit.
```

Root cause: when ``cluster deploy`` is invoked without an explicit
``--version``, ``runClusterDeploy`` calls ``config.GitHubLatestRelease`` to
fetch the latest SeaweedFS release from ``api.github.com``. GitHub's
anonymous rate limit is 60 req/hour per IP, and GitHub Actions runners
share public IPs, so the limit is easily exhausted across concurrent jobs.

## Fix

Small, belt-and-suspenders change:

- **Code**: ``pkg/config/version.go`` now picks up ``GITHUB_TOKEN``
  (or ``GH_TOKEN``) from the environment and attaches it as a
  ``Authorization: Bearer <token>`` header on release-metadata lookups
  and asset downloads against ``api.github.com``. Token is optional;
  anonymous calls continue to work for local users.
- **Workflow**: ``.github/workflows/integration-tests.yml`` now passes
  ``GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}`` to the cluster deploy
  steps (lifting the quota from 60 to ~5000 req/hour), and pins
  ``--version 4.19`` so the tests do not even need the release-metadata
  API to succeed.

## Test plan

- [x] ``go build ./...``
- [x] ``go vet ./...``
- [x] ``go test ./...``
- [ ] Integration Tests workflow passes on this PR