### PR TITLE
fix(scale-in): use correct weed shell evacuate command and fail loudly

### DIFF
--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -925,8 +925,12 @@ func drainViaWeedShell(masterIp string, masterSshPort, masterPort int, user, ide
 	if masterPort == 0 {
 		masterPort = 9333
 	}
-	return operator.ExecuteRemote(fmt.Sprintf("%s:%d", masterIp, masterSshPort), user, identity, sudoPass, func(op operator.CommandOperator) error {
-		cmd := fmt.Sprintf("echo 'volumeServer.evacuate -node=%s -apply' | weed shell -master=%s:%d 2>&1", nodeAddr, masterIp, masterPort)
+	sshHost := net.JoinHostPort(masterIp, strconv.Itoa(masterSshPort))
+	masterAddr := net.JoinHostPort(masterIp, strconv.Itoa(masterPort))
+	return operator.ExecuteRemote(sshHost, user, identity, sudoPass, func(op operator.CommandOperator) error {
+		evacuateCmd := fmt.Sprintf("volumeServer.evacuate -node=%s -apply", nodeAddr)
+		cmd := fmt.Sprintf("echo %s | weed shell -master=%s 2>&1",
+			shellSingleQuote(evacuateCmd), shellSingleQuote(masterAddr))
 		out, err := op.Output(cmd)
 		text := string(out)
 		if len(text) > 0 {

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -803,13 +803,12 @@ func runClusterScaleIn(clusterName string, opts *ClusterScaleInOptions) error {
 		if drainTimeout <= 0 {
 			drainTimeout = 30 * time.Minute
 		}
-		drainErr := scale.Drain(masterAddr, nodeAddr, drainTimeout)
-		if drainErr != nil {
-			color.Yellow("HTTP drain failed (%v); falling back to weed shell over SSH", drainErr)
-			masterSshPort := nonZero(master.PortSsh, opts.SSHPort)
-			if fbErr := drainViaWeedShell(master.Ip, masterSshPort, masterPort, sshUser, sshIdentity, sudoPass, nodeAddr); fbErr != nil {
-				return fmt.Errorf("drain %s: %w", nodeAddr, fbErr)
-			}
+		masterSshPort := nonZero(master.PortSsh, opts.SSHPort)
+		if err := drainViaWeedShell(master.Ip, masterSshPort, masterPort, sshUser, sshIdentity, sudoPass, nodeAddr); err != nil {
+			return fmt.Errorf("drain %s: %w", nodeAddr, err)
+		}
+		if err := scale.WaitForDrain(masterAddr, nodeAddr, drainTimeout); err != nil {
+			return fmt.Errorf("drain %s: %w", nodeAddr, err)
 		}
 		color.Green("Drain complete for %s", nodeAddr)
 
@@ -913,8 +912,12 @@ func currentSSHCreds(userOverride, identityOverride string) (user, identity, sud
 	return user, identity, sudoPass, nil
 }
 
-// drainViaWeedShell runs `weed shell ... volume.evacuate -node=<target>`
-// on a master host via SSH, as a fallback when HTTP drain is unavailable.
+// drainViaWeedShell runs `weed shell ... volumeServer.evacuate -node=<target> -apply`
+// on a master host via SSH. This is the only mechanism SeaweedFS exposes to
+// move volumes off a server — there is no master HTTP endpoint for it.
+//
+// `weed shell` exits 0 even when the command is unknown or evacuation fails,
+// so we capture stdout/stderr and inspect it for known failure phrases.
 func drainViaWeedShell(masterIp string, masterSshPort, masterPort int, user, identity, sudoPass, nodeAddr string) error {
 	if masterSshPort == 0 {
 		masterSshPort = 22
@@ -923,8 +926,23 @@ func drainViaWeedShell(masterIp string, masterSshPort, masterPort int, user, ide
 		masterPort = 9333
 	}
 	return operator.ExecuteRemote(fmt.Sprintf("%s:%d", masterIp, masterSshPort), user, identity, sudoPass, func(op operator.CommandOperator) error {
-		cmd := fmt.Sprintf("echo 'volume.evacuate -node=%s' | weed shell -master=%s:%d", nodeAddr, masterIp, masterPort)
-		return op.Execute(cmd)
+		cmd := fmt.Sprintf("echo 'volumeServer.evacuate -node=%s -apply' | weed shell -master=%s:%d 2>&1", nodeAddr, masterIp, masterPort)
+		out, err := op.Output(cmd)
+		text := string(out)
+		if len(text) > 0 {
+			fmt.Println(strings.TrimRight(text, "\n"))
+		}
+		if err != nil {
+			return fmt.Errorf("weed shell volumeServer.evacuate: %w", err)
+		}
+		lower := strings.ToLower(text)
+		if strings.Contains(lower, "unknown command") {
+			return fmt.Errorf("weed shell rejected volumeServer.evacuate (output: %s)", strings.TrimSpace(text))
+		}
+		if strings.Contains(lower, "no such") || strings.Contains(lower, "failed to evacuate") {
+			return fmt.Errorf("weed shell volumeServer.evacuate reported failure: %s", strings.TrimSpace(text))
+		}
+		return nil
 	})
 }
 

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -760,13 +760,20 @@ func runClusterScaleIn(clusterName string, opts *ClusterScaleInOptions) error {
 	if clusterSpec.GlobalOptions.TLSEnabled {
 		scheme = "https://"
 	}
+	// HTTP client aware of the cluster CA when TLS is enabled. Used for the
+	// master health probe and for the post-drain verification poll, both of
+	// which hit the master over HTTPS on TLS clusters.
+	masterHTTPClient := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: newUpgradeHTTPTransport(false, clusterSpec.Name),
+	}
 	var master *spec.MasterServerSpec
 	var masterPort int
 	var masterAddr string
 	for _, candidate := range clusterSpec.MasterServers {
 		port := nonZero(candidate.Port, 9333)
 		addr := fmt.Sprintf("%s%s:%d", scheme, candidate.Ip, port)
-		if healthyMaster(addr) {
+		if healthyMasterWithClient(masterHTTPClient, addr) {
 			master = candidate
 			masterPort = port
 			masterAddr = addr
@@ -807,7 +814,7 @@ func runClusterScaleIn(clusterName string, opts *ClusterScaleInOptions) error {
 		if err := drainViaWeedShell(master.Ip, masterSshPort, masterPort, sshUser, sshIdentity, sudoPass, nodeAddr); err != nil {
 			return fmt.Errorf("drain %s: %w", nodeAddr, err)
 		}
-		if err := scale.WaitForDrain(masterAddr, nodeAddr, drainTimeout); err != nil {
+		if err := scale.WaitForDrainWithClient(masterHTTPClient, masterAddr, nodeAddr, drainTimeout); err != nil {
 			return fmt.Errorf("drain %s: %w", nodeAddr, err)
 		}
 		color.Green("Drain complete for %s", nodeAddr)
@@ -1221,17 +1228,18 @@ func safeRemoveDir(dir string) bool {
 	return trimmed != ""
 }
 
-// healthyMaster performs a fast best-effort GET against a master's
+// healthyMasterWithClient performs a fast best-effort GET against a master's
 // /cluster/status endpoint. It returns true only if the endpoint responds
-// with a 2xx within a short timeout. This is used by scale-in to pick a
-// responsive master out of the configured list.
-func healthyMaster(masterURL string) bool {
-	client := &http.Client{Timeout: 3 * time.Second}
+// with a 2xx within a short timeout. The caller supplies the HTTP client so
+// TLS clusters can pass one that trusts the cluster CA.
+func healthyMasterWithClient(client *http.Client, masterURL string) bool {
+	probe := *client
+	probe.Timeout = 3 * time.Second
 	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(masterURL, "/")+"/cluster/status", nil)
 	if err != nil {
 		return false
 	}
-	resp, err := client.Do(req)
+	resp, err := probe.Do(req)
 	if err != nil {
 		return false
 	}

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -935,8 +935,12 @@ func drainViaWeedShell(masterIp string, masterSshPort, masterPort int, user, ide
 	sshHost := net.JoinHostPort(masterIp, strconv.Itoa(masterSshPort))
 	masterAddr := net.JoinHostPort(masterIp, strconv.Itoa(masterPort))
 	return operator.ExecuteRemote(sshHost, user, identity, sudoPass, func(op operator.CommandOperator) error {
+		// `volumeServer.evacuate -apply` calls confirmIsLocked, so the weed
+		// shell session must acquire the admin lock first. Pipe `lock`,
+		// then the evacuate command, then `unlock`. Use `printf '%s\n'` so
+		// the evacuate line is not subject to printf format interpretation.
 		evacuateCmd := fmt.Sprintf("volumeServer.evacuate -node=%s -apply", nodeAddr)
-		cmd := fmt.Sprintf("echo %s | weed shell -master=%s 2>&1",
+		cmd := fmt.Sprintf("printf '%%s\\n' lock %s unlock | weed shell -master=%s 2>&1",
 			shellSingleQuote(evacuateCmd), shellSingleQuote(masterAddr))
 		out, err := op.Output(cmd)
 		text := string(out)
@@ -949,6 +953,9 @@ func drainViaWeedShell(masterIp string, masterSshPort, masterPort int, user, ide
 		lower := strings.ToLower(text)
 		if strings.Contains(lower, "unknown command") {
 			return fmt.Errorf("weed shell rejected volumeServer.evacuate (output: %s)", strings.TrimSpace(text))
+		}
+		if strings.Contains(lower, `need to run "lock" first`) {
+			return fmt.Errorf("weed shell refused evacuate: admin lock not acquired (output: %s)", strings.TrimSpace(text))
 		}
 		if strings.Contains(lower, "no such") || strings.Contains(lower, "failed to evacuate") {
 			return fmt.Errorf("weed shell volumeServer.evacuate reported failure: %s", strings.TrimSpace(text))

--- a/pkg/cluster/scale/drain.go
+++ b/pkg/cluster/scale/drain.go
@@ -7,13 +7,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 )
 
-// HTTPClient is the subset of http.Client that Drain uses. It is defined as
-// an interface so tests can supply a custom transport / client.
+// HTTPClient is the subset of http.Client that WaitForDrain uses. It is
+// defined as an interface so tests can supply a custom transport / client.
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -25,19 +24,23 @@ var defaultClient HTTPClient = &http.Client{Timeout: 30 * time.Second}
 // package variable so tests can override it.
 var pollInterval = 2 * time.Second
 
-// Drain marks the given target volume server read-only on the master and
-// asks the master to evacuate all volumes off the node. It polls the master
-// until the target reports 0 volumes or the timeout expires.
+// WaitForDrain polls the master's /dir/status until the target volume server
+// reports 0 volumes (or is no longer present in the topology) or the timeout
+// expires. It does NOT initiate the drain itself — SeaweedFS exposes no
+// master HTTP endpoint for that, so the caller is expected to have already
+// kicked off `volumeServer.evacuate` via `weed shell`. This function exists
+// as an independent verification that evacuation actually completed.
 //
-// masterAddr is expected in the form "host:port" (no scheme). targetNode is
-// the volume server address as seen by the master, typically "ip:port".
-func Drain(masterAddr, targetNode string, timeout time.Duration) error {
-	return DrainWithClient(defaultClient, masterAddr, targetNode, timeout)
+// masterAddr is expected in the form "host:port" (scheme optional).
+// targetNode is the volume server address as seen by the master,
+// typically "ip:port".
+func WaitForDrain(masterAddr, targetNode string, timeout time.Duration) error {
+	return WaitForDrainWithClient(defaultClient, masterAddr, targetNode, timeout)
 }
 
-// DrainWithClient is like Drain but uses the supplied HTTP client. This is
-// primarily intended for testing against httptest servers.
-func DrainWithClient(client HTTPClient, masterAddr, targetNode string, timeout time.Duration) error {
+// WaitForDrainWithClient is like WaitForDrain but uses the supplied HTTP
+// client. This is primarily intended for testing against httptest servers.
+func WaitForDrainWithClient(client HTTPClient, masterAddr, targetNode string, timeout time.Duration) error {
 	if client == nil {
 		client = defaultClient
 	}
@@ -49,19 +52,6 @@ func DrainWithClient(client HTTPClient, masterAddr, targetNode string, timeout t
 	}
 
 	base := normalizeMaster(masterAddr)
-
-	// Best-effort mark read-only. A non-2xx is logged-equivalent but does
-	// not abort; the evacuate call is the authoritative step.
-	if err := postNode(client, base+"/cluster/volumeServer.markReadonly", targetNode); err != nil {
-		// mark read-only may not be supported on all versions; continue.
-		_ = err
-	}
-
-	// Kick off evacuation. If this fails outright, return the error so the
-	// caller can fall back to the `weed shell` path over SSH.
-	if err := postNode(client, base+"/cluster/evacuate", targetNode); err != nil {
-		return fmt.Errorf("drain: evacuate request failed: %w", err)
-	}
 
 	deadline := time.Now().Add(timeout)
 	for {
@@ -85,34 +75,6 @@ func normalizeMaster(masterAddr string) string {
 		return strings.TrimRight(masterAddr, "/")
 	}
 	return "http://" + strings.TrimRight(masterAddr, "/")
-}
-
-func postNode(client HTTPClient, endpoint, node string) error {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return err
-	}
-	q := u.Query()
-	q.Set("node", node)
-	u.RawQuery = q.Encode()
-
-	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
-	if err != nil {
-		return err
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("read drain response: %w", err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("POST %s: status %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-	return nil
 }
 
 // targetVolumeCount fetches /dir/status and returns the number of volumes
@@ -175,8 +137,8 @@ func stripScheme(addr string) string {
 	return addr
 }
 
-// dirStatus matches the pieces of /dir/status that Drain consumes. Extra
-// fields are ignored.
+// dirStatus matches the pieces of /dir/status that WaitForDrain consumes.
+// Extra fields are ignored.
 type dirStatus struct {
 	Topology topology `json:"Topology"`
 }

--- a/pkg/cluster/scale/drain_test.go
+++ b/pkg/cluster/scale/drain_test.go
@@ -9,29 +9,14 @@ import (
 	"time"
 )
 
-func TestDrainHappyPath(t *testing.T) {
+func TestWaitForDrainHappyPath(t *testing.T) {
 	origInterval := pollInterval
 	pollInterval = 10 * time.Millisecond
 	defer func() { pollInterval = origInterval }()
 
-	var (
-		markReadonlyHits int32
-		evacuateHits     int32
-		statusHits       int32
-	)
+	var statusHits int32
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/cluster/volumeServer.markReadonly", func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&markReadonlyHits, 1)
-		if got := r.URL.Query().Get("node"); got != "10.0.0.3:8080" {
-			t.Errorf("unexpected node on markReadonly: %q", got)
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc("/cluster/evacuate", func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&evacuateHits, 1)
-		w.WriteHeader(http.StatusOK)
-	})
 	mux.HandleFunc("/dir/status", func(w http.ResponseWriter, r *http.Request) {
 		hit := atomic.AddInt32(&statusHits, 1)
 		// First two polls show 3 then 1 volume, then drained.
@@ -50,33 +35,20 @@ func TestDrainHappyPath(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	err := Drain(srv.URL, "10.0.0.3:8080", 5*time.Second)
-	if err != nil {
-		t.Fatalf("Drain returned error: %v", err)
-	}
-	if atomic.LoadInt32(&markReadonlyHits) == 0 {
-		t.Errorf("markReadonly was not called")
-	}
-	if atomic.LoadInt32(&evacuateHits) == 0 {
-		t.Errorf("evacuate was not called")
+	if err := WaitForDrain(srv.URL, "10.0.0.3:8080", 5*time.Second); err != nil {
+		t.Fatalf("WaitForDrain returned error: %v", err)
 	}
 	if atomic.LoadInt32(&statusHits) < 3 {
 		t.Errorf("expected /dir/status to be polled at least 3 times, got %d", statusHits)
 	}
 }
 
-func TestDrainTimeout(t *testing.T) {
+func TestWaitForDrainTimeout(t *testing.T) {
 	origInterval := pollInterval
 	pollInterval = 10 * time.Millisecond
 	defer func() { pollInterval = origInterval }()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/cluster/volumeServer.markReadonly", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc("/cluster/evacuate", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
 	mux.HandleFunc("/dir/status", func(w http.ResponseWriter, r *http.Request) {
 		// Target never drains.
 		fmt.Fprint(w, `{"Topology":{"DataCenters":[{"Racks":[{"DataNodes":[{"Url":"10.0.0.3:8080","Volumes":5}]}]}]}}`)
@@ -85,42 +57,17 @@ func TestDrainTimeout(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	err := Drain(srv.URL, "10.0.0.3:8080", 100*time.Millisecond)
-	if err == nil {
+	if err := WaitForDrain(srv.URL, "10.0.0.3:8080", 100*time.Millisecond); err == nil {
 		t.Fatalf("expected timeout error, got nil")
 	}
 }
 
-func TestDrainEvacuateFailure(t *testing.T) {
+func TestWaitForDrainNodeNotPresentCountsAsDrained(t *testing.T) {
 	origInterval := pollInterval
 	pollInterval = 10 * time.Millisecond
 	defer func() { pollInterval = origInterval }()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/cluster/volumeServer.markReadonly", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc("/cluster/evacuate", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "not implemented", http.StatusNotFound)
-	})
-
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-
-	err := Drain(srv.URL, "10.0.0.3:8080", 100*time.Millisecond)
-	if err == nil {
-		t.Fatalf("expected error when evacuate fails, got nil")
-	}
-}
-
-func TestDrainNodeNotPresentCountsAsDrained(t *testing.T) {
-	origInterval := pollInterval
-	pollInterval = 10 * time.Millisecond
-	defer func() { pollInterval = origInterval }()
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/cluster/volumeServer.markReadonly", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
-	mux.HandleFunc("/cluster/evacuate", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
 	mux.HandleFunc("/dir/status", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"Topology":{"DataCenters":[]}}`)
 	})
@@ -128,7 +75,7 @@ func TestDrainNodeNotPresentCountsAsDrained(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	if err := Drain(srv.URL, "10.0.0.9:8080", 500*time.Millisecond); err != nil {
+	if err := WaitForDrain(srv.URL, "10.0.0.9:8080", 500*time.Millisecond); err != nil {
 		t.Fatalf("expected nil error when target absent, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Scale-in drain was a silent no-op: HTTP `/cluster/evacuate` 404s (SeaweedFS master has never served it), and the weed-shell fallback used `volume.evacuate` which isn't a real command — the correct name is `volumeServer.evacuate`, and it also needs `-apply` to actually move volumes. `weed shell` exits 0 for unknown commands, so we happily reported "Drain complete" without moving any data. With `replication: "000"`, this caused ~1-in-3 flaky data loss in the scale-in integration test (confirmed across recent dependabot runs: #57/#58/term bump fail, crypto/toml pass).
- Dropped the fictional HTTP evacuate path, renamed `scale.Drain` → `scale.WaitForDrain` to match its real role (poll `/dir/status` until `Volumes==0`), and made `drainViaWeedShell` the primary drain mechanism.
- `drainViaWeedShell` now issues `volumeServer.evacuate -node=<n> -apply` and uses `Output()` to capture stdout+stderr; it rejects "unknown command" and known failure phrases so a broken drain can no longer masquerade as success.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/cluster/scale/...`
- [ ] Integration Scale-In Tests workflow on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced node drain operations with explicit post-drain verification to ensure completion.
  * Added failure pattern detection for improved error reporting during drain operations.
  * Strengthened cluster communication with TLS-aware health checks for secure connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->