### PR TITLE
fix(systemd): move StartLimit* into [Unit] section

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -183,6 +183,8 @@ Description=Seaweed${COMPONENT_INSTANCE}
 Documentation=https://github.com/seaweedfs/seaweedfs/wiki
 Wants=network-online.target
 After=network-online.target
+StartLimitBurst=3
+StartLimitIntervalSec=10
 
 [Service]
 WorkingDirectory=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR}
@@ -194,8 +196,6 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 Restart=on-failure
 RestartSec=2
-StartLimitBurst=3
-StartLimitIntervalSec=10
 TasksMax=infinity
 
 [Install]

--- a/scripts/install_envoy.sh
+++ b/scripts/install_envoy.sh
@@ -144,6 +144,8 @@ Description=Seaweed${COMPONENT_INSTANCE}
 Documentation=https://github.com/seaweedfs/seaweedfs/wiki
 Wants=network-online.target
 After=network-online.target
+StartLimitBurst=3
+StartLimitIntervalSec=10
 
 [Service]
 WorkingDirectory=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR}
@@ -155,8 +157,6 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 Restart=on-failure
 RestartSec=2
-StartLimitBurst=3
-StartLimitIntervalSec=10
 TasksMax=infinity
 
 [Install]


### PR DESCRIPTION
## Summary

- `StartLimitBurst` and `StartLimitIntervalSec` have been `[Unit]` directives since systemd 230 (2016). Systemd still accepts them under `[Service]` for backward compatibility but logs a deprecation warning on every daemon-reload.
- Move them to `[Unit]` in both the seaweed and envoy unit templates so fresh deploys stop emitting the warning.
- Existing units are only rewritten on redeploy — no migration needed for already-running hosts.

Credit: cherry-picked from the systemd portion of #4 (seaweedfs/seaweed-up#4).

## Test plan
- [ ] `go build ./...` passes
- [ ] Deploy a fresh cluster, `journalctl -u seaweed_master0.service --no-pager | head` contains no "Support for option StartLimit*" deprecation warnings
- [ ] `systemctl show seaweed_master0.service -p StartLimitBurst -p StartLimitIntervalUSec` still returns the configured 3 / 10s