### PR TITLE
feat(deploy): add --envoy-version flag

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -85,6 +85,7 @@ SeaweedFS components across the target hosts using SSH.`,
 	cmd.Flags().IntVarP(&opts.SSHPort, "port", "p", 22, "SSH port")
 	cmd.Flags().StringVarP(&opts.IdentityFile, "identity", "i", "", "SSH identity file")
 	cmd.Flags().StringVar(&opts.Version, "version", "", "SeaweedFS version to deploy")
+	cmd.Flags().StringVar(&opts.EnvoyVersion, "envoy-version", "", "envoy release to pin (skips the GitHub latest-release lookup)")
 	cmd.Flags().StringVarP(&opts.Component, "component", "c", "", "specific component to deploy [master|volume|filer|s3|sftp|admin|envoy|worker]")
 	cmd.Flags().BoolVar(&opts.MountDisks, "mount-disks", true, "auto mount disks on volume servers")
 	cmd.Flags().BoolVar(&opts.HostPrep, "host-prep", false, "run host preparation (ulimits, sysctls, firewall, time sync) before deploy")

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -43,6 +43,7 @@ type ClusterDeployOptions struct {
 	SSHPort      int
 	IdentityFile string
 	Version      string
+	EnvoyVersion string
 	Component    string
 	MountDisks   bool
 	HostPrep     bool
@@ -133,6 +134,7 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 	mgr := manager.NewManager()
 	mgr.SshPort = opts.SSHPort
 	mgr.Version = opts.Version
+	mgr.EnvoyVersion = opts.EnvoyVersion
 	mgr.ComponentToDeploy = opts.Component
 	mgr.PrepareVolumeDisks = opts.MountDisks
 	mgr.HostPrep = opts.HostPrep

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -51,6 +51,7 @@ type Manager struct {
 	ProxyUrl           string // proxy URL for binary download
 	ComponentToDeploy  string
 	Version            string
+	EnvoyVersion       string // envoy release to pin; when empty the latest is looked up from github.com/envoyproxy/envoy
 	SshPort            int
 	PrepareVolumeDisks bool
 	HostPrep           bool

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -318,16 +318,30 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	}
 
 	if m.shouldInstall("envoy") && len(specification.EnvoyServers) > 0 {
-		defaultVersion := m.EnvoyVersion
-		if defaultVersion == "" {
-			latest, err := config.GitHubLatestRelease(context.Background(), "0", "envoyproxy", "envoy")
-			if err != nil {
-				return errors.Wrapf(err, "unable to get latest envoy version, pin one with --envoy-version")
+		// Resolve the fallback used when neither the CLI flag nor a
+		// per-server YAML version is set. Only hit GitHub if at least one
+		// server needs it.
+		var latestFallback string
+		if m.EnvoyVersion == "" {
+			for _, es := range specification.EnvoyServers {
+				if es.Version == "" {
+					latest, err := config.GitHubLatestRelease(context.Background(), "0", "envoyproxy", "envoy")
+					if err != nil {
+						return errors.Wrapf(err, "unable to get latest envoy version, pin one with --envoy-version")
+					}
+					latestFallback = latest.Version
+					break
+				}
 			}
-			defaultVersion = latest.Version
 		}
 		for index, envoySpec := range specification.EnvoyServers {
-			envoySpec.Version = utils.Nvl(envoySpec.Version, defaultVersion)
+			// Precedence: --envoy-version > per-server YAML version > GitHub latest.
+			switch {
+			case m.EnvoyVersion != "":
+				envoySpec.Version = m.EnvoyVersion
+			case envoySpec.Version == "":
+				envoySpec.Version = latestFallback
+			}
 			if err := m.DeployEnvoyServer(specification.FilerServers, envoySpec, index); err != nil {
 				return fmt.Errorf("deploy to envoy server %s:%d :%v", envoySpec.Ip, envoySpec.PortSsh, err)
 			}

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -318,12 +318,16 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	}
 
 	if m.shouldInstall("envoy") && len(specification.EnvoyServers) > 0 {
-		latest, err := config.GitHubLatestRelease(context.Background(), "0", "envoyproxy", "envoy")
-		if err != nil {
-			return errors.Wrapf(err, "unable to get latest version number, define a version manually with the --version flag")
+		defaultVersion := m.EnvoyVersion
+		if defaultVersion == "" {
+			latest, err := config.GitHubLatestRelease(context.Background(), "0", "envoyproxy", "envoy")
+			if err != nil {
+				return errors.Wrapf(err, "unable to get latest envoy version, pin one with --envoy-version")
+			}
+			defaultVersion = latest.Version
 		}
 		for index, envoySpec := range specification.EnvoyServers {
-			envoySpec.Version = utils.Nvl(envoySpec.Version, latest.Version)
+			envoySpec.Version = utils.Nvl(envoySpec.Version, defaultVersion)
 			if err := m.DeployEnvoyServer(specification.FilerServers, envoySpec, index); err != nil {
 				return fmt.Errorf("deploy to envoy server %s:%d :%v", envoySpec.Ip, envoySpec.PortSsh, err)
 			}


### PR DESCRIPTION
## Summary

- Adds `--envoy-version` to `seaweed-up cluster deploy` so operators can pin the envoy release used by the envoy gateway instead of resolving it via GitHubLatestRelease on every deploy.
- Default behavior is unchanged — if the flag is empty the latest release is looked up at deploy time, same as before.
- Plumbs an `EnvoyVersion` field through `Manager` and into `DeployCluster`.

Useful in air-gapped/offline setups and when reproducing a deploy against a specific envoy version without editing the cluster YAML.

Credit: cherry-picked from the envoy-version portion of #4 (seaweedfs/seaweed-up#4).

## Test plan
- [ ] `go build ./...` passes
- [ ] `seaweed-up cluster deploy --help` lists `--envoy-version`
- [ ] Deploy with `--envoy-version 1.25.3` and verify the envoy binary on the host reports `1.25.3` (e.g. `envoy --version`)
- [ ] Deploy without `--envoy-version`, observe the "latest release" lookup runs and deploy succeeds unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--envoy-version` flag to `cluster deploy` command, enabling users to pin and control the Envoy release version globally.
  * Introduced intelligent version resolution with multi-level precedence: explicitly pinned versions take priority, followed by per-server configuration, with GitHub-based latest-version detection as fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->