### PR TITLE
feat(plan): hardware drift detection between plan runs

### DIFF
--- a/cmd/cluster_plan.go
+++ b/cmd/cluster_plan.go
@@ -167,6 +167,14 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 		}
 	}
 
+	// Load the previous facts sidecar (if any) BEFORE the fresh
+	// probe runs. We need both sides to compute drift after Generate
+	// completes; deferring the read until after we'd already
+	// overwritten the file would lose the comparison baseline.
+	// Missing or unreadable is fine — drift detection silently
+	// degrades to "no prior facts" in that case.
+	prevFacts := loadPreviousFacts(opts.OutputFile)
+
 	hosts := inv.ProbeHosts()
 	if len(hosts) == 0 {
 		return fmt.Errorf("no probeable hosts in %s (all entries are 'external'?)", opts.InventoryFile)
@@ -210,6 +218,7 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 	// deploy share one source of truth on disk eligibility (including
 	// inventory excludes and ephemeral filtering).
 	allowlist := plan.EligibleDisks(inv, factsByTarget)
+	driftReports := plan.DetectDrift(prevFacts, facts)
 	printSkipReport(report)
 
 	var (
@@ -221,8 +230,9 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 		// Append-merge into the existing file. Merge() guarantees
 		// byte-stable output for unchanged inventory; new hosts are
 		// appended at each section's tail and orphans surface in
-		// mergeReport without mutating existing entries. (Drift
-		// detection lands in Phase 4 alongside --refresh-host.)
+		// mergeReport without mutating existing entries. Hardware
+		// drift surfaces independently via plan.DetectDrift earlier
+		// in this function.
 		var readErr error
 		existing, readErr = os.ReadFile(opts.OutputFile)
 		if readErr != nil {
@@ -275,6 +285,7 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 			factsFile, len(facts),
 			deployDisksFile, len(allowlist), countAllowlistDisks(allowlist))
 		printMergeReport(mergeReport)
+		printDriftReport(driftReports)
 		return nil
 	}
 
@@ -336,6 +347,7 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 		factsFile, len(facts),
 		deployDisksFile, len(allowlist), countAllowlistDisks(allowlist))
 	printMergeReport(mergeReport) // no-op when nil (greenfield path)
+	printDriftReport(driftReports)
 	return nil
 }
 
@@ -344,9 +356,8 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 // produced by this plan run — removed from inventory, probe failed,
 // or role was dropped because no eligible disks were found). All go
 // to stderr to keep stdout reserved for --json mode and because
-// they're advisory. Drift detection (warn when a previously-emitted
-// entry's facts changed) is deferred to Phase 4 alongside
-// `--refresh-host`.
+// they're advisory. Hardware drift between successive plan runs is
+// surfaced separately by printDriftReport.
 func printMergeReport(r *plan.MergeReport) {
 	if r == nil {
 		return
@@ -373,6 +384,52 @@ func printMergeReport(r *plan.MergeReport) {
 	for _, u := range r.Unparseable {
 		fmt.Fprintf(os.Stderr, "  WARN: unparseable existing entry — fresh inventory hosts won't dedupe against it: %s\n", u)
 	}
+}
+
+// printDriftReport surfaces per-host hardware drift between the
+// previous plan run's facts.json and the fresh probe. Each entry
+// becomes a stderr WARN line so operators see hosts whose disk set
+// has shifted since the last run — typically a drive added or
+// pulled without anyone re-running plan in between. Empty input is
+// the common case (no prior facts, or no observed drift) and
+// silently produces no output.
+func printDriftReport(reports []plan.DriftReport) {
+	for _, r := range reports {
+		var parts []string
+		if len(r.Added) > 0 {
+			parts = append(parts, "added "+strings.Join(r.Added, ","))
+		}
+		if len(r.Removed) > 0 {
+			parts = append(parts, "removed "+strings.Join(r.Removed, ","))
+		}
+		fmt.Fprintf(os.Stderr, "  WARN: drift on %s (since previous facts.json): %s\n",
+			r.Host, strings.Join(parts, "; "))
+	}
+}
+
+// loadPreviousFacts reads the cluster.facts.json sidecar that the
+// previous plan run wrote next to outputFile. Returns nil for any
+// failure path — missing file (greenfield), unreadable file, or
+// unparseable JSON. Drift detection is a soft signal; we never want
+// a corrupted sidecar to fail the whole plan run.
+//
+// outputFile may be empty (the --json branch never reaches this
+// helper, so the empty-path case is unreachable in practice but
+// handled defensively).
+func loadPreviousFacts(outputFile string) []probe.HostFacts {
+	if outputFile == "" {
+		return nil
+	}
+	path := factsFilePath(outputFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var prev []probe.HostFacts
+	if err := json.Unmarshal(data, &prev); err != nil {
+		return nil
+	}
+	return prev
 }
 
 func countAllowlistDisks(a plan.DeployDiskAllowlist) int {

--- a/cmd/cluster_plan_test.go
+++ b/cmd/cluster_plan_test.go
@@ -100,6 +100,48 @@ func TestLoadPlannedDeployDisks_handWritten_noMarkerNoSidecar_returnsNilNil(t *t
 	}
 }
 
+// TestLoadPreviousFacts covers the soft-fail loader: a missing,
+// unreadable, or malformed cluster.facts.json must return nil rather
+// than failing the plan run. Drift detection is a soft advisory
+// signal; a corrupt sidecar shouldn't block legitimate work.
+func TestLoadPreviousFacts(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "cluster.yaml")
+	factsPath := factsFilePath(specPath)
+
+	// 1. Missing sidecar → nil.
+	if got := loadPreviousFacts(specPath); got != nil {
+		t.Errorf("missing sidecar should return nil, got %+v", got)
+	}
+
+	// 2. Malformed JSON → nil (soft fail, no error surface).
+	if err := os.WriteFile(factsPath, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadPreviousFacts(specPath); got != nil {
+		t.Errorf("malformed sidecar should return nil, got %+v", got)
+	}
+
+	// 3. Valid JSON → decoded into HostFacts.
+	body := `[{"ip":"10.0.0.21","ssh_port":22,"disks":[{"path":"/dev/sdb","size_bytes":0}]}]`
+	if err := os.WriteFile(factsPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := loadPreviousFacts(specPath)
+	if len(got) != 1 {
+		t.Fatalf("valid sidecar: got %d facts, want 1", len(got))
+	}
+	if got[0].IP != "10.0.0.21" || len(got[0].Disks) != 1 || got[0].Disks[0].Path != "/dev/sdb" {
+		t.Errorf("decoded facts mismatch: %+v", got[0])
+	}
+
+	// 4. Empty outputFile → nil (defensive; the --json branch never
+	// reaches this helper, but the contract is "nil when nothing to load").
+	if got := loadPreviousFacts(""); got != nil {
+		t.Errorf("empty path should return nil, got %+v", got)
+	}
+}
+
 // TestRunClusterPlan_dryRunRequiresOutput pins down the early-exit
 // validation: --dry-run renders a diff against -o, so without -o
 // there's no diff target to render. The check fires before any SSH

--- a/docs/design/inventory-and-plan.md
+++ b/docs/design/inventory-and-plan.md
@@ -206,15 +206,16 @@ planner observed.
 When `-o cluster.yaml` is set, the same `HostFacts` slice is also
 written as a sidecar JSON file alongside the synthesized YAML
 (`cluster.yaml` → `cluster.facts.json`). The sidecar gives operators
-a record of what the probe saw without re-running it, and is the
-intended audit input for Phase 4 drift detection (compare the
-previously-recorded facts against a fresh probe to surface hosts
-whose disks/NICs/CPU shape have changed since plan last ran).
-Phase 3 append-merge does not consult the sidecar — it works
-entirely off the parsed YAML — but it does refresh it on every
-run so the next plan/diff has current facts to compare against.
-Sidecar permissions are `0600` since facts include hostnames, NIC
-addresses, and disk model strings.
+a record of what the probe saw without re-running it, and feeds
+Phase 4 drift detection: each plan run loads the previous sidecar
+*before* the fresh probe writes its replacement, then `plan.DetectDrift`
+compares per-host disk paths and surfaces a `WARN: drift on <host>` line
+when the set has changed (see `pkg/cluster/plan/drift.go`). Phase 3
+append-merge does not consult the sidecar — it works entirely off the
+parsed YAML — but it does refresh it on every run so the next drift
+comparison has current facts to compare against. Sidecar permissions
+are `0600` since facts include hostnames, NIC addresses, and disk
+model strings.
 
 `cluster plan -o` also writes an explicit allowlist sidecar at
 `cluster.deploy-disks.json` carrying the *result* of plan's
@@ -639,11 +640,18 @@ pkg/disks/
      `pkg/cluster/plan/diff.go`. Sidecars are summarized but not
      touched. Pairs naturally with append-merge: operators preview
      before letting plan mutate the file.
+   - **Drift detection** *(done)* — load the previous
+     `cluster.facts.json` before the fresh probe writes its
+     replacement; for each host present on both sides, compare disk
+     paths and surface a `WARN: drift on <host>: added /…; removed
+     /…` line so operators see hardware that's shifted since the
+     last plan run. Currently disk-path-only on purpose: size,
+     model, NIC, and CPU signals are too noisy on cloud hosts
+     (resizes, NIC reattach) to be worth flagging today; expand one
+     dimension at a time if real use surfaces a need. Implementation
+     in `pkg/cluster/plan/drift.go`.
    - `--refresh-host=<ip>` — re-emit a single host's entry from
      fresh facts without mutating the rest of the file.
-   - Drift detection — compare the previously-recorded
-     `cluster.facts.json` against a fresh probe and surface hosts
-     whose hardware shape has changed since plan last ran.
    - Inventory tag references (`tag: postgres-metadata` → DSN
      rewrite).
 

--- a/pkg/cluster/plan/drift.go
+++ b/pkg/cluster/plan/drift.go
@@ -1,0 +1,105 @@
+package plan
+
+import (
+	"sort"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/probe"
+)
+
+// DriftReport summarizes per-host hardware changes between a previous
+// plan run's recorded facts and the current probe. The cmd layer
+// surfaces these as `WARN: drift` lines so operators see hosts whose
+// hardware shape has shifted since the last plan — typically a disk
+// added or removed without anyone re-running plan in between.
+//
+// Empty (Added + Removed both empty) means "no observed drift on
+// this host"; DetectDrift omits such reports entirely.
+type DriftReport struct {
+	// Host is the SSH target (ip:port) the drift was observed on.
+	// Matches the same key inventory.ProbeHosts and the rest of plan
+	// use, so log lines line up across messages.
+	Host string
+	// Added lists disk paths the current probe sees but the previous
+	// facts.json didn't (operator added a drive between plan runs).
+	Added []string
+	// Removed lists disk paths the previous facts.json had but the
+	// current probe doesn't see (operator pulled a drive, the kernel
+	// stopped enumerating it, or it failed entirely).
+	Removed []string
+}
+
+// IsEmpty reports whether the report contains any observed change.
+func (d DriftReport) IsEmpty() bool {
+	return len(d.Added) == 0 && len(d.Removed) == 0
+}
+
+// DetectDrift compares prev (loaded from cluster.facts.json) against
+// fresh (the current probe's HostFacts slice) and returns one
+// DriftReport per host whose disk path set has changed.
+//
+// Hosts present in fresh but not in prev are skipped — they're new
+// inventory additions, not drift. Hosts present in prev but not in
+// fresh are skipped too: the orphan signal is the cluster.yaml
+// MergeReport.Orphaned warning, not drift (drift would imply the
+// host is still here but with different hardware).
+//
+// Currently the comparison covers disk path set only. Size changes,
+// model strings, NIC counts, and CPU/memory shifts are deliberately
+// out of scope — they're either too noisy on cloud hosts (NICs
+// detach/reattach across reboots; disks get resized in place) or
+// don't move the needle on a deploy decision. Future expansion can
+// add more dimensions one field at a time as use cases emerge.
+func DetectDrift(prev, fresh []probe.HostFacts) []DriftReport {
+	if len(prev) == 0 || len(fresh) == 0 {
+		return nil
+	}
+	prevByTarget := make(map[string]probe.HostFacts, len(prev))
+	for _, p := range prev {
+		prevByTarget[SSHTargetKey(p.IP, p.SSHPort)] = p
+	}
+	var out []DriftReport
+	for _, f := range fresh {
+		key := SSHTargetKey(f.IP, f.SSHPort)
+		p, ok := prevByTarget[key]
+		if !ok {
+			continue
+		}
+		if r := compareDiskPaths(key, p, f); !r.IsEmpty() {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Host < out[j].Host })
+	return out
+}
+
+// compareDiskPaths builds a DriftReport from the symmetric difference
+// of prev.Disks vs fresh.Disks (keyed on Path). Empty paths are
+// skipped so a malformed probe entry doesn't manifest as drift.
+func compareDiskPaths(host string, prev, fresh probe.HostFacts) DriftReport {
+	prevPaths := pathSet(prev.Disks)
+	freshPaths := pathSet(fresh.Disks)
+	report := DriftReport{Host: host}
+	for p := range freshPaths {
+		if _, ok := prevPaths[p]; !ok {
+			report.Added = append(report.Added, p)
+		}
+	}
+	for p := range prevPaths {
+		if _, ok := freshPaths[p]; !ok {
+			report.Removed = append(report.Removed, p)
+		}
+	}
+	sort.Strings(report.Added)
+	sort.Strings(report.Removed)
+	return report
+}
+
+func pathSet(disks []probe.DiskFact) map[string]struct{} {
+	out := make(map[string]struct{}, len(disks))
+	for _, d := range disks {
+		if d.Path != "" {
+			out[d.Path] = struct{}{}
+		}
+	}
+	return out
+}

--- a/pkg/cluster/plan/drift_test.go
+++ b/pkg/cluster/plan/drift_test.go
@@ -1,0 +1,145 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/probe"
+)
+
+func host(ip string, paths ...string) probe.HostFacts {
+	hf := probe.HostFacts{IP: ip, SSHPort: 22}
+	for _, p := range paths {
+		hf.Disks = append(hf.Disks, probe.DiskFact{Path: p})
+	}
+	return hf
+}
+
+func TestDetectDrift_noPrev(t *testing.T) {
+	// First plan run: nothing to compare against. DetectDrift returns
+	// no reports rather than treating every disk as "added drift".
+	if got := DetectDrift(nil, []probe.HostFacts{host("10.0.0.21", "/dev/sdb")}); got != nil {
+		t.Errorf("nil prev should return nil, got %+v", got)
+	}
+}
+
+func TestDetectDrift_noFresh(t *testing.T) {
+	// Inverse: probe somehow returned no facts. Don't synthesize
+	// "everything removed" warnings — the missing probe is the bigger
+	// signal and the cmd layer surfaces that separately.
+	if got := DetectDrift([]probe.HostFacts{host("10.0.0.21", "/dev/sdb")}, nil); got != nil {
+		t.Errorf("nil fresh should return nil, got %+v", got)
+	}
+}
+
+func TestDetectDrift_noChange(t *testing.T) {
+	prev := []probe.HostFacts{host("10.0.0.21", "/dev/sdb", "/dev/sdc")}
+	fresh := []probe.HostFacts{host("10.0.0.21", "/dev/sdb", "/dev/sdc")}
+	if got := DetectDrift(prev, fresh); got != nil {
+		t.Errorf("identical disk sets should produce no drift, got %+v", got)
+	}
+}
+
+func TestDetectDrift_diskAdded(t *testing.T) {
+	prev := []probe.HostFacts{host("10.0.0.21", "/dev/sdb")}
+	fresh := []probe.HostFacts{host("10.0.0.21", "/dev/sdb", "/dev/sdc")}
+	got := DetectDrift(prev, fresh)
+	if len(got) != 1 {
+		t.Fatalf("expected one drift report, got %+v", got)
+	}
+	if got[0].Host != "10.0.0.21:22" {
+		t.Errorf("Host = %q, want 10.0.0.21:22", got[0].Host)
+	}
+	if len(got[0].Added) != 1 || got[0].Added[0] != "/dev/sdc" {
+		t.Errorf("Added = %v, want [/dev/sdc]", got[0].Added)
+	}
+	if len(got[0].Removed) != 0 {
+		t.Errorf("Removed = %v, want empty", got[0].Removed)
+	}
+}
+
+func TestDetectDrift_diskRemoved(t *testing.T) {
+	prev := []probe.HostFacts{host("10.0.0.21", "/dev/sdb", "/dev/sdc")}
+	fresh := []probe.HostFacts{host("10.0.0.21", "/dev/sdb")}
+	got := DetectDrift(prev, fresh)
+	if len(got) != 1 {
+		t.Fatalf("expected one drift report, got %+v", got)
+	}
+	if len(got[0].Removed) != 1 || got[0].Removed[0] != "/dev/sdc" {
+		t.Errorf("Removed = %v, want [/dev/sdc]", got[0].Removed)
+	}
+}
+
+func TestDetectDrift_replacedDisk(t *testing.T) {
+	// Operator pulled /dev/sdc and added /dev/sdd. Both ends should
+	// surface so the operator can confirm the swap was intentional.
+	prev := []probe.HostFacts{host("10.0.0.21", "/dev/sdb", "/dev/sdc")}
+	fresh := []probe.HostFacts{host("10.0.0.21", "/dev/sdb", "/dev/sdd")}
+	got := DetectDrift(prev, fresh)
+	if len(got) != 1 {
+		t.Fatalf("expected one drift report, got %+v", got)
+	}
+	if len(got[0].Added) != 1 || got[0].Added[0] != "/dev/sdd" {
+		t.Errorf("Added = %v, want [/dev/sdd]", got[0].Added)
+	}
+	if len(got[0].Removed) != 1 || got[0].Removed[0] != "/dev/sdc" {
+		t.Errorf("Removed = %v, want [/dev/sdc]", got[0].Removed)
+	}
+}
+
+func TestDetectDrift_newHostSkipped(t *testing.T) {
+	// A host present in fresh but not prev is a new inventory addition,
+	// not drift. The append-merge path will surface it; we shouldn't
+	// also fire a drift warning on it.
+	prev := []probe.HostFacts{host("10.0.0.21", "/dev/sdb")}
+	fresh := []probe.HostFacts{
+		host("10.0.0.21", "/dev/sdb"),
+		host("10.0.0.22", "/dev/sdb", "/dev/sdc"),
+	}
+	if got := DetectDrift(prev, fresh); got != nil {
+		t.Errorf("new host (no prev entry) should not surface as drift, got %+v", got)
+	}
+}
+
+func TestDetectDrift_orphanHostSkipped(t *testing.T) {
+	// A host present in prev but not in fresh is an orphan signal,
+	// surfaced by MergeReport.Orphaned. DetectDrift stays out of that
+	// lane: drift means "still here, different hardware", not "gone".
+	prev := []probe.HostFacts{
+		host("10.0.0.21", "/dev/sdb"),
+		host("10.0.0.22", "/dev/sdb"),
+	}
+	fresh := []probe.HostFacts{host("10.0.0.21", "/dev/sdb")}
+	if got := DetectDrift(prev, fresh); got != nil {
+		t.Errorf("orphan host should not surface as drift, got %+v", got)
+	}
+}
+
+func TestDetectDrift_multipleHostsSorted(t *testing.T) {
+	// Output must be sorted by host so log lines / golden tests stay
+	// stable across map iteration order.
+	prev := []probe.HostFacts{
+		host("10.0.0.22", "/dev/sdb"),
+		host("10.0.0.21", "/dev/sdb"),
+	}
+	fresh := []probe.HostFacts{
+		host("10.0.0.22", "/dev/sdb", "/dev/sdc"),
+		host("10.0.0.21", "/dev/sdb", "/dev/sdc"),
+	}
+	got := DetectDrift(prev, fresh)
+	if len(got) != 2 {
+		t.Fatalf("expected two drift reports, got %+v", got)
+	}
+	if got[0].Host != "10.0.0.21:22" || got[1].Host != "10.0.0.22:22" {
+		t.Errorf("hosts not sorted: got %s then %s", got[0].Host, got[1].Host)
+	}
+}
+
+func TestDetectDrift_emptyPathsSkipped(t *testing.T) {
+	// A probe entry with an empty Path (malformed lsblk row, very rare)
+	// shouldn't manifest as a phantom drift entry.
+	prev := []probe.HostFacts{{IP: "10.0.0.21", SSHPort: 22, Disks: []probe.DiskFact{{Path: "/dev/sdb"}, {Path: ""}}}}
+	fresh := []probe.HostFacts{{IP: "10.0.0.21", SSHPort: 22, Disks: []probe.DiskFact{{Path: "/dev/sdb"}}}}
+	if got := DetectDrift(prev, fresh); got != nil {
+		t.Errorf("empty path in prev should not surface as drift, got %+v", got)
+	}
+}

--- a/test/integration/harness/cluster_plan_test.go
+++ b/test/integration/harness/cluster_plan_test.go
@@ -131,6 +131,77 @@ func TestClusterPlanGreenfield(t *testing.T) {
 	}
 }
 
+// TestClusterPlanDriftWarning exercises the drift-detection path:
+// run plan to write the initial facts.json, then mutate the recorded
+// facts file by hand to simulate a host whose disk set has shifted
+// since the last run, and re-run plan. The drift warning must
+// surface on stderr; the on-disk cluster.yaml stays mid-merge.
+//
+// Mutating the sidecar instead of actually attaching/detaching disks
+// keeps the test independent of container disk topology.
+func TestClusterPlanDriftWarning(t *testing.T) {
+	h := New(t, 2)
+	hosts := h.Hosts()
+	invPath := filepath.Join(h.TempDir(), "inventory.yaml")
+	if err := writeInventory(invPath, hosts, h.SSHKey()); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+	outPath := filepath.Join(h.TempDir(), "cluster.yaml")
+	h.BuildBinary(t)
+
+	// 1. Initial plan run: writes facts.json from scratch, no prior to
+	//    compare against, so no drift WARN is expected.
+	out, err := runPlan(h, invPath, outPath)
+	if err != nil {
+		t.Fatalf("initial plan failed: %v\noutput:\n%s", err, out)
+	}
+	if strings.Contains(out, "WARN: drift") {
+		t.Errorf("first plan run should produce no drift warning; got:\n%s", out)
+	}
+
+	// 2. Inject a fake "previous" disk path into facts.json so the
+	//    next run sees it as removed-since-last-run drift.
+	factsPath := strings.TrimSuffix(outPath, ".yaml") + ".facts.json"
+	factsRaw, err := os.ReadFile(factsPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", factsPath, err)
+	}
+	var prev []map[string]any
+	if err := json.Unmarshal(factsRaw, &prev); err != nil {
+		t.Fatalf("decode facts.json: %v", err)
+	}
+	if len(prev) == 0 {
+		t.Fatalf("facts.json carried no host entries: %s", factsRaw)
+	}
+	// Append a phantom disk path to the first host. The next probe
+	// won't see it (the harness containers don't expose extra
+	// devices), so DetectDrift will flag it as Removed.
+	prev[0]["disks"] = []map[string]any{
+		{"path": "/dev/zzphantom", "size_bytes": 0},
+	}
+	mutated, err := json.MarshalIndent(prev, "", "  ")
+	if err != nil {
+		t.Fatalf("re-encode facts.json: %v", err)
+	}
+	if err := os.WriteFile(factsPath, append(mutated, '\n'), 0o600); err != nil {
+		t.Fatalf("write %s: %v", factsPath, err)
+	}
+
+	// 3. Re-run plan. The drift detector reads the mutated facts.json
+	//    BEFORE overwriting it, compares against the fresh probe, and
+	//    surfaces "WARN: drift on <host>: removed /dev/zzphantom".
+	out, err = runPlan(h, invPath, outPath)
+	if err != nil {
+		t.Fatalf("second plan failed: %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "WARN: drift") {
+		t.Errorf("expected drift warning after sidecar mutation; got:\n%s", out)
+	}
+	if !strings.Contains(out, "/dev/zzphantom") {
+		t.Errorf("drift warning should name the phantom path; got:\n%s", out)
+	}
+}
+
 // TestClusterPlanDryRun exercises the --dry-run preview path against
 // real SSH-reachable harness containers. The contract:
 //   - Greenfield --dry-run writes nothing and prints the proposed


### PR DESCRIPTION
## Summary

Phase 4's second piece: surface hosts whose hardware shape has shifted since the previous ` + "`cluster plan -o`" + ` run. Plan now loads the previous ` + "`cluster.facts.json`" + ` BEFORE the fresh probe writes its replacement, then ` + "`plan.DetectDrift`" + ` compares per-host disk paths and emits a ` + "`WARN: drift on <host>: added /…; removed /…`" + ` line on stderr.

Pairs with the existing pieces:
- ` + "`--dry-run`" + ` (PR #70) — see what changed before letting plan touch the file
- ` + "`append-merge`" + ` (PR #69) — re-running plan after a hardware change announces the change rather than silently re-emitting the same YAML

## Implementation

- ` + "`pkg/cluster/plan/drift.go`" + ` — ` + "`DetectDrift(prev, fresh)`" + ` returning ` + "`[]DriftReport`" + ` per host with ` + "`Added`" + ` / ` + "`Removed`" + ` disk-path lists. Hosts in ` + "`fresh`" + ` but not ` + "`prev`" + ` (new inventory adds) and the inverse (orphans) are skipped — those signals already surface elsewhere.
- ` + "`cmd/cluster_plan.go`" + ` — ` + "`loadPreviousFacts`" + ` (soft-fail loader: missing/unreadable/malformed → nil) and ` + "`printDriftReport`" + ` (stderr WARN renderer); wired into both ` + "`--dry-run`" + ` and the write path.

### Scope is intentionally narrow

Disk path set only. Size shifts and model-string churn are out of scope on purpose — they're noisy on cloud hosts (in-place resizes, vendor revs). NIC/CPU shifts are out of scope for the same reason. Expand one dimension at a time if real use surfaces a need.

## Test plan

- [x] ` + "`TestDetectDrift_*`" + ` (10 cases) — add, remove, replace, no-prev, no-fresh, no-change, new-host, orphan-host, sorted output, empty paths
- [x] ` + "`TestLoadPreviousFacts`" + ` — missing / malformed / valid sidecar
- [x] ` + "`TestClusterPlanDriftWarning`" + ` (integration harness) — runs plan twice with the recorded ` + "`facts.json`" + ` mutated between runs to simulate a removed disk
- [x] ` + "`go build -tags=integration ./...`" + `, ` + "`go vet -tags=integration ./...`" + `, ` + "`go test ./...`" + ` all green

## Out of scope (rest of Phase 4)

- ` + "`--refresh-host=<ip>`" + ` — re-emit one host's entry from fresh facts
- Inventory ` + "`tag:`" + ` references → DSN rewrite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cluster plan now automatically detects and reports disk configuration drift between consecutive plan runs by comparing the current cluster state against previously saved facts. When disk additions or removals are detected, warning messages display the changes per affected host to help identify unexpected infrastructure modifications.

* **Documentation**
  * Updated design documentation to reflect the drift-detection workflow and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->