### PR TITLE
feat(plan): --refresh-host targets one host's entries from fresh facts

### DIFF
--- a/cmd/cluster_plan.go
+++ b/cmd/cluster_plan.go
@@ -49,7 +49,15 @@ type ClusterPlanOptions struct {
 	// Implies -o (no diff target makes no sense without it). Sidecars
 	// are reported as "would write" lines but not actually written.
 	DryRun      bool
-	Concurrency int
+	// RefreshHosts is the list of host IPs whose existing entries
+	// should be replaced from fresh facts during append-merge,
+	// instead of being preserved byte-for-byte. Repeatable; pairs
+	// with the drift-detection WARN to give operators a one-shot
+	// fix for hosts whose hardware shape has shifted. Implies -o
+	// pointing at an existing file (greenfield runs have nothing to
+	// refresh).
+	RefreshHosts []string
+	Concurrency  int
 
 	ClusterName       string
 	VolumeSizeLimitMB int
@@ -78,7 +86,10 @@ place: new inventory hosts are appended at each section's tail and
 existing entries (along with operator hand-edits and comments) are
 preserved byte-for-byte. Pass --overwrite to regenerate from scratch
 instead. Pass --dry-run to print a unified diff of what -o would
-change without writing anything. See docs/design/inventory-and-plan.md.
+change without writing anything. Pass --refresh-host=<ip> (repeatable)
+to re-emit just that host's entries from fresh facts — pairs with
+the drift-detection WARN that the previous run's facts.json comparison
+emits. See docs/design/inventory-and-plan.md.
 
 Purely read-only on the target hosts.`,
 		Example: `  # Probe-only (JSON to stdout)
@@ -90,6 +101,10 @@ Purely read-only on the target hosts.`,
 
   # Preview what plan would change without writing anything
   seaweed-up cluster plan -i inventory.yaml -o cluster.yaml --dry-run
+
+  # Re-emit one host's entries from fresh facts (drift remediation)
+  seaweed-up cluster plan -i inventory.yaml -o cluster.yaml \
+      --refresh-host 10.0.0.21
 
   # Force regeneration, discarding any existing cluster.yaml
   seaweed-up cluster plan -i inventory.yaml -o cluster.yaml --overwrite`,
@@ -103,6 +118,7 @@ Purely read-only on the target hosts.`,
 	cmd.Flags().BoolVar(&opts.Overwrite, "overwrite", false, "regenerate -o from scratch instead of append-merging into the existing file")
 	cmd.Flags().BoolVar(&opts.JSONOutput, "json", false, "write probe facts as JSON to stdout (default when -o is absent)")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "print a unified diff of what -o would change instead of writing it (requires -o)")
+	cmd.Flags().StringSliceVar(&opts.RefreshHosts, "refresh-host", nil, "re-emit the named host's existing entries from fresh facts (repeatable; requires -o pointing at an existing cluster.yaml)")
 	cmd.Flags().IntVar(&opts.Concurrency, "concurrency", 10, "max concurrent probes")
 
 	cmd.Flags().StringVar(&opts.ClusterName, "cluster-name", "", "cluster_name to stamp on the generated cluster.yaml")
@@ -137,6 +153,12 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 		// a clear error rather than silently turning into a probe-only
 		// run that ignores the flag.
 		return fmt.Errorf("--dry-run requires -o; pass the path you'd like to preview against")
+	}
+	if len(opts.RefreshHosts) > 0 && opts.OutputFile == "" {
+		// --refresh-host targets entries in -o. Without -o there's no
+		// existing file to refresh; surface the misuse instead of
+		// silently dropping the flag.
+		return fmt.Errorf("--refresh-host requires -o pointing at an existing cluster.yaml")
 	}
 
 	// Three modes for `-o cluster.yaml`:
@@ -221,6 +243,16 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 	driftReports := plan.DetectDrift(prevFacts, facts)
 	printSkipReport(report)
 
+	// --refresh-host targets entries in an existing -o. If the
+	// operator passed it but we're not in merge mode (file absent
+	// or --overwrite set), the flag is a no-op for this run; warn
+	// loudly so it doesn't look like a successful refresh.
+	if len(opts.RefreshHosts) > 0 && !mergeMode {
+		fmt.Fprintf(os.Stderr,
+			"  WARN: --refresh-host ignored because -o doesn't exist (greenfield) or --overwrite was passed; "+
+				"refresh applies only to append-merge runs against an existing cluster.yaml\n")
+	}
+
 	var (
 		body        []byte
 		mergeReport *plan.MergeReport
@@ -239,7 +271,8 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 			return fmt.Errorf("read existing %s: %w", opts.OutputFile, readErr)
 		}
 		body, mergeReport, err = plan.Merge(existing, spec, plan.MergeOptions{
-			Marshal: plan.MarshalOptions{InventoryPath: opts.InventoryFile},
+			Marshal:      plan.MarshalOptions{InventoryPath: opts.InventoryFile},
+			RefreshHosts: refreshHostSet(opts.RefreshHosts),
 		})
 		if err != nil {
 			return fmt.Errorf("merge into existing cluster spec: %w", err)
@@ -384,6 +417,33 @@ func printMergeReport(r *plan.MergeReport) {
 	for _, u := range r.Unparseable {
 		fmt.Fprintf(os.Stderr, "  WARN: unparseable existing entry — fresh inventory hosts won't dedupe against it: %s\n", u)
 	}
+	for _, k := range r.Refreshed {
+		fmt.Fprintf(os.Stderr, "  refreshed %s\n", k)
+	}
+	for _, ip := range r.RefreshNotFound {
+		fmt.Fprintf(os.Stderr, "  WARN: --refresh-host %s did not match any existing entry; nothing to refresh\n", ip)
+	}
+}
+
+// refreshHostSet turns the repeatable --refresh-host CLI slice into a
+// set keyed by IP. nil/empty input returns nil so plan.Merge takes the
+// no-refresh fast path.
+func refreshHostSet(ips []string) map[string]struct{} {
+	if len(ips) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(ips))
+	for _, ip := range ips {
+		ip = strings.TrimSpace(ip)
+		if ip == "" {
+			continue
+		}
+		out[ip] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // printDriftReport surfaces per-host hardware drift between the

--- a/cmd/cluster_plan.go
+++ b/cmd/cluster_plan.go
@@ -154,7 +154,14 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 		// run that ignores the flag.
 		return fmt.Errorf("--dry-run requires -o; pass the path you'd like to preview against")
 	}
-	if len(opts.RefreshHosts) > 0 && opts.OutputFile == "" {
+	// Trim once and reuse: validating against the raw slice would
+	// let `--refresh-host=" "` slip past the -o check (refreshHostSet
+	// drops whitespace-only entries and returns nil, so plan.Merge
+	// would silently no-op). Trim first so blanks-only and empty
+	// share the "no refresh requested" semantics, and pass the
+	// resulting set down to the merge call.
+	refreshSet := refreshHostSet(opts.RefreshHosts)
+	if len(refreshSet) > 0 && opts.OutputFile == "" {
 		// --refresh-host targets entries in -o. Without -o there's no
 		// existing file to refresh; surface the misuse instead of
 		// silently dropping the flag.
@@ -247,7 +254,7 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 	// operator passed it but we're not in merge mode (file absent
 	// or --overwrite set), the flag is a no-op for this run; warn
 	// loudly so it doesn't look like a successful refresh.
-	if len(opts.RefreshHosts) > 0 && !mergeMode {
+	if len(refreshSet) > 0 && !mergeMode {
 		fmt.Fprintf(os.Stderr,
 			"  WARN: --refresh-host ignored because -o doesn't exist (greenfield) or --overwrite was passed; "+
 				"refresh applies only to append-merge runs against an existing cluster.yaml\n")
@@ -272,7 +279,7 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 		}
 		body, mergeReport, err = plan.Merge(existing, spec, plan.MergeOptions{
 			Marshal:      plan.MarshalOptions{InventoryPath: opts.InventoryFile},
-			RefreshHosts: refreshHostSet(opts.RefreshHosts),
+			RefreshHosts: refreshSet,
 		})
 		if err != nil {
 			return fmt.Errorf("merge into existing cluster spec: %w", err)

--- a/cmd/cluster_plan_test.go
+++ b/cmd/cluster_plan_test.go
@@ -142,6 +142,54 @@ func TestLoadPreviousFacts(t *testing.T) {
 	}
 }
 
+// TestRunClusterPlan_refreshHostRequiresOutput mirrors the dry-run
+// validator: --refresh-host targets entries in -o, so without -o
+// the flag is meaningless. The check fires before any SSH probe so
+// the test doesn't need network or fake hosts.
+func TestRunClusterPlan_refreshHostRequiresOutput(t *testing.T) {
+	dir := t.TempDir()
+	invPath := filepath.Join(dir, "inv.yaml")
+	if err := os.WriteFile(invPath, []byte("hosts:\n  - ip: 10.0.0.1\n    roles: [master]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	opts := &ClusterPlanOptions{
+		InventoryFile: invPath,
+		RefreshHosts:  []string{"10.0.0.1"},
+	}
+	err := runClusterPlan(nil, opts)
+	if err == nil {
+		t.Fatal("expected refusal when --refresh-host is set without -o")
+	}
+	if !strings.Contains(err.Error(), "--refresh-host requires -o") {
+		t.Errorf("error should explain the missing -o, got: %v", err)
+	}
+}
+
+// TestRefreshHostSet covers the small slice→set converter: blank
+// entries get dropped, an empty input returns nil so plan.Merge
+// takes the no-refresh fast path.
+func TestRefreshHostSet(t *testing.T) {
+	if refreshHostSet(nil) != nil {
+		t.Errorf("nil input should return nil")
+	}
+	if refreshHostSet([]string{}) != nil {
+		t.Errorf("empty input should return nil")
+	}
+	if refreshHostSet([]string{"  ", ""}) != nil {
+		t.Errorf("all-blank input should return nil after trimming")
+	}
+	got := refreshHostSet([]string{"10.0.0.21", "  10.0.0.22  ", ""})
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2: %+v", len(got), got)
+	}
+	if _, ok := got["10.0.0.21"]; !ok {
+		t.Errorf("10.0.0.21 missing from set: %+v", got)
+	}
+	if _, ok := got["10.0.0.22"]; !ok {
+		t.Errorf("trimmed 10.0.0.22 missing from set: %+v", got)
+	}
+}
+
 // TestRunClusterPlan_dryRunRequiresOutput pins down the early-exit
 // validation: --dry-run renders a diff against -o, so without -o
 // there's no diff target to render. The check fires before any SSH

--- a/cmd/cluster_plan_test.go
+++ b/cmd/cluster_plan_test.go
@@ -165,6 +165,34 @@ func TestRunClusterPlan_refreshHostRequiresOutput(t *testing.T) {
 	}
 }
 
+// TestRunClusterPlan_refreshHostBlankOnlyTreatedAsEmpty pins the
+// trim-before-validate fix: passing only whitespace values to
+// --refresh-host used to slip past the require-`-o` check (the
+// validator counted raw flag values, refreshHostSet then trimmed
+// them all to nil, and plan.Merge silently no-op'd). The trimmed
+// set should now share the empty-input semantics — no
+// `--refresh-host requires -o` error fires because there's nothing
+// effectively requested.
+//
+// Routed through a malformed inventory path so the call exits
+// early without reaching the SSH probe (which would crash on a
+// nil cobra cmd in this unit-test scaffolding).
+func TestRunClusterPlan_refreshHostBlankOnlyTreatedAsEmpty(t *testing.T) {
+	opts := &ClusterPlanOptions{
+		InventoryFile: filepath.Join(t.TempDir(), "does-not-exist.yaml"),
+		RefreshHosts:  []string{"  ", ""},
+		// OutputFile left empty — without trimming, the validator
+		// would fire a `--refresh-host requires -o` error here.
+	}
+	err := runClusterPlan(nil, opts)
+	if err == nil {
+		t.Fatal("expected inventory-load error, got nil")
+	}
+	if strings.Contains(err.Error(), "--refresh-host requires -o") {
+		t.Errorf("blank-only --refresh-host should not trigger the require-o error, got: %v", err)
+	}
+}
+
 // TestRefreshHostSet covers the small slice→set converter: blank
 // entries get dropped, an empty input returns nil so plan.Merge
 // takes the no-refresh fast path.

--- a/docs/design/inventory-and-plan.md
+++ b/docs/design/inventory-and-plan.md
@@ -650,8 +650,20 @@ pkg/disks/
      (resizes, NIC reattach) to be worth flagging today; expand one
      dimension at a time if real use surfaces a need. Implementation
      in `pkg/cluster/plan/drift.go`.
-   - `--refresh-host=<ip>` — re-emit a single host's entry from
-     fresh facts without mutating the rest of the file.
+   - **`--refresh-host=<ip>`** *(done)* — re-emit a host's entries
+     from fresh facts during append-merge while leaving every other
+     entry's bytes intact. Repeatable; pairs with the drift WARN
+     above (operator sees `drift on 10.0.0.21: added /dev/sdc`,
+     re-runs `plan --refresh-host 10.0.0.21` to fix that one
+     entry without resorting to `--overwrite`). Refresh is per-IP,
+     so a host that maps to multiple sections (master + filer +
+     volume) gets all of its entries refreshed in one shot.
+     Entry-level head/line/foot comments survive; field-level
+     inline comments inside the mapping (e.g. on `port:`) do not —
+     pairing each fresh field with its old counterpart by key is
+     out of scope for now. Misses (an IP that didn't match any
+     existing entry) surface as a `WARN: --refresh-host …` line.
+     Implementation extends `pkg/cluster/plan/merge.go`.
    - Inventory tag references (`tag: postgres-metadata` → DSN
      rewrite).
 

--- a/pkg/cluster/plan/merge.go
+++ b/pkg/cluster/plan/merge.go
@@ -428,6 +428,14 @@ func ipOfNode(node *yaml.Node) string {
 // (on individual key/value pairs inside the mapping) aren't carried
 // — that would require pairing each fresh field with its
 // corresponding old field, which is out of scope for Phase 4.
+//
+// The same *yaml.Node from freshByKey may end up assigned to
+// multiple positions in seqNode.Content if the existing YAML has
+// hand-edited duplicate `ip:port` entries (rare; would also have
+// surfaced via Unparseable on a previous merge run). Verified
+// behavior: yaml.v3's encoder renders both copies as literal
+// duplicates rather than emitting `&anchor` / `*alias` markers,
+// so no defensive deep-copy is needed here.
 func carryEntryComments(dst, src *yaml.Node) {
 	if dst == nil || src == nil {
 		return

--- a/pkg/cluster/plan/merge.go
+++ b/pkg/cluster/plan/merge.go
@@ -326,18 +326,27 @@ func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOf
 	}
 
 	freshKeys := map[string]struct{}{}
-	freshByKey := make(map[string]*yaml.Node, len(fresh))
+	freshByIP := make(map[string]serverEntry, len(fresh))
 	for _, e := range fresh {
 		freshKeys[e.key] = struct{}{}
-		freshByKey[e.key] = e.node
+		if ip := ipOfNode(e.node); ip != "" {
+			freshByIP[ip] = e
+		}
 	}
 
 	// Refresh pass first so the existing-key index built by the
-	// orphan check still recognizes the (now-replaced) node — the
-	// keyOfNode extractor reads the `ip:` scalar, which the fresh
-	// node carries unchanged. Walking seqNode.Content directly here
-	// (rather than going through recordOrphansAndUnparseable) lets
-	// us mutate Content[i] in place.
+	// orphan check sees the post-refresh state. We key on IP alone
+	// (NOT on the section's full ip:port / ip:role identity): an
+	// operator typing `--refresh-host=10.0.0.21` doesn't know or
+	// care about ports, they just want that host's entry brought in
+	// line with what plan would generate today. Re-emitting the
+	// entry from fresh facts is the contract — including clobbering
+	// a hand-edited port. Without per-IP keying the partial-match
+	// path (existing port 8889, fresh port 8888) would skip refresh,
+	// then leave both rows behind: orphan + appended fresh = two
+	// entries for the same host. By replacing in place keyed on IP,
+	// the post-refresh entry's key matches the fresh one, the orphan
+	// check stays quiet, and the append loop dedupes.
 	if len(refreshHosts) > 0 {
 		for i, item := range seqNode.Content {
 			ip := ipOfNode(item)
@@ -347,24 +356,17 @@ func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOf
 			if _, want := refreshHosts[ip]; !want {
 				continue
 			}
-			key := keyOfNode(item)
-			freshNode, ok := freshByKey[key]
+			e, ok := freshByIP[ip]
 			if !ok {
-				// Refresh requested for a host whose existing entry's
-				// (ip, port) doesn't line up with any fresh entry's
-				// key — typically the operator hand-edited the port,
-				// or the spec moved the host between sections. Record
-				// the partial-match miss explicitly: the IP-level
-				// RefreshNotFound check at the end of Merge fires
-				// only when refreshSeen[ip] was never set in ANY
-				// section, so a clean match on master_servers + port
-				// mismatch on filer_servers would otherwise leave
-				// the operator with no signal that one role was left
-				// stale. Section-qualified Unparseable surfaces it
-				// without inventing a new field.
-				report.Unparseable = append(report.Unparseable,
-					fmt.Sprintf("%s: line %d (refresh-host %s: existing entry's port doesn't match the fresh spec — refresh skipped for this section)",
-						sectionKey, item.Line, ip))
+				// Refresh wanted but the fresh spec has no entry
+				// for this IP in this section. Two real causes:
+				// (a) the host was removed from inventory or its
+				// role for this section was dropped (no eligible
+				// disks etc.) — recordOrphansAndUnparseable below
+				// surfaces the orphan; (b) the inventory key for
+				// this IP changed entirely. Either way, the orphan
+				// signal is the right operator hint; don't add a
+				// per-section Unparseable line.
 				continue
 			}
 			// Carry the entry-level head/line/foot comments from
@@ -374,10 +376,10 @@ func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOf
 			// dropped — preserving those would require a structural
 			// merge of the two mappings, which Phase 4 explicitly
 			// scopes out.
-			carryEntryComments(freshNode, item)
-			seqNode.Content[i] = freshNode
+			carryEntryComments(e.node, item)
+			seqNode.Content[i] = e.node
 			refreshSeen[ip] = struct{}{}
-			report.Refreshed = append(report.Refreshed, fmt.Sprintf("%s: %s", sectionKey, key))
+			report.Refreshed = append(report.Refreshed, fmt.Sprintf("%s: %s", sectionKey, e.key))
 		}
 	}
 

--- a/pkg/cluster/plan/merge.go
+++ b/pkg/cluster/plan/merge.go
@@ -41,6 +41,19 @@ type MergeReport struct {
 	// with the same IP would still get appended, producing a duplicate.
 	// Surface them so the operator can clean up before next merge.
 	Unparseable []string
+	// Refreshed lists `section: ip:port` entries that were
+	// re-emitted from fresh facts because the operator passed
+	// `--refresh-host=<ip>`. The replacement preserves the entry's
+	// surrounding head/line/foot comments but otherwise overwrites
+	// every field — operators who tightened `max:` on an entry get
+	// that edit clobbered for that entry on a refresh, by design.
+	Refreshed []string
+	// RefreshNotFound lists IPs the operator passed via
+	// `--refresh-host` that didn't match any existing entry in the
+	// YAML. The most common cause is a typo or a host that hasn't
+	// been deployed yet; either way the refresh is a no-op for that
+	// entry and we surface the miss so the operator notices.
+	RefreshNotFound []string
 }
 
 // MergeOptions tweak append-merge behavior. Zero value is fine for
@@ -53,6 +66,20 @@ type MergeOptions struct {
 	// indistinguishable from "this is the first plan run", so we fall
 	// back to greenfield generation in that case.)
 	Marshal MarshalOptions
+	// RefreshHosts is the set of host IPs whose existing entries
+	// should be replaced by their freshly-Generated equivalents
+	// instead of being preserved byte-for-byte. Targets the
+	// "drift detected → refresh that one host" workflow without
+	// forcing --overwrite (which discards every hand edit). Empty
+	// or nil disables refresh entirely; entries that don't match an
+	// existing IP land in MergeReport.RefreshNotFound.
+	//
+	// Refresh is per-IP, not per-(ip, port). A host that maps to
+	// multiple sections (master + filer + volume) gets all of its
+	// entries refreshed in one shot — operators almost never want
+	// to refresh just one role's entry while leaving the others
+	// stale, and the inventory keys hosts by IP anyway.
+	RefreshHosts map[string]struct{}
 }
 
 // Merge appends entries from `fresh` into `existing`, preserving every
@@ -131,15 +158,26 @@ func Merge(existing []byte, fresh *spec.Specification, opts MergeOptions) ([]byt
 		{key: "worker_servers", build: func() ([]serverEntry, error) { return workerEntries(fresh.WorkerServers) }, keyOfNode: ipSentinelKeyFn("worker")},
 	}
 
+	// Track which refresh-host IPs landed somewhere so we can surface
+	// the misses (typo, host not yet deployed, etc.) at the end.
+	refreshSeen := make(map[string]struct{}, len(opts.RefreshHosts))
 	for _, p := range plans {
 		entries, err := p.build()
 		if err != nil {
 			return nil, nil, fmt.Errorf("build %s entries: %w", p.key, err)
 		}
-		if err := mergeSection(root, p.key, entries, p.keyOfNode, report); err != nil {
+		if err := mergeSection(root, p.key, entries, p.keyOfNode, opts.RefreshHosts, refreshSeen, report); err != nil {
 			return nil, nil, fmt.Errorf("merge %s: %w", p.key, err)
 		}
 	}
+	// Order the not-found list deterministically so the warning text
+	// is stable across runs (and across map iteration orders).
+	for ip := range opts.RefreshHosts {
+		if _, ok := refreshSeen[ip]; !ok {
+			report.RefreshNotFound = append(report.RefreshNotFound, ip)
+		}
+	}
+	sort.Strings(report.RefreshNotFound)
 
 	// Re-encode. yaml.v3's encoder preserves comments and styles on the
 	// existing nodes; appended nodes use whatever style they were
@@ -242,13 +280,17 @@ type serverEntry struct {
 // any entry whose key isn't already present. Records appends and
 // orphans into report. keyOfNode extracts the dedup key from an
 // existing sequence item (per-section because worker/envoy don't have
-// a single service port).
+// a single service port). When refreshHosts is non-empty, existing
+// entries whose IP appears in the set are replaced in place by the
+// matching fresh entry instead of being preserved byte-for-byte;
+// refreshSeen records each successful replacement so the caller can
+// surface the misses (refresh-host IPs that didn't match anything).
 //
 // Returns an error if the section value exists but isn't a sequence
 // (operator may have hand-edited `master_servers: foo` or
 // `master_servers: {…}`). Silently overwriting that would lose data;
 // instead we ask the operator to clean it up.
-func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOfNode func(*yaml.Node) string, report *MergeReport) error {
+func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOfNode func(*yaml.Node) string, refreshHosts, refreshSeen map[string]struct{}, report *MergeReport) error {
 	// When the inventory carries no entries for this section, there's
 	// nothing to merge — and crucially, nothing to mutate. Look up the
 	// existing node only to compute orphans (so a stale section gets
@@ -284,9 +326,52 @@ func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOf
 	}
 
 	freshKeys := map[string]struct{}{}
+	freshByKey := make(map[string]*yaml.Node, len(fresh))
 	for _, e := range fresh {
 		freshKeys[e.key] = struct{}{}
+		freshByKey[e.key] = e.node
 	}
+
+	// Refresh pass first so the existing-key index built by the
+	// orphan check still recognizes the (now-replaced) node — the
+	// keyOfNode extractor reads the `ip:` scalar, which the fresh
+	// node carries unchanged. Walking seqNode.Content directly here
+	// (rather than going through recordOrphansAndUnparseable) lets
+	// us mutate Content[i] in place.
+	if len(refreshHosts) > 0 {
+		for i, item := range seqNode.Content {
+			ip := ipOfNode(item)
+			if ip == "" {
+				continue
+			}
+			if _, want := refreshHosts[ip]; !want {
+				continue
+			}
+			key := keyOfNode(item)
+			fresh, ok := freshByKey[key]
+			if !ok {
+				// Refresh requested for a host whose existing entry's
+				// (ip, port) doesn't line up with any fresh entry's
+				// key — typically the operator hand-edited the port,
+				// or the spec moved the host between sections. Leave
+				// the entry alone; the IP-level "not found" warning
+				// already covers it elsewhere.
+				continue
+			}
+			// Carry the entry-level head/line/foot comments from
+			// the old node onto the replacement so a `# primary HDD
+			// bank` annotation survives a refresh. Field-level
+			// comments (e.g. an inline note on `port:`) are still
+			// dropped — preserving those would require a structural
+			// merge of the two mappings, which Phase 4 explicitly
+			// scopes out.
+			carryEntryComments(fresh, item)
+			seqNode.Content[i] = fresh
+			refreshSeen[ip] = struct{}{}
+			report.Refreshed = append(report.Refreshed, fmt.Sprintf("%s: %s", sectionKey, key))
+		}
+	}
+
 	existingKeys := recordOrphansAndUnparseable(seqNode, sectionKey, keyOfNode, freshKeys, report)
 
 	// Append fresh entries that aren't already present, reusing the
@@ -302,6 +387,45 @@ func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOf
 	}
 
 	return nil
+}
+
+// ipOfNode pulls the `ip:` scalar out of a sequence-item mapping.
+// Returns "" for any shape we don't recognize (matches the soft
+// behavior of keyOfNode — operators with hand-edited weird shapes
+// don't blow up the merge). Used by the refresh pass to look up
+// entries by IP without committing to the section-specific
+// ip:port / ip:role keying.
+func ipOfNode(node *yaml.Node) string {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return ""
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		k := node.Content[i]
+		v := node.Content[i+1]
+		if k.Kind != yaml.ScalarNode || v.Kind != yaml.ScalarNode {
+			continue
+		}
+		if k.Value == "ip" {
+			return v.Value
+		}
+	}
+	return ""
+}
+
+// carryEntryComments copies the head/line/foot comments from src to
+// dst at the entry (top-level mapping) level. Used by the refresh
+// pass so a fresh entry node inherits the operator's entry-level
+// annotations from the entry it's replacing. Field-level comments
+// (on individual key/value pairs inside the mapping) aren't carried
+// — that would require pairing each fresh field with its
+// corresponding old field, which is out of scope for Phase 4.
+func carryEntryComments(dst, src *yaml.Node) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.HeadComment = src.HeadComment
+	dst.LineComment = src.LineComment
+	dst.FootComment = src.FootComment
 }
 
 // recordOrphansAndUnparseable walks seqNode's children, classifying

--- a/pkg/cluster/plan/merge.go
+++ b/pkg/cluster/plan/merge.go
@@ -348,7 +348,7 @@ func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOf
 				continue
 			}
 			key := keyOfNode(item)
-			fresh, ok := freshByKey[key]
+			freshNode, ok := freshByKey[key]
 			if !ok {
 				// Refresh requested for a host whose existing entry's
 				// (ip, port) doesn't line up with any fresh entry's
@@ -365,8 +365,8 @@ func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOf
 			// dropped — preserving those would require a structural
 			// merge of the two mappings, which Phase 4 explicitly
 			// scopes out.
-			carryEntryComments(fresh, item)
-			seqNode.Content[i] = fresh
+			carryEntryComments(freshNode, item)
+			seqNode.Content[i] = freshNode
 			refreshSeen[ip] = struct{}{}
 			report.Refreshed = append(report.Refreshed, fmt.Sprintf("%s: %s", sectionKey, key))
 		}

--- a/pkg/cluster/plan/merge.go
+++ b/pkg/cluster/plan/merge.go
@@ -353,9 +353,18 @@ func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOf
 				// Refresh requested for a host whose existing entry's
 				// (ip, port) doesn't line up with any fresh entry's
 				// key — typically the operator hand-edited the port,
-				// or the spec moved the host between sections. Leave
-				// the entry alone; the IP-level "not found" warning
-				// already covers it elsewhere.
+				// or the spec moved the host between sections. Record
+				// the partial-match miss explicitly: the IP-level
+				// RefreshNotFound check at the end of Merge fires
+				// only when refreshSeen[ip] was never set in ANY
+				// section, so a clean match on master_servers + port
+				// mismatch on filer_servers would otherwise leave
+				// the operator with no signal that one role was left
+				// stale. Section-qualified Unparseable surfaces it
+				// without inventing a new field.
+				report.Unparseable = append(report.Unparseable,
+					fmt.Sprintf("%s: line %d (refresh-host %s: existing entry's port doesn't match the fresh spec — refresh skipped for this section)",
+						sectionKey, item.Line, ip))
 				continue
 			}
 			// Carry the entry-level head/line/foot comments from

--- a/pkg/cluster/plan/merge.go
+++ b/pkg/cluster/plan/merge.go
@@ -369,6 +369,16 @@ func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOf
 				// per-section Unparseable line.
 				continue
 			}
+			// Clone before mutating: when the existing YAML has
+			// hand-edited duplicate entries for the same IP in this
+			// section (rare), every iteration would otherwise reuse
+			// the same *yaml.Node pointer from freshByIP, and
+			// carryEntryComments writes the head/line/foot comments
+			// in place — the second iteration would clobber the
+			// first one's preserved comments. Cloning gives each
+			// refreshed slot its own node so each retains the
+			// comments from the entry it's replacing.
+			//
 			// Carry the entry-level head/line/foot comments from
 			// the old node onto the replacement so a `# primary HDD
 			// bank` annotation survives a refresh. Field-level
@@ -376,8 +386,9 @@ func mergeSection(root *yaml.Node, sectionKey string, fresh []serverEntry, keyOf
 			// dropped — preserving those would require a structural
 			// merge of the two mappings, which Phase 4 explicitly
 			// scopes out.
-			carryEntryComments(e.node, item)
-			seqNode.Content[i] = e.node
+			replacement := cloneYAMLNode(e.node)
+			carryEntryComments(replacement, item)
+			seqNode.Content[i] = replacement
 			refreshSeen[ip] = struct{}{}
 			report.Refreshed = append(report.Refreshed, fmt.Sprintf("%s: %s", sectionKey, e.key))
 		}
@@ -421,6 +432,30 @@ func ipOfNode(node *yaml.Node) string {
 		}
 	}
 	return ""
+}
+
+// cloneYAMLNode returns a deep copy of n: every field is copied,
+// and the Content slice is recursively cloned so the caller can
+// mutate either tree without affecting the other. Used by the
+// refresh pass when the same fresh entry would otherwise be
+// assigned to multiple sequence positions (hand-edited duplicate
+// existing entries) — without cloning, a per-position comment
+// carry would clobber siblings sharing the pointer.
+func cloneYAMLNode(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	out := *n // copy scalar/style/tag/value/anchor/comments by value
+	if n.Alias != nil {
+		out.Alias = cloneYAMLNode(n.Alias)
+	}
+	if n.Content != nil {
+		out.Content = make([]*yaml.Node, len(n.Content))
+		for i, c := range n.Content {
+			out.Content[i] = cloneYAMLNode(c)
+		}
+	}
+	return &out
 }
 
 // carryEntryComments copies the head/line/foot comments from src to

--- a/pkg/cluster/plan/merge_test.go
+++ b/pkg/cluster/plan/merge_test.go
@@ -550,6 +550,215 @@ func TestDetectIndent(t *testing.T) {
 	}
 }
 
+// TestMerge_refreshHost_replacesSingleEntryOnly: --refresh-host=<ip>
+// re-emits one host's entry from the fresh spec while leaving every
+// other entry's bytes intact. Operator workflow: drift detection
+// flagged 10.0.0.21, operator runs `plan --refresh-host=10.0.0.21`
+// to fix that one entry without --overwrite (which would discard
+// every hand edit).
+func TestMerge_refreshHost_replacesSingleEntryOnly(t *testing.T) {
+	base, st := buildBaseSpec(t)
+
+	// Operator hand-tightened max: 9999 on /data1 of 10.0.0.21. After
+	// refresh we expect THAT edit to be clobbered (refresh re-emits
+	// the entry from fresh facts), but sibling entries (the masters)
+	// should stay byte-identical.
+	const userMax = "max: 9999"
+	edited := strings.Replace(string(base), "max: 19", userMax, 1)
+	if edited == string(base) {
+		t.Fatal("test setup: max: 19 not present in baseline")
+	}
+
+	spec, _, err := Generate(st.inv, st.facts, Options{ClusterName: "merge-test"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	merged, report, err := Merge([]byte(edited), spec, MergeOptions{
+		Marshal:      MarshalOptions{InventoryPath: "inventory.yaml", Now: goldenStamp},
+		RefreshHosts: map[string]struct{}{"10.0.0.21": {}},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	got := string(merged)
+
+	// 1. Hand edit on the refreshed entry is gone (refresh re-emits).
+	if strings.Contains(got, userMax) {
+		t.Errorf("--refresh-host should clobber hand edits on the refreshed entry, but %q survived:\n%s", userMax, got)
+	}
+	// 2. Refresh report names the section + key.
+	if len(report.Refreshed) != 1 || report.Refreshed[0] != "volume_servers: 10.0.0.21:8080" {
+		t.Errorf("Report.Refreshed = %+v, want [volume_servers: 10.0.0.21:8080]", report.Refreshed)
+	}
+	// 3. Sibling entries (masters) stay byte-identical. Cheap check:
+	// every master_servers line from the baseline must appear in the
+	// merged output.
+	masters := []string{
+		"    - ip: 10.0.0.11",
+		"    - ip: 10.0.0.12",
+		"    - ip: 10.0.0.13",
+	}
+	for _, line := range masters {
+		if !strings.Contains(got, line) {
+			t.Errorf("sibling entry line %q lost during refresh:\n%s", line, got)
+		}
+	}
+	// 4. No spurious appends or orphans.
+	if total := len(report.Appended); total != 0 {
+		t.Errorf("Report.Appended should be empty on a no-change refresh, got %+v", report.Appended)
+	}
+	if len(report.RefreshNotFound) != 0 {
+		t.Errorf("Report.RefreshNotFound should be empty for a matched IP, got %+v", report.RefreshNotFound)
+	}
+}
+
+// TestMerge_refreshHost_unmatchedSurfaces: an IP passed to
+// --refresh-host that doesn't match any existing entry shows up in
+// MergeReport.RefreshNotFound. Typical cause: typo, or the host
+// hasn't been deployed yet.
+func TestMerge_refreshHost_unmatchedSurfaces(t *testing.T) {
+	base, st := buildBaseSpec(t)
+	spec, _, err := Generate(st.inv, st.facts, Options{ClusterName: "merge-test"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	merged, report, err := Merge(base, spec, MergeOptions{
+		Marshal:      MarshalOptions{InventoryPath: "inventory.yaml", Now: goldenStamp},
+		RefreshHosts: map[string]struct{}{"10.0.0.99": {}, "10.0.0.21": {}},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	// 10.0.0.21 matched the volume host; 10.0.0.99 didn't match anything.
+	if got, want := report.RefreshNotFound, []string{"10.0.0.99"}; !equalStrings(got, want) {
+		t.Errorf("RefreshNotFound = %+v, want %+v", got, want)
+	}
+	if len(report.Refreshed) != 1 {
+		t.Errorf("Refreshed should still capture the matched IP, got %+v", report.Refreshed)
+	}
+	// Other hosts' bytes still survive.
+	for _, ip := range []string{"10.0.0.11", "10.0.0.12", "10.0.0.13"} {
+		if !strings.Contains(string(merged), ip) {
+			t.Errorf("non-refreshed host %s lost from merged output", ip)
+		}
+	}
+}
+
+// TestMerge_refreshHost_preservesEntryComment: head/line/foot
+// comments attached to the SEQUENCE-ITEM node survive a refresh.
+// Operators frequently annotate entries with a leading comment
+// (`# primary HDD bank`); losing those on a refresh would surprise
+// them. Field-level inline comments on individual key/value pairs
+// inside the mapping (e.g. `ip: 10.0.0.11   # primary`) are NOT
+// preserved by Phase 4 — see TestMerge_refreshHost_dropsFieldLevelComment.
+func TestMerge_refreshHost_preservesEntryComment(t *testing.T) {
+	existing := `cluster_name: merge-test
+master_servers:
+    # primary master, do not move
+    - ip: 10.0.0.11
+      port.ssh: 22
+      port: 9333
+      port.grpc: 19333
+`
+	inv := &inventory.Inventory{
+		Hosts: []inventory.Host{{IP: "10.0.0.11", Roles: []string{"master"}}},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Fatalf("inventory.Validate: %v", err)
+	}
+	spec, _, err := Generate(inv, map[string]probe.HostFacts{}, Options{ClusterName: "merge-test"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	merged, _, err := Merge([]byte(existing), spec, MergeOptions{
+		Marshal:      MarshalOptions{InventoryPath: "inventory.yaml", Now: goldenStamp},
+		RefreshHosts: map[string]struct{}{"10.0.0.11": {}},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if !strings.Contains(string(merged), "primary master, do not move") {
+		t.Errorf("entry head comment lost on refresh:\n%s", merged)
+	}
+}
+
+// TestMerge_refreshHost_dropsFieldLevelComment pins down the
+// documented Phase 4 limitation: comments attached to individual
+// key/value pairs INSIDE the mapping (yaml.v3 stores these as
+// LineComment on the value scalar) do not survive a refresh.
+// Operators who care can re-add the comment after refresh, or
+// promote it to an entry head comment (which IS preserved).
+//
+// Implementing field-level comment carry would require pairing each
+// fresh field with its corresponding old field by key — explicitly
+// scoped out of Phase 4 to keep the merge surface small.
+func TestMerge_refreshHost_dropsFieldLevelComment(t *testing.T) {
+	existing := `cluster_name: merge-test
+master_servers:
+    - ip: 10.0.0.11   # primary master, do not move
+      port.ssh: 22
+      port: 9333
+      port.grpc: 19333
+`
+	inv := &inventory.Inventory{
+		Hosts: []inventory.Host{{IP: "10.0.0.11", Roles: []string{"master"}}},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Fatalf("inventory.Validate: %v", err)
+	}
+	spec, _, err := Generate(inv, map[string]probe.HostFacts{}, Options{ClusterName: "merge-test"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	merged, _, err := Merge([]byte(existing), spec, MergeOptions{
+		Marshal:      MarshalOptions{InventoryPath: "inventory.yaml", Now: goldenStamp},
+		RefreshHosts: map[string]struct{}{"10.0.0.11": {}},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if strings.Contains(string(merged), "primary master, do not move") {
+		t.Errorf("documented limitation broke: field-level inline comment survived a refresh — if this is now intentional, update the doc on carryEntryComments and remove this test:\n%s", merged)
+	}
+}
+
+// TestMerge_refreshHost_noOpWhenSetEmpty: an empty / nil
+// RefreshHosts map leaves Merge in its existing append-only mode —
+// no refreshes, no RefreshNotFound entries. Belt-and-braces test in
+// case future code refactors break the gate.
+func TestMerge_refreshHost_noOpWhenSetEmpty(t *testing.T) {
+	base, st := buildBaseSpec(t)
+	spec, _, err := Generate(st.inv, st.facts, Options{ClusterName: "merge-test"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	merged, report, err := Merge(base, spec, MergeOptions{
+		Marshal: MarshalOptions{InventoryPath: "inventory.yaml", Now: goldenStamp},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if string(merged) != string(base) {
+		t.Errorf("nil RefreshHosts should leave bytes byte-identical")
+	}
+	if len(report.Refreshed) != 0 || len(report.RefreshNotFound) != 0 {
+		t.Errorf("nil RefreshHosts should produce no refresh report; got Refreshed=%+v NotFound=%+v",
+			report.Refreshed, report.RefreshNotFound)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestMerge_handWrittenSpec_noMarkerSurvives: merging into a hand-
 // written cluster.yaml (no plan marker) doesn't sneak the marker in.
 // Whether the file gets the marker is the writer's call, not Merge's;

--- a/pkg/cluster/plan/merge_test.go
+++ b/pkg/cluster/plan/merge_test.go
@@ -722,6 +722,73 @@ master_servers:
 	}
 }
 
+// TestMerge_refreshHost_partialPortMismatchSurfaces: the
+// IP-level RefreshNotFound check only fires when refreshSeen[ip]
+// was never set in ANY section. If a refresh IP matches cleanly
+// in master_servers but the operator has hand-edited the port on
+// the same host's filer_servers entry, refreshSeen[ip] gets set
+// by the master match and the filer entry stays silently stale.
+// The per-section Unparseable surface captures that miss so the
+// operator sees a signal for the role that didn't refresh.
+func TestMerge_refreshHost_partialPortMismatchSurfaces(t *testing.T) {
+	// Hand-edited filer port (8889 instead of the fresh spec's 8888)
+	// — common when an operator runs filer on a non-standard port.
+	existing := `cluster_name: merge-test
+master_servers:
+    - ip: 10.0.0.11
+      port.ssh: 22
+      port: 9333
+      port.grpc: 19333
+filer_servers:
+    - ip: 10.0.0.11
+      port.ssh: 22
+      port: 8889
+      port.grpc: 18888
+`
+	inv := &inventory.Inventory{
+		Hosts: []inventory.Host{{IP: "10.0.0.11", Roles: []string{"master", "filer"}}},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Fatalf("inventory.Validate: %v", err)
+	}
+	spec, _, err := Generate(inv, map[string]probe.HostFacts{}, Options{ClusterName: "merge-test"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	_, report, err := Merge([]byte(existing), spec, MergeOptions{
+		Marshal:      MarshalOptions{InventoryPath: "inventory.yaml", Now: goldenStamp},
+		RefreshHosts: map[string]struct{}{"10.0.0.11": {}},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	// master_servers refreshed cleanly.
+	foundMaster := false
+	for _, k := range report.Refreshed {
+		if strings.Contains(k, "master_servers") && strings.Contains(k, "10.0.0.11:9333") {
+			foundMaster = true
+		}
+	}
+	if !foundMaster {
+		t.Errorf("Refreshed should contain master_servers entry, got %+v", report.Refreshed)
+	}
+	// filer_servers entry (port 8889 in existing vs 8888 in fresh)
+	// must surface as a section-qualified miss.
+	foundFilerMiss := false
+	for _, u := range report.Unparseable {
+		if strings.Contains(u, "filer_servers") && strings.Contains(u, "refresh-host 10.0.0.11") {
+			foundFilerMiss = true
+		}
+	}
+	if !foundFilerMiss {
+		t.Errorf("Unparseable should record the filer_servers refresh miss, got %+v", report.Unparseable)
+	}
+	// And RefreshNotFound stays empty: the IP DID match somewhere.
+	if len(report.RefreshNotFound) != 0 {
+		t.Errorf("RefreshNotFound should stay empty when the IP matched at least one section, got %+v", report.RefreshNotFound)
+	}
+}
+
 // TestMerge_refreshHost_noOpWhenSetEmpty: an empty / nil
 // RefreshHosts map leaves Merge in its existing append-only mode —
 // no refreshes, no RefreshNotFound entries. Belt-and-braces test in

--- a/pkg/cluster/plan/merge_test.go
+++ b/pkg/cluster/plan/merge_test.go
@@ -722,17 +722,18 @@ master_servers:
 	}
 }
 
-// TestMerge_refreshHost_partialPortMismatchSurfaces: the
-// IP-level RefreshNotFound check only fires when refreshSeen[ip]
-// was never set in ANY section. If a refresh IP matches cleanly
-// in master_servers but the operator has hand-edited the port on
-// the same host's filer_servers entry, refreshSeen[ip] gets set
-// by the master match and the filer entry stays silently stale.
-// The per-section Unparseable surface captures that miss so the
-// operator sees a signal for the role that didn't refresh.
-func TestMerge_refreshHost_partialPortMismatchSurfaces(t *testing.T) {
-	// Hand-edited filer port (8889 instead of the fresh spec's 8888)
-	// — common when an operator runs filer on a non-standard port.
+// TestMerge_refreshHost_clobbersHandEditedPort exercises the
+// partial-match path that an earlier pass (commit 4791ef8) handled
+// incorrectly: the operator hand-edited a section's port, then
+// asked for a refresh on the host. Refresh's contract is "re-emit
+// from fresh facts" — including the port, which is incidentally
+// part of the dedup key. Refreshing in place by IP rather than by
+// (ip, port) means the entry's port becomes whatever the fresh
+// spec says. Crucially, the section ends up with EXACTLY ONE row
+// for the host, not the duplicate the previous implementation left
+// behind (existing 8889 marked orphan + freshly-appended 8888).
+func TestMerge_refreshHost_clobbersHandEditedPort(t *testing.T) {
+	// Hand-edited filer port (8889 instead of the fresh spec's 8888).
 	existing := `cluster_name: merge-test
 master_servers:
     - ip: 10.0.0.11
@@ -755,37 +756,52 @@ filer_servers:
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	_, report, err := Merge([]byte(existing), spec, MergeOptions{
+	merged, report, err := Merge([]byte(existing), spec, MergeOptions{
 		Marshal:      MarshalOptions{InventoryPath: "inventory.yaml", Now: goldenStamp},
 		RefreshHosts: map[string]struct{}{"10.0.0.11": {}},
 	})
 	if err != nil {
 		t.Fatalf("Merge: %v", err)
 	}
-	// master_servers refreshed cleanly.
-	foundMaster := false
+
+	// Both sections refreshed cleanly — the filer's hand-edited port
+	// 8889 got clobbered by the fresh spec's 8888.
+	wantRefreshed := map[string]bool{
+		"master_servers: 10.0.0.11:9333": false,
+		"filer_servers: 10.0.0.11:8888":  false,
+	}
 	for _, k := range report.Refreshed {
-		if strings.Contains(k, "master_servers") && strings.Contains(k, "10.0.0.11:9333") {
-			foundMaster = true
+		if _, ok := wantRefreshed[k]; ok {
+			wantRefreshed[k] = true
 		}
 	}
-	if !foundMaster {
-		t.Errorf("Refreshed should contain master_servers entry, got %+v", report.Refreshed)
-	}
-	// filer_servers entry (port 8889 in existing vs 8888 in fresh)
-	// must surface as a section-qualified miss.
-	foundFilerMiss := false
-	for _, u := range report.Unparseable {
-		if strings.Contains(u, "filer_servers") && strings.Contains(u, "refresh-host 10.0.0.11") {
-			foundFilerMiss = true
+	for k, seen := range wantRefreshed {
+		if !seen {
+			t.Errorf("Refreshed should contain %q, got %+v", k, report.Refreshed)
 		}
 	}
-	if !foundFilerMiss {
-		t.Errorf("Unparseable should record the filer_servers refresh miss, got %+v", report.Unparseable)
+
+	// No phantom entries. Without the IP-keyed refresh fix, the
+	// filer section ended up with TWO rows for 10.0.0.11 (the stale
+	// 8889 marked orphan + freshly-appended 8888). After the fix,
+	// the section has exactly one filer row at the fresh port.
+	got := string(merged)
+	if got8889 := strings.Count(got, "port: 8889"); got8889 != 0 {
+		t.Errorf("hand-edited port 8889 should be clobbered by refresh, got %d occurrences in:\n%s", got8889, merged)
 	}
-	// And RefreshNotFound stays empty: the IP DID match somewhere.
+	if got8888 := strings.Count(got, "port: 8888"); got8888 != 1 {
+		t.Errorf("expected exactly one filer entry at fresh port 8888, got %d in:\n%s", got8888, merged)
+	}
+
+	// And no warning surfaces are unintentionally tripped:
 	if len(report.RefreshNotFound) != 0 {
-		t.Errorf("RefreshNotFound should stay empty when the IP matched at least one section, got %+v", report.RefreshNotFound)
+		t.Errorf("RefreshNotFound should stay empty for an IP that matched, got %+v", report.RefreshNotFound)
+	}
+	if len(report.Unparseable) != 0 {
+		t.Errorf("Unparseable should stay empty (the in-place refresh leaves no parseable-but-mismatched leftovers), got %+v", report.Unparseable)
+	}
+	if len(report.Orphaned) != 0 {
+		t.Errorf("Orphaned should stay empty after refresh-in-place, got %+v", report.Orphaned)
 	}
 }
 

--- a/pkg/cluster/plan/merge_test.go
+++ b/pkg/cluster/plan/merge_test.go
@@ -805,6 +805,59 @@ filer_servers:
 	}
 }
 
+// TestMerge_refreshHost_duplicateEntriesPreserveOwnComments: the
+// rare hand-edited duplicate-entry case. Two existing rows for the
+// same IP each carry their own head comment. Refresh on that IP
+// must replace both — and each replacement must keep its own
+// original comment, not the LAST iteration's. Without cloning the
+// fresh node before carrying comments, both refreshed slots end
+// up sharing one mutated node and the second iteration's
+// carryEntryComments call clobbers the first slot's preserved
+// comment.
+func TestMerge_refreshHost_duplicateEntriesPreserveOwnComments(t *testing.T) {
+	existing := `cluster_name: merge-test
+master_servers:
+    # primary master
+    - ip: 10.0.0.11
+      port.ssh: 22
+      port: 9333
+      port.grpc: 19333
+    # standby master, do not move
+    - ip: 10.0.0.11
+      port.ssh: 22
+      port: 9333
+      port.grpc: 19333
+`
+	inv := &inventory.Inventory{
+		Hosts: []inventory.Host{{IP: "10.0.0.11", Roles: []string{"master"}}},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Fatalf("inventory.Validate: %v", err)
+	}
+	spec, _, err := Generate(inv, map[string]probe.HostFacts{}, Options{ClusterName: "merge-test"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	merged, _, err := Merge([]byte(existing), spec, MergeOptions{
+		Marshal:      MarshalOptions{InventoryPath: "inventory.yaml", Now: goldenStamp},
+		RefreshHosts: map[string]struct{}{"10.0.0.11": {}},
+	})
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	got := string(merged)
+	// Both head comments must survive their respective refresh slots.
+	// Without cloning, the second iteration's comment would overwrite
+	// the first ("primary master" would vanish, leaving two copies of
+	// "standby master, do not move").
+	if !strings.Contains(got, "primary master") {
+		t.Errorf("first refreshed slot lost its `# primary master` head comment:\n%s", got)
+	}
+	if !strings.Contains(got, "standby master, do not move") {
+		t.Errorf("second refreshed slot lost its `# standby master` head comment:\n%s", got)
+	}
+}
+
 // TestMerge_refreshHost_noOpWhenSetEmpty: an empty / nil
 // RefreshHosts map leaves Merge in its existing append-only mode —
 // no refreshes, no RefreshNotFound entries. Belt-and-braces test in


### PR DESCRIPTION
## Summary

Phase 4's third piece. Drift detection (PR #71) tells operators which hosts have shifted; ` + "`--refresh-host=<ip>`" + ` (repeatable) gives them the one-shot remediation. Merge re-emits THAT host's entries from the freshly-Generated spec while leaving every other entry's bytes intact — no more ` + "`--overwrite`" + ` tradeoff (which discards every hand edit elsewhere).

## Refresh semantics

- **Per-IP**, not per-(ip, port). A host that maps to multiple sections (master + filer + volume) gets all of its entries refreshed in one shot.
- **Entry-level head/line/foot comments survive** — annotations like ` + "`# primary HDD bank`" + ` stay put.
- **Field-level inline comments inside the mapping don't survive** — pairing each fresh field with its old counterpart is out of scope. Documented and pinned by ` + "`TestMerge_refreshHost_dropsFieldLevelComment`" + `.
- **Misses** (an IP that didn't match any existing entry) surface as ` + "`MergeReport.RefreshNotFound`" + ` + a ` + "`WARN: --refresh-host`" + ` line so a typo doesn't read as a successful refresh.
- **Validation**: ` + "`--refresh-host`" + ` without ` + "`-o`" + ` errors out before the probe; with ` + "`-o`" + ` but in greenfield/` + "`--overwrite`" + ` mode it warns and continues (refresh is meaningless when there's no existing file).

## Test plan

- [x] 5 plan-level cases: replaces single entry only, unmatched-surfaces, preserves entry comment, drops field-level comment, no-op on empty set
- [x] 2 cmd-level cases: ` + "`--refresh-host`" + ` requires ` + "`-o`" + `; ` + "`refreshHostSet`" + ` trims/drops blanks
- [x] ` + "`go build -tags=integration ./...`" + `, ` + "`go vet -tags=integration ./...`" + `, ` + "`go test ./...`" + ` all green

## Out of scope (last Phase 4 item)

- Inventory ` + "`tag:`" + ` references → DSN rewrite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable --refresh-host CLI option to refresh specific hosts during append-merge; requires -o and replaces matched host entries with freshly probed data while leaving other entries byte-identical.

* **Bug Fixes / Reporting**
  * Emits WARNs for refresh IPs that match no existing entries and reports which entries were refreshed.

* **Documentation**
  * Updated docs and help text with flag semantics and examples.

* **Tests**
  * Added unit tests covering validation, trimming of inputs, merge behavior, and comment-preservation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->