### PR TITLE
feat(plan): inventory tag references rewrite in --filer-backend

### DIFF
--- a/cmd/cluster_plan.go
+++ b/cmd/cluster_plan.go
@@ -123,8 +123,8 @@ Purely read-only on the target hosts.`,
 
 	cmd.Flags().StringVar(&opts.ClusterName, "cluster-name", "", "cluster_name to stamp on the generated cluster.yaml")
 	cmd.Flags().IntVar(&opts.VolumeSizeLimitMB, "volume-size-limit-mb", 0, "volumeSizeLimitMB for the generated global block (default 5000)")
-	cmd.Flags().StringVar(&opts.FilerBackend, "filer-backend", "", "filer metadata DSN, e.g. postgres://user:pass@host/db (leaks via ps; prefer --filer-backend-file)")
-	cmd.Flags().StringVar(&opts.FilerBackendFile, "filer-backend-file", "", "path to a file containing the filer metadata DSN")
+	cmd.Flags().StringVar(&opts.FilerBackend, "filer-backend", "", "filer metadata DSN, e.g. postgres://user:pass@host/db; the host segment may be `tag:<name>` to resolve against an inventory tag (leaks via ps; prefer --filer-backend-file)")
+	cmd.Flags().StringVar(&opts.FilerBackendFile, "filer-backend-file", "", "path to a file containing the filer metadata DSN (same `tag:<name>` host substitution applies)")
 	cmd.Flags().StringVar(&opts.VolumeServerShape, "volume-server-shape", "", "how to map disks to volume_server entries: per-host (default; one entry, all disks under folders:) or per-disk (one entry per disk, distinct ports)")
 
 	_ = cmd.MarkFlagRequired("inventory")
@@ -224,7 +224,7 @@ func runClusterPlan(cmd *cobra.Command, opts *ClusterPlanOptions) error {
 	// json-only branch) so a stray $SEAWEEDUP_FILER_BACKEND in the
 	// environment can't fail a probe-only run with a backend it
 	// doesn't even need.
-	backend, err := resolveFilerBackend(opts)
+	backend, err := resolveFilerBackend(opts, inv)
 	if err != nil {
 		return err
 	}
@@ -650,10 +650,16 @@ func printSkipReport(report plan.Report) {
 }
 
 // resolveFilerBackend picks the filer DSN from (in priority order)
-// --filer-backend-file, --filer-backend, SEAWEEDUP_FILER_BACKEND. Zero
-// return value (nil) is fine — the planner emits a placeholder comment
-// instead of a config block.
-func resolveFilerBackend(opts *ClusterPlanOptions) (map[string]interface{}, error) {
+// --filer-backend-file, --filer-backend, SEAWEEDUP_FILER_BACKEND, then
+// resolves any `tag:<name>` references against the inventory before
+// parsing. Zero return value (nil) is fine — the planner emits a
+// placeholder comment instead of a config block.
+//
+// inv may be nil when the caller couldn't load it; tag rewriting
+// then no-ops and a literal `tag:` in the DSN reaches the parser
+// (which will error with a host-shaped message — acceptable since
+// the operator should pair tag references with a working inventory).
+func resolveFilerBackend(opts *ClusterPlanOptions, inv *inventory.Inventory) (map[string]interface{}, error) {
 	var dsn string
 	switch {
 	case opts.FilerBackendFile != "":
@@ -669,6 +675,10 @@ func resolveFilerBackend(opts *ClusterPlanOptions) (map[string]interface{}, erro
 	}
 	if dsn == "" {
 		return nil, nil
+	}
+	dsn, err := plan.RewriteTagReferences(dsn, inv)
+	if err != nil {
+		return nil, fmt.Errorf("filer backend: %w", err)
 	}
 	backend, err := plan.ParseFilerBackendDSN(dsn)
 	if err != nil {

--- a/cmd/cluster_plan_test.go
+++ b/cmd/cluster_plan_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/inventory"
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/plan"
 )
 
@@ -215,6 +216,59 @@ func TestRefreshHostSet(t *testing.T) {
 	}
 	if _, ok := got["10.0.0.22"]; !ok {
 		t.Errorf("trimmed 10.0.0.22 missing from set: %+v", got)
+	}
+}
+
+// TestResolveFilerBackend_rewritesTagReference confirms the cmd
+// layer threads the inventory through to plan.RewriteTagReferences
+// before parsing the DSN. An inventory carrying tag:postgres-metadata
+// on 10.0.0.41 means `--filer-backend postgres://…@tag:postgres-
+// metadata:5432/db` resolves to the host's IP in the parsed config.
+func TestResolveFilerBackend_rewritesTagReference(t *testing.T) {
+	inv := &inventory.Inventory{
+		Hosts: []inventory.Host{
+			{IP: "10.0.0.11", Roles: []string{"master"}},
+			{IP: "10.0.0.41", Roles: []string{"external"}, Tag: "postgres-metadata"},
+		},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	opts := &ClusterPlanOptions{
+		FilerBackend: "postgres://seaweed:s3cret@tag:postgres-metadata:5432/seaweedfs?sslmode=disable",
+	}
+	got, err := resolveFilerBackend(opts, inv)
+	if err != nil {
+		t.Fatalf("resolveFilerBackend: %v", err)
+	}
+	if got["hostname"] != "10.0.0.41" {
+		t.Errorf("hostname = %v, want 10.0.0.41 (tag rewrite didn't happen)", got["hostname"])
+	}
+	if got["username"] != "seaweed" || got["database"] != "seaweedfs" {
+		t.Errorf("non-host fields lost in tag rewrite path: %+v", got)
+	}
+}
+
+// TestResolveFilerBackend_unknownTagErrors: a typo in the tag name
+// surfaces as an error instead of falling through to the parser
+// (which would reject `tag:nonexistent` as a malformed host with a
+// confusing message).
+func TestResolveFilerBackend_unknownTagErrors(t *testing.T) {
+	inv := &inventory.Inventory{
+		Hosts: []inventory.Host{{IP: "10.0.0.11", Roles: []string{"master"}}},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	opts := &ClusterPlanOptions{
+		FilerBackend: "postgres://u:p@tag:typo:5432/db",
+	}
+	_, err := resolveFilerBackend(opts, inv)
+	if err == nil {
+		t.Fatal("expected unknown-tag error, got nil")
+	}
+	if !strings.Contains(err.Error(), "tag:typo") {
+		t.Errorf("error should name the missing tag, got: %v", err)
 	}
 }
 

--- a/docs/design/inventory-and-plan.md
+++ b/docs/design/inventory-and-plan.md
@@ -664,11 +664,21 @@ pkg/disks/
      out of scope for now. Misses (an IP that didn't match any
      existing entry) surface as a `WARN: --refresh-host …` line.
      Implementation extends `pkg/cluster/plan/merge.go`.
-   - Inventory tag references (`tag: postgres-metadata` → DSN
-     rewrite).
+   - **Inventory `tag:` references** *(done)* — declare a host as
+     `roles: [external]` with `tag: postgres-metadata`, then write
+     `--filer-backend postgres://user:pw@tag:postgres-metadata:5432/db`.
+     Plan substitutes the tagged host's IP before parsing the DSN,
+     so the generated `cluster.yaml` carries the resolved address
+     and `cluster deploy` doesn't need to know about tags. Decouples
+     "where the metadata DB lives" (inventory edit) from "what its
+     credentials are" (DSN file). Tag uniqueness is enforced at
+     inventory load; missing-tag references error at plan time
+     rather than reaching the DSN parser. v6 IPs get bracketed for
+     URL safety. Implementation in `pkg/cluster/plan/tagrewrite.go`.
 
-Phases 1–3 are the minimum product. Phase 4 is ice cream — each
-flag is opt-in and lands independently as it earns its keep.
+With this last item Phase 4 is feature-complete. Phases 1–3 are the
+minimum product; Phase 4 is ice cream — each flag landed
+independently as it earned its keep.
 
 ## Resolved design decisions
 

--- a/pkg/cluster/inventory/inventory.go
+++ b/pkg/cluster/inventory/inventory.go
@@ -180,12 +180,25 @@ func (inv *Inventory) Validate() error {
 	sshSeen := make(map[sshKey]SSHConfig)
 	sshWhere := make(map[sshKey]string) // for the error message
 
+	// Tag uniqueness: --filer-backend tag:<name> rewrites resolve a
+	// tag to the IP of the host carrying it. A duplicate tag would
+	// be ambiguous; refuse at load time so the operator sees the
+	// collision before the planner picks an arbitrary winner.
+	tagOwner := make(map[string]string) // tag → ip-of-first-bearer
 	for i, h := range inv.Hosts {
 		if h.IP == "" {
 			return fmt.Errorf("host[%d] has no ip", i)
 		}
 		if len(h.Roles) == 0 {
 			return fmt.Errorf("host %s has no roles", h.IP)
+		}
+		if h.Tag != "" {
+			if owner, dup := tagOwner[h.Tag]; dup {
+				return fmt.Errorf(
+					"tag %q is declared on both host %s and host %s; tags must be unique within an inventory",
+					h.Tag, owner, h.IP)
+			}
+			tagOwner[h.Tag] = h.IP
 		}
 		for _, role := range h.Roles {
 			if _, ok := validRoles[role]; !ok {
@@ -267,6 +280,22 @@ func validateDeviceGlob(g string) error {
 		return fmt.Errorf("unsupported glob %q: only a literal path with an optional trailing '*' is allowed", g)
 	}
 	return nil
+}
+
+// HostByTag returns the (first and, after Validate, only) host
+// carrying the given tag. The bool is false when no host owns the
+// tag. Used by the --filer-backend `tag:<name>` rewrite to resolve
+// a symbolic reference to a concrete IP at plan time.
+func (inv *Inventory) HostByTag(tag string) (*Host, bool) {
+	if tag == "" {
+		return nil, false
+	}
+	for i := range inv.Hosts {
+		if inv.Hosts[i].Tag == tag {
+			return &inv.Hosts[i], true
+		}
+	}
+	return nil, false
 }
 
 // ProbeHosts returns the deduplicated set of hosts to SSH-probe. External-only

--- a/pkg/cluster/inventory/inventory_test.go
+++ b/pkg/cluster/inventory/inventory_test.go
@@ -235,6 +235,66 @@ func TestProbeHosts_dedupsBySSHTarget(t *testing.T) {
 	}
 }
 
+func TestValidate_rejectsDuplicateTag(t *testing.T) {
+	// Two hosts carrying the same tag would make tag:<name> rewrites
+	// ambiguous. Refuse at load time so the operator sees the
+	// collision instead of the planner picking an arbitrary winner.
+	inv := &Inventory{
+		Hosts: []Host{
+			{IP: "10.0.0.41", Roles: []string{"external"}, Tag: "postgres-metadata"},
+			{IP: "10.0.0.42", Roles: []string{"external"}, Tag: "postgres-metadata"},
+		},
+	}
+	err := inv.Validate()
+	if err == nil {
+		t.Fatal("expected duplicate-tag error, got nil")
+	}
+	if !strings.Contains(err.Error(), "postgres-metadata") {
+		t.Errorf("error should name the offending tag, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "10.0.0.41") || !strings.Contains(err.Error(), "10.0.0.42") {
+		t.Errorf("error should name both hosts, got: %v", err)
+	}
+}
+
+func TestValidate_emptyTagIsNotShared(t *testing.T) {
+	// Empty tag means "no tag at all" — multiple hosts without a tag
+	// must not collide with each other.
+	inv := &Inventory{
+		Hosts: []Host{
+			{IP: "10.0.0.11", Roles: []string{"master"}},
+			{IP: "10.0.0.12", Roles: []string{"master"}},
+		},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Errorf("empty tags should not collide: %v", err)
+	}
+}
+
+func TestHostByTag(t *testing.T) {
+	inv := &Inventory{
+		Hosts: []Host{
+			{IP: "10.0.0.11", Roles: []string{"master"}},
+			{IP: "10.0.0.41", Roles: []string{"external"}, Tag: "postgres-metadata"},
+			{IP: "10.0.0.51", Roles: []string{"external"}, Tag: "redis"},
+		},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	h, ok := inv.HostByTag("postgres-metadata")
+	if !ok || h.IP != "10.0.0.41" {
+		t.Errorf("HostByTag(postgres-metadata) = (%+v, %v), want 10.0.0.41 / true", h, ok)
+	}
+	if _, ok := inv.HostByTag("nonexistent"); ok {
+		t.Errorf("HostByTag should miss on unknown tag")
+	}
+	if _, ok := inv.HostByTag(""); ok {
+		t.Errorf("HostByTag(\"\") should miss — empty tag is not a key")
+	}
+}
+
 func TestHasRole(t *testing.T) {
 	h := &Host{Roles: []string{"master", "filer"}}
 	if !h.HasRole("master") || !h.HasRole("filer") {

--- a/pkg/cluster/plan/tagrewrite.go
+++ b/pkg/cluster/plan/tagrewrite.go
@@ -57,7 +57,13 @@ func RewriteTagReferences(dsn string, inv *inventory.Inventory) (string, error) 
 	// Build the output by interleaving unchanged spans with
 	// resolved IPs. ReplaceAllStringFunc would work but loses the
 	// per-match error path we want for unknown tags.
-	var out []byte
+	//
+	// Pre-allocate at the input length: the common substitution
+	// (tag:<short-name> → 10.0.0.X) is roughly the same number of
+	// bytes, so this gets us through most rewrites in a single
+	// allocation. v6 substitutions slightly grow the output and
+	// trigger one append-resize, which is fine.
+	out := make([]byte, 0, len(dsn))
 	last := 0
 	for _, m := range matches {
 		// m = [start, end, prefixStart, prefixEnd, tagStart, tagEnd].

--- a/pkg/cluster/plan/tagrewrite.go
+++ b/pkg/cluster/plan/tagrewrite.go
@@ -1,0 +1,87 @@
+package plan
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/inventory"
+)
+
+// tagRefRE matches `tag:<name>` symbolic references in a DSN. Tag
+// names follow the same lenient grammar as DNS labels — letters,
+// digits, dot, dash, underscore — so postgres-metadata, redis_main,
+// metadata.staging, etc. all work. Anchored with word boundaries on
+// the left so we don't match `flagtag:foo` or `???tag:`.
+//
+// Why a regexp instead of a hand-rolled scanner: a DSN like
+// `postgres://user:pw@tag:metadata-db:5432/db?sslmode=disable`
+// contains other `:` separators around the tag substring, and we
+// want to substitute exactly the `tag:metadata-db` segment without
+// touching `user:pw` or `:5432/db`. The (^|\W) prefix guards the
+// left edge; the [a-zA-Z0-9_.-]+ on the right consumes only the
+// tag name and stops at the next `:` or `/` etc.
+var tagRefRE = regexp.MustCompile(`(^|\W)tag:([a-zA-Z0-9_.\-]+)`)
+
+// RewriteTagReferences resolves `tag:<name>` references in dsn by
+// substituting the tagged host's IP from inv. Returns the rewritten
+// string and a non-nil error when any referenced tag isn't declared
+// on a host (typo, host removed, etc.) — failing loud rather than
+// passing through a `tag:` literal that ParseFilerBackendDSN would
+// then reject as a malformed host.
+//
+// When dsn carries no tag references the function is a fast no-op
+// and returns the input unchanged. Useful for the operator who just
+// wants to keep typing literal IPs/hostnames.
+//
+// IPv6: a v6 IP is wrapped in brackets so it slots cleanly into a
+// URL authority (`postgres://user:pw@[2001:db8::1]:5432/db`). v4
+// IPs and DNS names are substituted verbatim.
+func RewriteTagReferences(dsn string, inv *inventory.Inventory) (string, error) {
+	if inv == nil || dsn == "" {
+		return dsn, nil
+	}
+	// Cheap pre-check: avoid the regexp engine on the common case
+	// where the operator typed a plain DSN with no tag: forms.
+	matches := tagRefRE.FindAllStringSubmatchIndex(dsn, -1)
+	if len(matches) == 0 {
+		return dsn, nil
+	}
+
+	// Build the output by interleaving unchanged spans with
+	// resolved IPs. ReplaceAllStringFunc would work but loses the
+	// per-match error path we want for unknown tags.
+	var out []byte
+	last := 0
+	for _, m := range matches {
+		// m = [start, end, prefixStart, prefixEnd, tagStart, tagEnd]
+		prefixStart, prefixEnd := m[2], m[3]
+		tagStart, tagEnd := m[4], m[5]
+		tag := dsn[tagStart:tagEnd]
+
+		host, ok := inv.HostByTag(tag)
+		if !ok {
+			return "", fmt.Errorf("--filer-backend references tag:%s but no host in the inventory carries that tag", tag)
+		}
+
+		out = append(out, dsn[last:prefixEnd]...) // includes the prefix byte
+		out = append(out, formatTagSubstitution(host.IP)...)
+		last = tagEnd
+		_ = prefixStart // already covered by the append above
+	}
+	out = append(out, dsn[last:]...)
+	return string(out), nil
+}
+
+// formatTagSubstitution renders a host IP for inline DSN
+// substitution. v6 IPs get bracketed so the surrounding URL parser
+// sees a single authority component; v4 and DNS names go in raw.
+// Detection is shallow on purpose — anything containing `:` is
+// treated as v6.
+func formatTagSubstitution(ip string) string {
+	for i := 0; i < len(ip); i++ {
+		if ip[i] == ':' {
+			return "[" + ip + "]"
+		}
+	}
+	return ip
+}

--- a/pkg/cluster/plan/tagrewrite.go
+++ b/pkg/cluster/plan/tagrewrite.go
@@ -60,7 +60,12 @@ func RewriteTagReferences(dsn string, inv *inventory.Inventory) (string, error) 
 
 		host, ok := inv.HostByTag(tag)
 		if !ok {
-			return "", fmt.Errorf("--filer-backend references tag:%s but no host in the inventory carries that tag", tag)
+			// Stay generic here so the error reads sensibly when
+			// future callers reuse RewriteTagReferences for more
+			// than just --filer-backend; the cmd layer already
+			// wraps with "filer backend: " for the operator-facing
+			// message.
+			return "", fmt.Errorf("tag:%s not found in inventory", tag)
 		}
 
 		out = append(out, dsn[last:prefixEnd]...) // includes the prefix byte

--- a/pkg/cluster/plan/tagrewrite.go
+++ b/pkg/cluster/plan/tagrewrite.go
@@ -53,8 +53,12 @@ func RewriteTagReferences(dsn string, inv *inventory.Inventory) (string, error) 
 	var out []byte
 	last := 0
 	for _, m := range matches {
-		// m = [start, end, prefixStart, prefixEnd, tagStart, tagEnd]
-		prefixStart, prefixEnd := m[2], m[3]
+		// m = [start, end, prefixStart, prefixEnd, tagStart, tagEnd].
+		// prefixStart isn't needed: dsn[last:prefixEnd] copies
+		// everything from the previous match's tail through and
+		// including the boundary character (the `\W` or BOL the
+		// regex matched), so the substitution drops in cleanly.
+		_, prefixEnd := m[2], m[3]
 		tagStart, tagEnd := m[4], m[5]
 		tag := dsn[tagStart:tagEnd]
 
@@ -71,7 +75,6 @@ func RewriteTagReferences(dsn string, inv *inventory.Inventory) (string, error) 
 		out = append(out, dsn[last:prefixEnd]...) // includes the prefix byte
 		out = append(out, formatTagSubstitution(host.IP)...)
 		last = tagEnd
-		_ = prefixStart // already covered by the append above
 	}
 	out = append(out, dsn[last:]...)
 	return string(out), nil

--- a/pkg/cluster/plan/tagrewrite.go
+++ b/pkg/cluster/plan/tagrewrite.go
@@ -41,8 +41,14 @@ func RewriteTagReferences(dsn string, inv *inventory.Inventory) (string, error) 
 	if inv == nil || dsn == "" {
 		return dsn, nil
 	}
-	// Cheap pre-check: avoid the regexp engine on the common case
-	// where the operator typed a plain DSN with no tag: forms.
+	// Cheap pre-check: avoid spinning up the regexp state machine
+	// on the common case where the operator typed a plain DSN with
+	// no tag: forms. strings.Contains is O(n) byte-by-byte; the
+	// regex would do considerably more work to reach the same "no
+	// matches" answer.
+	if !strings.Contains(dsn, "tag:") {
+		return dsn, nil
+	}
 	matches := tagRefRE.FindAllStringSubmatchIndex(dsn, -1)
 	if len(matches) == 0 {
 		return dsn, nil

--- a/pkg/cluster/plan/tagrewrite.go
+++ b/pkg/cluster/plan/tagrewrite.go
@@ -23,16 +23,27 @@ import (
 // tag name and stops at the next `:` or `/` etc.
 var tagRefRE = regexp.MustCompile(`(^|\W)tag:([a-zA-Z0-9_.\-]+)`)
 
-// RewriteTagReferences resolves `tag:<name>` references in dsn by
-// substituting the tagged host's IP from inv. Returns the rewritten
-// string and a non-nil error when any referenced tag isn't declared
-// on a host (typo, host removed, etc.) — failing loud rather than
-// passing through a `tag:` literal that ParseFilerBackendDSN would
-// then reject as a malformed host.
+// RewriteTagReferences resolves `tag:<name>` references in dsn's
+// authority host segment (the bytes after `://[userinfo@]` and
+// before the next `/?#`) by substituting the tagged host's IP from
+// inv. Other parts of the DSN — scheme, userinfo, port, path,
+// query, fragment — are left strictly alone. Constraining the
+// rewrite to the host position avoids clobbering literal `tag:`
+// substrings that legitimately appear in passwords (`user:tag:secret@…`)
+// or query values (`?note=tag:prod`).
 //
-// When dsn carries no tag references the function is a fast no-op
-// and returns the input unchanged. Useful for the operator who just
-// wants to keep typing literal IPs/hostnames.
+// Returns a non-nil error when a tag in the host segment isn't
+// declared on any host in the inventory (typo, host removed, etc.)
+// — failing loud rather than passing through a `tag:` literal that
+// ParseFilerBackendDSN would then reject as a malformed host.
+//
+// Fast no-ops, in priority order:
+//   - inv is nil or dsn is empty
+//   - dsn doesn't contain the substring "tag:" anywhere
+//   - dsn doesn't contain the scheme separator "://" (we can't
+//     locate the host segment without one; the operator gets the
+//     literal pass-through and ParseFilerBackendDSN can complain
+//     about the missing scheme on its own terms)
 //
 // IPv6: a v6 IP is wrapped in brackets so it slots cleanly into a
 // URL authority (`postgres://user:pw@[2001:db8::1]:5432/db`). v4
@@ -49,31 +60,76 @@ func RewriteTagReferences(dsn string, inv *inventory.Inventory) (string, error) 
 	if !strings.Contains(dsn, "tag:") {
 		return dsn, nil
 	}
-	matches := tagRefRE.FindAllStringSubmatchIndex(dsn, -1)
-	if len(matches) == 0 {
+
+	// Locate the authority host segment — the slice we're allowed
+	// to touch. Anything outside it (userinfo password, path,
+	// query, fragment) stays verbatim even if it contains `tag:`.
+	hostStart, hostEnd, ok := authorityHostRange(dsn)
+	if !ok {
 		return dsn, nil
 	}
+	rewritten, err := rewriteTagsInRange(dsn, hostStart, hostEnd, inv)
+	if err != nil {
+		return "", err
+	}
+	return dsn[:hostStart] + rewritten + dsn[hostEnd:], nil
+}
 
-	// Build the output by interleaving unchanged spans with
-	// resolved IPs. ReplaceAllStringFunc would work but loses the
-	// per-match error path we want for unknown tags.
-	//
-	// Pre-allocate at the input length: the common substitution
+// authorityHostRange returns the [start, end) byte offsets of the
+// host segment within a URL-style DSN: everything after `://` and
+// the optional `userinfo@`, up to the first authority terminator
+// (`/`, `?`, `#`) or end-of-string. The bool reports whether a
+// scheme separator was found at all; callers use it to skip the
+// rewrite on non-URL inputs.
+//
+// Splitting the userinfo on the LAST `@` handles passwords that
+// contain `@` (e.g. `user:p@ss@host`); the URL spec is ambiguous
+// here but the de-facto convention is "everything before the last
+// @ is userinfo". Authority-end uses the FIRST occurrence of `/`,
+// `?`, or `#` after the scheme — a literal `?` inside userinfo
+// would already have made the DSN unparseable.
+func authorityHostRange(dsn string) (start, end int, ok bool) {
+	scheme := strings.Index(dsn, "://")
+	if scheme < 0 {
+		return 0, 0, false
+	}
+	authStart := scheme + 3
+	authEnd := len(dsn)
+	if i := strings.IndexAny(dsn[authStart:], "/?#"); i >= 0 {
+		authEnd = authStart + i
+	}
+	hostStart := authStart
+	if at := strings.LastIndex(dsn[authStart:authEnd], "@"); at >= 0 {
+		hostStart = authStart + at + 1
+	}
+	return hostStart, authEnd, true
+}
+
+// rewriteTagsInRange runs the tag regex against dsn[start:end] and
+// returns the substituted segment. Errors loudly on unknown tags;
+// no-op when the segment carries no tag references.
+func rewriteTagsInRange(dsn string, start, end int, inv *inventory.Inventory) (string, error) {
+	segment := dsn[start:end]
+	matches := tagRefRE.FindAllStringSubmatchIndex(segment, -1)
+	if len(matches) == 0 {
+		return segment, nil
+	}
+	// Pre-allocate at the segment length: the common substitution
 	// (tag:<short-name> → 10.0.0.X) is roughly the same number of
 	// bytes, so this gets us through most rewrites in a single
 	// allocation. v6 substitutions slightly grow the output and
 	// trigger one append-resize, which is fine.
-	out := make([]byte, 0, len(dsn))
+	out := make([]byte, 0, len(segment))
 	last := 0
 	for _, m := range matches {
 		// m = [start, end, prefixStart, prefixEnd, tagStart, tagEnd].
-		// prefixStart isn't needed: dsn[last:prefixEnd] copies
+		// prefixStart isn't needed: segment[last:prefixEnd] copies
 		// everything from the previous match's tail through and
 		// including the boundary character (the `\W` or BOL the
 		// regex matched), so the substitution drops in cleanly.
 		_, prefixEnd := m[2], m[3]
 		tagStart, tagEnd := m[4], m[5]
-		tag := dsn[tagStart:tagEnd]
+		tag := segment[tagStart:tagEnd]
 
 		host, ok := inv.HostByTag(tag)
 		if !ok {
@@ -84,12 +140,11 @@ func RewriteTagReferences(dsn string, inv *inventory.Inventory) (string, error) 
 			// message.
 			return "", fmt.Errorf("tag:%s not found in inventory", tag)
 		}
-
-		out = append(out, dsn[last:prefixEnd]...) // includes the prefix byte
+		out = append(out, segment[last:prefixEnd]...)
 		out = append(out, formatTagSubstitution(host.IP)...)
 		last = tagEnd
 	}
-	out = append(out, dsn[last:]...)
+	out = append(out, segment[last:]...)
 	return string(out), nil
 }
 

--- a/pkg/cluster/plan/tagrewrite.go
+++ b/pkg/cluster/plan/tagrewrite.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/inventory"
 )
@@ -86,10 +87,8 @@ func RewriteTagReferences(dsn string, inv *inventory.Inventory) (string, error) 
 // Detection is shallow on purpose — anything containing `:` is
 // treated as v6.
 func formatTagSubstitution(ip string) string {
-	for i := 0; i < len(ip); i++ {
-		if ip[i] == ':' {
-			return "[" + ip + "]"
-		}
+	if strings.Contains(ip, ":") {
+		return "[" + ip + "]"
 	}
 	return ip
 }

--- a/pkg/cluster/plan/tagrewrite.go
+++ b/pkg/cluster/plan/tagrewrite.go
@@ -86,7 +86,16 @@ func RewriteTagReferences(dsn string, inv *inventory.Inventory) (string, error) 
 // sees a single authority component; v4 and DNS names go in raw.
 // Detection is shallow on purpose — anything containing `:` is
 // treated as v6.
+//
+// Already-bracketed inputs (operator typed `ip: "[2001:db8::1]"`
+// in inventory.yaml — natural after a copy-paste from a connection
+// URL) pass through unchanged so the rewrite doesn't produce
+// `@[[2001:db8::1]]:5432`, which the DSN parser would reject with
+// a confusing host-shaped error.
 func formatTagSubstitution(ip string) string {
+	if strings.HasPrefix(ip, "[") {
+		return ip
+	}
 	if strings.Contains(ip, ":") {
 		return "[" + ip + "]"
 	}

--- a/pkg/cluster/plan/tagrewrite_test.go
+++ b/pkg/cluster/plan/tagrewrite_test.go
@@ -54,13 +54,58 @@ func TestRewriteTagReferences_noTagPassesThrough(t *testing.T) {
 	}
 }
 
-func TestRewriteTagReferences_multipleTags(t *testing.T) {
+// TestRewriteTagReferences_passwordContainingTagPrefixIsNotRewritten
+// is the regression test for the host-only-substitution rule: a
+// password literal that happens to start with `tag:` (operator
+// chose `tag:secret` as their password — unwise but valid) must
+// not be touched by the rewriter. Before the fix, the regex
+// matched anywhere in the DSN and either errored on an unknown
+// tag or silently substituted credentials with an inventory IP.
+func TestRewriteTagReferences_passwordContainingTagPrefixIsNotRewritten(t *testing.T) {
+	inv := invWithTags(t, map[string]string{"primary": "10.0.0.41"})
+	in := "postgres://user:tag:secret@10.0.0.41/db"
+	got, err := RewriteTagReferences(in, inv)
+	if err != nil {
+		t.Fatalf("RewriteTagReferences: %v", err)
+	}
+	if got != in {
+		t.Errorf("password-containing-`tag:` DSN should pass through; got %q", got)
+	}
+}
+
+// TestRewriteTagReferences_queryValueContainingTagIsNotRewritten
+// pairs with the password test above: a `?note=tag:prod` query
+// value (or any tag-shaped substring after `?`) must stay
+// verbatim. Without the host-only constraint the rewriter would
+// either error on unknown tags or substitute credentials/queries
+// with an inventory IP.
+func TestRewriteTagReferences_queryValueContainingTagIsNotRewritten(t *testing.T) {
+	inv := invWithTags(t, map[string]string{"primary": "10.0.0.41"})
+	in := "postgres://user:p@10.0.0.41/db?note=tag:prod&fallback=tag:primary"
+	got, err := RewriteTagReferences(in, inv)
+	if err != nil {
+		t.Fatalf("RewriteTagReferences: %v", err)
+	}
+	if got != in {
+		t.Errorf("query-string `tag:` substrings should pass through; got %q", got)
+	}
+}
+
+// TestRewriteTagReferences_multipleTagsInHost is the upper bound
+// of host-segment substitution: a DSN that legitimately needs two
+// tag references in the same authority position (extremely rare;
+// included to pin behavior). With the host-only constraint the
+// rewriter substitutes both, leaving the rest of the DSN alone.
+func TestRewriteTagReferences_multipleTagsInHost(t *testing.T) {
+	// SeaweedFS doesn't actually parse multi-host DSNs in
+	// --filer-backend, but this exercises the loop logic against a
+	// concocted shape (no port to keep the regex unambiguous).
 	inv := invWithTags(t, map[string]string{
 		"primary": "10.0.0.41",
 		"replica": "10.0.0.42",
 	})
-	dsn := "tag:primary,tag:replica?weight=1"
-	got, err := RewriteTagReferences(dsn, inv)
+	in := "postgres://u:p@tag:primary,tag:replica/db"
+	got, err := RewriteTagReferences(in, inv)
 	if err != nil {
 		t.Fatalf("RewriteTagReferences: %v", err)
 	}
@@ -69,6 +114,22 @@ func TestRewriteTagReferences_multipleTags(t *testing.T) {
 	}
 	if strings.Contains(got, "tag:") {
 		t.Errorf("output still contains a literal tag: reference: %q", got)
+	}
+}
+
+// TestRewriteTagReferences_noSchemePassesThrough: without `://`
+// we can't locate the host segment safely, so the rewriter is a
+// no-op. The downstream parser will complain about a missing
+// scheme on its own terms — better than guessing.
+func TestRewriteTagReferences_noSchemePassesThrough(t *testing.T) {
+	inv := invWithTags(t, map[string]string{"primary": "10.0.0.41"})
+	in := "host=tag:primary user=foo password=bar" // libpq-style key/value
+	got, err := RewriteTagReferences(in, inv)
+	if err != nil {
+		t.Fatalf("RewriteTagReferences: %v", err)
+	}
+	if got != in {
+		t.Errorf("schemeless DSN should pass through; got %q", got)
 	}
 }
 

--- a/pkg/cluster/plan/tagrewrite_test.go
+++ b/pkg/cluster/plan/tagrewrite_test.go
@@ -1,0 +1,123 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/inventory"
+)
+
+// invWithTags returns an inventory carrying the supplied tag→IP
+// mappings (plus a master so Validate is happy). Each tag's host
+// is `external` so the SSH-config conflict check stays out of the
+// way.
+func invWithTags(t *testing.T, tags map[string]string) *inventory.Inventory {
+	t.Helper()
+	inv := &inventory.Inventory{
+		Hosts: []inventory.Host{
+			{IP: "10.0.0.11", Roles: []string{"master"}},
+		},
+	}
+	for tag, ip := range tags {
+		inv.Hosts = append(inv.Hosts, inventory.Host{
+			IP: ip, Roles: []string{"external"}, Tag: tag,
+		})
+	}
+	if err := inv.Validate(); err != nil {
+		t.Fatalf("inventory.Validate: %v", err)
+	}
+	return inv
+}
+
+func TestRewriteTagReferences_substitutesSingle(t *testing.T) {
+	inv := invWithTags(t, map[string]string{"postgres-metadata": "10.0.0.41"})
+	dsn := "postgres://seaweed:s3cret@tag:postgres-metadata:5432/seaweedfs?sslmode=disable"
+	got, err := RewriteTagReferences(dsn, inv)
+	if err != nil {
+		t.Fatalf("RewriteTagReferences: %v", err)
+	}
+	want := "postgres://seaweed:s3cret@10.0.0.41:5432/seaweedfs?sslmode=disable"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteTagReferences_noTagPassesThrough(t *testing.T) {
+	inv := invWithTags(t, nil)
+	in := "postgres://user:pass@10.0.0.41:5432/db"
+	got, err := RewriteTagReferences(in, inv)
+	if err != nil {
+		t.Fatalf("RewriteTagReferences: %v", err)
+	}
+	if got != in {
+		t.Errorf("no-tag DSN should pass through unchanged; got %q", got)
+	}
+}
+
+func TestRewriteTagReferences_multipleTags(t *testing.T) {
+	inv := invWithTags(t, map[string]string{
+		"primary": "10.0.0.41",
+		"replica": "10.0.0.42",
+	})
+	dsn := "tag:primary,tag:replica?weight=1"
+	got, err := RewriteTagReferences(dsn, inv)
+	if err != nil {
+		t.Fatalf("RewriteTagReferences: %v", err)
+	}
+	if !strings.Contains(got, "10.0.0.41") || !strings.Contains(got, "10.0.0.42") {
+		t.Errorf("both tag substitutions missing in %q", got)
+	}
+	if strings.Contains(got, "tag:") {
+		t.Errorf("output still contains a literal tag: reference: %q", got)
+	}
+}
+
+func TestRewriteTagReferences_unknownTagErrors(t *testing.T) {
+	inv := invWithTags(t, map[string]string{"primary": "10.0.0.41"})
+	_, err := RewriteTagReferences("postgres://u:p@tag:nonexistent:5432/db", inv)
+	if err == nil {
+		t.Fatal("expected error for unknown tag, got nil")
+	}
+	if !strings.Contains(err.Error(), "tag:nonexistent") {
+		t.Errorf("error should name the missing tag, got: %v", err)
+	}
+}
+
+func TestRewriteTagReferences_ipv6BracketsTaggedHost(t *testing.T) {
+	// v6 IP must be wrapped in brackets so it slots into a URL
+	// authority cleanly: `@[2001:db8::1]:5432`.
+	inv := invWithTags(t, map[string]string{"v6db": "2001:db8::1"})
+	got, err := RewriteTagReferences("postgres://u:p@tag:v6db:5432/db", inv)
+	if err != nil {
+		t.Fatalf("RewriteTagReferences: %v", err)
+	}
+	if !strings.Contains(got, "@[2001:db8::1]:5432/") {
+		t.Errorf("v6 substitution should bracket the address; got %q", got)
+	}
+}
+
+func TestRewriteTagReferences_nilInventoryNoOp(t *testing.T) {
+	in := "postgres://u:p@tag:foo/db"
+	got, err := RewriteTagReferences(in, nil)
+	if err != nil {
+		t.Fatalf("nil inventory should be a no-op, got err %v", err)
+	}
+	if got != in {
+		t.Errorf("nil inventory should pass through unchanged; got %q", got)
+	}
+}
+
+func TestRewriteTagReferences_doesNotMatchEmbeddedSubstring(t *testing.T) {
+	// `flagtag:foo` shouldn't trigger — the regexp boundary on the
+	// left guards against a `tag:` that's actually a suffix of some
+	// other identifier.
+	inv := invWithTags(t, map[string]string{"foo": "10.0.0.41"})
+	in := "postgres://flagtag:foo@host/db"
+	got, err := RewriteTagReferences(in, inv)
+	if err != nil {
+		t.Fatalf("RewriteTagReferences: %v", err)
+	}
+	if got != in {
+		t.Errorf("embedded `tag:` shouldn't be rewritten; got %q", got)
+	}
+}

--- a/pkg/cluster/plan/tagrewrite_test.go
+++ b/pkg/cluster/plan/tagrewrite_test.go
@@ -96,6 +96,25 @@ func TestRewriteTagReferences_ipv6BracketsTaggedHost(t *testing.T) {
 	}
 }
 
+// TestRewriteTagReferences_alreadyBracketedIPv6PassThrough: an
+// operator who pastes `[2001:db8::1]` into inventory.yaml's `ip:`
+// field shouldn't see the rewrite produce `@[[2001:db8::1]]:5432`
+// (which the DSN parser would reject as a malformed host). The
+// shallow brackets-already-present check keeps the value verbatim.
+func TestRewriteTagReferences_alreadyBracketedIPv6PassThrough(t *testing.T) {
+	inv := invWithTags(t, map[string]string{"v6db": "[2001:db8::1]"})
+	got, err := RewriteTagReferences("postgres://u:p@tag:v6db:5432/db", inv)
+	if err != nil {
+		t.Fatalf("RewriteTagReferences: %v", err)
+	}
+	if !strings.Contains(got, "@[2001:db8::1]:5432/") {
+		t.Errorf("already-bracketed v6 should pass through; got %q", got)
+	}
+	if strings.Contains(got, "[[") {
+		t.Errorf("output should not double-bracket; got %q", got)
+	}
+}
+
 func TestRewriteTagReferences_nilInventoryNoOp(t *testing.T) {
 	in := "postgres://u:p@tag:foo/db"
 	got, err := RewriteTagReferences(in, nil)


### PR DESCRIPTION
## Summary

Closes the last Phase 4 item. Operators declare a host as ` + "`roles: [external]`" + ` carrying ` + "`tag: postgres-metadata`" + `, then write:

` + "```bash" + `
seaweed-up cluster plan -i inventory.yaml -o cluster.yaml \
    --filer-backend 'postgres://user:pw@tag:postgres-metadata:5432/db?sslmode=disable'
` + "```" + `

Plan substitutes the tagged host's IP before parsing the DSN. The generated ` + "`cluster.yaml`" + ` carries the resolved address, so ` + "`cluster deploy`" + ` doesn't need to know about tags.

**Why**: decouples "where the metadata DB lives" (one inventory edit) from "what its credentials are" (the DSN file or env var stays stable across IP changes).

## Implementation

- **inventory** — ` + "`Validate()`" + ` rejects duplicate tags so the resolver can't pick an arbitrary winner; new ` + "`HostByTag`" + ` lookup helper.
- **pkg/cluster/plan/tagrewrite.go** — ` + "`RewriteTagReferences`" + ` scans the DSN with a tight regexp (` + "`(^|\\W)tag:[a-zA-Z0-9_.-]+`" + `), resolves each match against the inventory, errors loudly on a missing tag (so a typo doesn't reach the DSN parser as a malformed host). v6 IPs get bracketed. ` + "`flagtag:foo`" + `-style false matches are guarded by the left boundary.
- **cmd/cluster_plan.go** — ` + "`resolveFilerBackend`" + ` takes the inventory and runs the rewrite before ` + "`plan.ParseFilerBackendDSN`" + `. Both ` + "`--filer-backend`" + ` and ` + "`--filer-backend-file`" + ` help text mention the ` + "`tag:`" + ` form.

## Test plan

- [x] inventory: duplicate-tag rejection, empty tag isn't shared, ` + "`HostByTag`" + ` hit/miss/empty
- [x] plan: 7 cases — substitute single, no-tag pass-through, multiple tags, unknown-tag error, IPv6 bracketing, nil inventory no-op, embedded ` + "`tag:`" + ` doesn't match
- [x] cmd: ` + "`resolveFilerBackend`" + ` rewrites the host segment, surfaces unknown-tag errors
- [x] ` + "`go build -tags=integration ./...`" + `, ` + "`go vet -tags=integration ./...`" + `, ` + "`go test ./...`" + ` all green

## Phase 4 status

This was the last item. Phase 4 (` + "`--dry-run`" + ` / drift detection / ` + "`--refresh-host`" + ` / tag references) is now feature-complete; all four landed independently as standalone PRs. Design doc updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for tag:<name> host substitution in filer backend DSNs supplied via --filer-backend and --filer-backend-file
  * Inventory lookup is used during planning so resolved addresses are embedded before parsing

* **Bug Fixes**
  * Plan now errors early for missing or ambiguous tag references; tag uniqueness is enforced
  * IPv6 addresses are correctly bracketed when substituted into DSNs

* **Tests**
  * Added unit tests covering tag rewriting, error paths, and IPv6/address-format handling

* **Documentation**
  * Updated design docs to describe inventory tag rewriting behavior and validation rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->