### PR TITLE
feat: workers default to -jobType=all; refuse multi-admin specs

### DIFF
--- a/docs/design/inventory-and-plan.md
+++ b/docs/design/inventory-and-plan.md
@@ -721,6 +721,21 @@ independently as it earned its keep.
 7. **Network probe degrades gracefully.** Prefer `ip -j addr` (JSON,
    iproute2 ≥ 4.15); fall back to parsing `ip addr` text output so
    older LTS images (CentOS 7, Ubuntu 16.04) still probe.
+8. **Admin UI is single-instance; refuse multiples at validation
+   time.** SeaweedFS's `weed admin` component has no leader
+   election or shared-state story, so two instances would race on
+   task scheduling. Both `inventory.Validate()` (plan-side) and
+   `Manager.DeployCluster` (deploy-side, for hand-written specs)
+   refuse specs with more than one admin entry up front, before
+   any SSH session opens. Zero admins is allowed — the cluster
+   runs without the admin UI.
+9. **Workers run with `-jobType=all` by default.** Stamping the
+   default explicitly on every plan-generated `worker_servers`
+   entry makes the rendered `cluster.yaml` self-describing —
+   operators don't have to know `weed worker`'s implicit default
+   to predict task coverage. Override per-pool via
+   `worker_servers[].jobType: ec,balance` etc. when sharding task
+   handling.
 
 ## Open questions
 

--- a/pkg/cluster/inventory/inventory.go
+++ b/pkg/cluster/inventory/inventory.go
@@ -185,6 +185,13 @@ func (inv *Inventory) Validate() error {
 	// be ambiguous; refuse at load time so the operator sees the
 	// collision before the planner picks an arbitrary winner.
 	tagOwner := make(map[string]string) // tag → ip-of-first-bearer
+	// Single-admin guard: SeaweedFS's admin UI is single-instance,
+	// so an inventory with multiple `admin` role bearers would
+	// produce a deploy-time failure. Catch it here so plan errors
+	// before doing any probe work; the deploy-side validator in
+	// pkg/cluster/manager catches hand-written specs that bypass
+	// this path.
+	var adminHost string
 	for i, h := range inv.Hosts {
 		if h.IP == "" {
 			return fmt.Errorf("host[%d] has no ip", i)
@@ -209,6 +216,14 @@ func (inv *Inventory) Validate() error {
 				return fmt.Errorf("host %s declares role %q twice", h.IP, role)
 			}
 			seenRoles[rk] = struct{}{}
+			if role == RoleAdmin {
+				if adminHost != "" {
+					return fmt.Errorf(
+						"the admin role is declared on both host %s and host %s; SeaweedFS's admin UI is single-instance, keep at most one host with `roles: [admin]`",
+						adminHost, h.IP)
+				}
+				adminHost = h.IP
+			}
 		}
 
 		// External entries don't open SSH sessions, so they don't need to

--- a/pkg/cluster/inventory/inventory_test.go
+++ b/pkg/cluster/inventory/inventory_test.go
@@ -235,6 +235,55 @@ func TestProbeHosts_dedupsBySSHTarget(t *testing.T) {
 	}
 }
 
+func TestValidate_rejectsMultipleAdminHosts(t *testing.T) {
+	// SeaweedFS's admin UI is single-instance — there's no leader
+	// election or shared-state story for the `weed admin` component,
+	// so an inventory with two admin hosts would silently produce
+	// conflicting task scheduling at deploy time. Refuse at load.
+	inv := &Inventory{
+		Hosts: []Host{
+			{IP: "10.0.0.11", Roles: []string{"master"}},
+			{IP: "10.0.0.61", Roles: []string{"admin"}},
+			{IP: "10.0.0.62", Roles: []string{"admin"}},
+		},
+	}
+	err := inv.Validate()
+	if err == nil {
+		t.Fatal("expected multi-admin error, got nil")
+	}
+	if !strings.Contains(err.Error(), "10.0.0.61") || !strings.Contains(err.Error(), "10.0.0.62") {
+		t.Errorf("error should name both admin hosts, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "single-instance") {
+		t.Errorf("error should explain the rationale, got: %v", err)
+	}
+}
+
+func TestValidate_singleAdminAllowed(t *testing.T) {
+	// One admin host is the canonical shape. Make sure the new
+	// guard doesn't accidentally trip on it.
+	inv := &Inventory{
+		Hosts: []Host{
+			{IP: "10.0.0.11", Roles: []string{"master"}},
+			{IP: "10.0.0.61", Roles: []string{"admin"}},
+		},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Errorf("single admin should validate: %v", err)
+	}
+}
+
+func TestValidate_zeroAdminsAllowed(t *testing.T) {
+	// Cluster without an admin UI is legitimate — the `weed admin`
+	// component is optional. Make sure the guard doesn't require it.
+	inv := &Inventory{
+		Hosts: []Host{{IP: "10.0.0.11", Roles: []string{"master"}}},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Errorf("inventory without admin role should validate: %v", err)
+	}
+}
+
 func TestValidate_rejectsDuplicateTag(t *testing.T) {
 	// Two hosts carrying the same tag would make tag:<name> rewrites
 	// ambiguous. Refuse at load time so the operator sees the

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -54,32 +54,41 @@ func validateS3Prerequisites(specification *spec.Specification) error {
 	return nil
 }
 
-// validateSingleAdminServer enforces the at-most-one-admin rule.
-// SeaweedFS's admin UI is single-instance today: there's no leader
-// election or shared-state story for the `weed admin` component, so
-// running two admin processes against the same cluster would race on
-// task scheduling and produce conflicting decisions. Refuse the spec
-// at deploy time before any SSH session opens — fail fast with the
-// offending IPs in the error so the operator can see exactly which
-// rows to consolidate.
+// validateSingleAdminServer enforces the at-most-one-admin rule and
+// rejects nil entries. SeaweedFS's admin UI is single-instance today:
+// there's no leader election or shared-state story for the `weed
+// admin` component, so running two admin processes against the same
+// cluster would race on task scheduling and produce conflicting
+// decisions. Refuse the spec at deploy time before any SSH session
+// opens — fail fast with the offending IPs in the error so the
+// operator can see exactly which rows to consolidate.
+//
+// Nil entries are caught even on a single-element list: a YAML null
+// list item (`admin_servers: [null]` or a stray bullet on its own
+// line) decodes to a nil *AdminServerSpec, and resolveWorkerDefault
+// Admins would then panic on AdminServers[0].Port. The defensive
+// scan turns that into a clear error.
 //
 // Zero admin_servers entries is allowed: the cluster runs without
 // the admin UI, and any worker_servers must carry their own explicit
 // `admin:` endpoint (or resolveWorkerDefaultAdmins errors instead).
 func validateSingleAdminServer(specification *spec.Specification) error {
-	if len(specification.AdminServers) <= 1 {
+	if len(specification.AdminServers) == 0 {
 		return nil
 	}
 	ips := make([]string, 0, len(specification.AdminServers))
-	for _, a := range specification.AdminServers {
+	for i, a := range specification.AdminServers {
 		if a == nil {
-			continue
+			return fmt.Errorf("invalid cluster spec: admin_servers[%d] is null (yaml null list item?)", i)
 		}
 		ips = append(ips, a.Ip)
 	}
+	if len(ips) <= 1 {
+		return nil
+	}
 	return fmt.Errorf(
 		"invalid cluster spec: %d admin_servers entries (%s); SeaweedFS's admin UI is single-instance — keep at most one admin_server row, or remove the role from the extras",
-		len(specification.AdminServers), strings.Join(ips, ", "))
+		len(ips), strings.Join(ips, ", "))
 }
 
 // validateSftpFilerPrerequisite ensures that any SFTP server can reach a

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -51,6 +52,34 @@ func validateS3Prerequisites(specification *spec.Specification) error {
 		}
 	}
 	return nil
+}
+
+// validateSingleAdminServer enforces the at-most-one-admin rule.
+// SeaweedFS's admin UI is single-instance today: there's no leader
+// election or shared-state story for the `weed admin` component, so
+// running two admin processes against the same cluster would race on
+// task scheduling and produce conflicting decisions. Refuse the spec
+// at deploy time before any SSH session opens — fail fast with the
+// offending IPs in the error so the operator can see exactly which
+// rows to consolidate.
+//
+// Zero admin_servers entries is allowed: the cluster runs without
+// the admin UI, and any worker_servers must carry their own explicit
+// `admin:` endpoint (or resolveWorkerDefaultAdmins errors instead).
+func validateSingleAdminServer(specification *spec.Specification) error {
+	if len(specification.AdminServers) <= 1 {
+		return nil
+	}
+	ips := make([]string, 0, len(specification.AdminServers))
+	for _, a := range specification.AdminServers {
+		if a == nil {
+			continue
+		}
+		ips = append(ips, a.Ip)
+	}
+	return fmt.Errorf(
+		"invalid cluster spec: %d admin_servers entries (%s); SeaweedFS's admin UI is single-instance — keep at most one admin_server row, or remove the role from the extras",
+		len(specification.AdminServers), strings.Join(ips, ", "))
 }
 
 // validateSftpFilerPrerequisite ensures that any SFTP server can reach a
@@ -133,6 +162,9 @@ func computeVolumeTargetDemand(volumes []*spec.VolumeServerSpec) (mountpoints, s
 }
 
 func (m *Manager) DeployCluster(specification *spec.Specification) error {
+	if err := validateSingleAdminServer(specification); err != nil {
+		return err
+	}
 	if err := validateS3Prerequisites(specification); err != nil {
 		return err
 	}

--- a/pkg/cluster/manager/manager_deploy_test.go
+++ b/pkg/cluster/manager/manager_deploy_test.go
@@ -7,6 +7,39 @@ import (
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
 )
 
+func TestValidateSingleAdminServer_zeroOrOneOK(t *testing.T) {
+	// Zero admins: cluster runs without the admin UI. Allowed.
+	if err := validateSingleAdminServer(&spec.Specification{}); err != nil {
+		t.Errorf("zero admins should pass: %v", err)
+	}
+	// One admin: canonical shape. Allowed.
+	one := &spec.Specification{}
+	one.AdminServers = append(one.AdminServers, &spec.AdminServerSpec{Ip: "10.0.0.61"})
+	if err := validateSingleAdminServer(one); err != nil {
+		t.Errorf("single admin should pass: %v", err)
+	}
+}
+
+func TestValidateSingleAdminServer_rejectsTwo(t *testing.T) {
+	// Two admins: SeaweedFS's admin UI is single-instance, so this
+	// would race on task scheduling. Refuse before any SSH session.
+	s := &spec.Specification{}
+	s.AdminServers = append(s.AdminServers,
+		&spec.AdminServerSpec{Ip: "10.0.0.61"},
+		&spec.AdminServerSpec{Ip: "10.0.0.62"},
+	)
+	err := validateSingleAdminServer(s)
+	if err == nil {
+		t.Fatal("expected error for two admins, got nil")
+	}
+	if !strings.Contains(err.Error(), "10.0.0.61") || !strings.Contains(err.Error(), "10.0.0.62") {
+		t.Errorf("error should name both admin IPs, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "single-instance") {
+		t.Errorf("error should explain the rationale, got: %v", err)
+	}
+}
+
 func TestValidateSftpFilerPrerequisite_NoSftp(t *testing.T) {
 	s := &spec.Specification{}
 	if err := validateSftpFilerPrerequisite(s); err != nil {

--- a/pkg/cluster/manager/manager_deploy_test.go
+++ b/pkg/cluster/manager/manager_deploy_test.go
@@ -20,6 +20,34 @@ func TestValidateSingleAdminServer_zeroOrOneOK(t *testing.T) {
 	}
 }
 
+func TestValidateSingleAdminServer_rejectsNilEntry(t *testing.T) {
+	// A YAML null list item (`admin_servers: [null]` or a stray
+	// bullet on its own line) decodes to a nil *AdminServerSpec.
+	// Without the defensive nil check, resolveWorkerDefaultAdmins
+	// would later panic on AdminServers[0].Port; the validator
+	// turns that into an actionable error.
+	s := &spec.Specification{}
+	s.AdminServers = append(s.AdminServers, nil)
+	err := validateSingleAdminServer(s)
+	if err == nil {
+		t.Fatal("expected error for nil admin entry, got nil")
+	}
+	if !strings.Contains(err.Error(), "null") {
+		t.Errorf("error should mention the null entry, got: %v", err)
+	}
+
+	// Same protection when the nil sits next to a real entry —
+	// the count alone (>1) might mask the nil otherwise.
+	s2 := &spec.Specification{}
+	s2.AdminServers = append(s2.AdminServers,
+		&spec.AdminServerSpec{Ip: "10.0.0.61"},
+		nil,
+	)
+	if err := validateSingleAdminServer(s2); err == nil {
+		t.Fatal("expected error for mixed nil-and-valid admin entries, got nil")
+	}
+}
+
 func TestValidateSingleAdminServer_rejectsTwo(t *testing.T) {
 	// Two admins: SeaweedFS's admin UI is single-instance, so this
 	// would race on task scheduling. Refuse before any SSH session.

--- a/pkg/cluster/plan/generate.go
+++ b/pkg/cluster/plan/generate.go
@@ -404,6 +404,12 @@ func newWorkerSpec(h *inventory.Host, ssh inventory.SSHConfig) *spec.WorkerServe
 	return &spec.WorkerServerSpec{
 		Ip:      h.IP,
 		PortSsh: ssh.Port,
+		// Stamp the default job-type explicitly so the rendered
+		// cluster.yaml is self-describing — operators reading the
+		// file shouldn't have to know `weed worker`'s implicit
+		// default to predict what task categories the worker will
+		// pick up.
+		JobType: spec.DefaultWorkerJobType,
 	}
 }
 

--- a/pkg/cluster/spec/worker_server_spec.go
+++ b/pkg/cluster/spec/worker_server_spec.go
@@ -7,15 +7,32 @@ import (
 )
 
 // WorkerServerSpec describes a SeaweedFS maintenance worker instance.
-// Equivalent to running `weed worker -admin=<admin>:23646` on the target host.
+// Equivalent to running `weed worker -admin=<admin>:23646 -jobType=all`
+// on the target host.
 type WorkerServerSpec struct {
-	Ip      string                 `yaml:"ip"`
-	PortSsh int                    `yaml:"port.ssh" default:"22"`
-	Admin   string                 `yaml:"admin,omitempty"`
+	Ip      string `yaml:"ip"`
+	PortSsh int    `yaml:"port.ssh" default:"22"`
+	Admin   string `yaml:"admin,omitempty"`
+	// JobType selects which task categories or explicit handler names
+	// the worker accepts from the admin's task queue. Mirrors the
+	// `weed worker -jobType=<value>` flag (enterprise build): `all`,
+	// `default`, `heavy`, or comma-separated explicit names like
+	// `ec,balance,iceberg`. When empty, WriteToBuffer fills in
+	// "all" so a worker started by seaweed-up always picks up
+	// every task type the admin offers — operators who want to
+	// shard task handling across worker pools override per-pool.
+	JobType string                 `yaml:"jobType,omitempty" default:"all"`
 	Config  map[string]interface{} `yaml:"config,omitempty"`
 	Arch    string                 `yaml:"arch,omitempty"`
 	OS      string                 `yaml:"os,omitempty"`
 }
+
+// DefaultWorkerJobType is the value WriteToBuffer falls back to when
+// WorkerServerSpec.JobType is empty. Matches `weed worker`'s own
+// default in pluginworker, but stamping it on the rendered options
+// file makes the cluster.yaml self-describing and survives a future
+// upstream default change.
+const DefaultWorkerJobType = "all"
 
 // workerReservedKeys lists `weed worker` CLI option names that must not be
 // set via the generic Config map because they are either derived from an
@@ -29,6 +46,11 @@ var workerReservedKeys = map[string]struct{}{
 	// from the cluster's master servers). Allowing it to also appear in
 	// Config would produce a duplicate `-admin` flag.
 	"admin": {},
+	// `jobType` is always emitted from WorkerServerSpec.JobType (with
+	// "all" as the empty-input fallback). Allowing it via Config too
+	// would produce a duplicate `-jobType` flag whose ordering is
+	// shell-implementation-defined.
+	"jobType": {},
 }
 
 // WriteToBuffer writes `weed worker` CLI options to buf.
@@ -42,6 +64,12 @@ func (w *WorkerServerSpec) WriteToBuffer(admins []string, buf *bytes.Buffer) {
 		admin = admins[0]
 	}
 	addToBuffer(buf, "admin", admin)
+
+	jobType := w.JobType
+	if jobType == "" {
+		jobType = DefaultWorkerJobType
+	}
+	addToBuffer(buf, "jobType", jobType)
 
 	if len(w.Config) == 0 {
 		return

--- a/pkg/cluster/spec/worker_server_spec.go
+++ b/pkg/cluster/spec/worker_server_spec.go
@@ -18,10 +18,14 @@ type WorkerServerSpec struct {
 	// `weed worker -jobType=<value>` flag (enterprise build): `all`,
 	// `default`, `heavy`, or comma-separated explicit names like
 	// `ec,balance,iceberg`. When empty, WriteToBuffer fills in
-	// "all" so a worker started by seaweed-up always picks up
-	// every task type the admin offers — operators who want to
-	// shard task handling across worker pools override per-pool.
-	JobType string                 `yaml:"jobType,omitempty" default:"all"`
+	// DefaultWorkerJobType ("all") so a worker started by
+	// seaweed-up always picks up every task type the admin offers —
+	// operators who want to shard task handling across worker pools
+	// override per-pool. No struct-tag default: nothing in this
+	// codebase reads `default:` at unmarshal time, so a tag would
+	// only be decorative; the doc comment and DefaultWorkerJobType
+	// are the real source of truth.
+	JobType string                 `yaml:"jobType,omitempty"`
 	Config  map[string]interface{} `yaml:"config,omitempty"`
 	Arch    string                 `yaml:"arch,omitempty"`
 	OS      string                 `yaml:"os,omitempty"`

--- a/pkg/cluster/spec/worker_server_spec_test.go
+++ b/pkg/cluster/spec/worker_server_spec_test.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -14,7 +15,7 @@ func TestWorkerServerSpec_WriteToBuffer_ExplicitAdmin(t *testing.T) {
 	w.WriteToBuffer(nil, &buf)
 
 	got := buf.String()
-	want := "admin=10.0.0.1:23646\n"
+	want := "admin=10.0.0.1:23646\njobType=all\n"
 	if got != want {
 		t.Fatalf("WriteToBuffer with explicit admin: got %q want %q", got, want)
 	}
@@ -26,18 +27,72 @@ func TestWorkerServerSpec_WriteToBuffer_FallbackAdmin(t *testing.T) {
 	w.WriteToBuffer([]string{"10.0.0.1:23646", "10.0.0.2:23646"}, &buf)
 
 	got := buf.String()
-	want := "admin=10.0.0.1:23646\n"
+	want := "admin=10.0.0.1:23646\njobType=all\n"
 	if got != want {
 		t.Fatalf("WriteToBuffer fallback admin: got %q want %q", got, want)
 	}
 }
 
-func TestWorkerServerSpec_WriteToBuffer_NoAdmin(t *testing.T) {
+func TestWorkerServerSpec_WriteToBuffer_NoAdminStillEmitsJobType(t *testing.T) {
+	// With no admin endpoint resolvable the worker won't actually
+	// start, but WriteToBuffer's job is to render the spec — emit
+	// jobType=all regardless so the on-disk options file is
+	// self-describing even before deploy fills in the admin.
 	w := &WorkerServerSpec{Ip: "10.0.0.5"}
 	var buf bytes.Buffer
 	w.WriteToBuffer(nil, &buf)
 
-	if buf.Len() != 0 {
-		t.Fatalf("expected empty buffer when no admin supplied, got %q", buf.String())
+	got := buf.String()
+	want := "jobType=all\n"
+	if got != want {
+		t.Fatalf("WriteToBuffer no-admin: got %q want %q", got, want)
+	}
+}
+
+func TestWorkerServerSpec_WriteToBuffer_ExplicitJobType(t *testing.T) {
+	// Operators who shard task handling across worker pools set
+	// JobType per-worker; the explicit value wins over the "all"
+	// default.
+	w := &WorkerServerSpec{
+		Ip:      "10.0.0.5",
+		Admin:   "10.0.0.1:23646",
+		JobType: "ec,balance",
+	}
+	var buf bytes.Buffer
+	w.WriteToBuffer(nil, &buf)
+
+	got := buf.String()
+	if !strings.Contains(got, "jobType=ec,balance\n") {
+		t.Errorf("explicit JobType not emitted: got %q", got)
+	}
+	if strings.Contains(got, "jobType=all") {
+		t.Errorf("default jobType=all leaked when explicit value was set: got %q", got)
+	}
+}
+
+func TestWorkerServerSpec_WriteToBuffer_JobTypeInConfigSuppressed(t *testing.T) {
+	// jobType is a reserved key — putting it in Config would
+	// produce a duplicate `-jobType` flag whose ordering is
+	// shell-implementation-defined. The reserved-key filter drops
+	// the Config entry; the explicit struct field's value (or "all"
+	// fallback) is the only -jobType emitted.
+	w := &WorkerServerSpec{
+		Ip:      "10.0.0.5",
+		Admin:   "10.0.0.1:23646",
+		JobType: "ec",
+		Config:  map[string]interface{}{"jobType": "balance"},
+	}
+	var buf bytes.Buffer
+	w.WriteToBuffer(nil, &buf)
+
+	got := buf.String()
+	if strings.Count(got, "jobType=") != 1 {
+		t.Errorf("expected exactly one jobType line, got %q", got)
+	}
+	if !strings.Contains(got, "jobType=ec\n") {
+		t.Errorf("expected jobType=ec from struct field; got %q", got)
+	}
+	if strings.Contains(got, "jobType=balance") {
+		t.Errorf("Config jobType should be dropped by reserved-keys filter; got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Two small cleanups around worker startup and admin-UI invariants:

1. **Workers now run with ` + "`-jobType=all`" + ` by default.** Enterprise ` + "`weed worker`" + ` accepts a ` + "`-jobType`" + ` flag selecting which task categories to pull from the admin's queue (` + "`all`" + `, ` + "`default`" + `, ` + "`heavy`" + `, or comma-separated explicit names like ` + "`ec,balance,iceberg`" + `). Default in ` + "`weed worker`" + ` itself is ` + "`all`" + ` if the flag is omitted, but seaweed-up wasn't emitting it — operators reading the rendered options file couldn't predict task coverage without knowing the implicit default. Now stamped explicitly so ` + "`cluster.yaml`" + ` is self-describing.

2. **Refuse specs with more than one ` + "`admin_servers`" + ` entry.** SeaweedFS's ` + "`weed admin`" + ` component is single-instance — there's no leader election or shared-state story, so two instances would race on task scheduling and produce conflicting decisions. Validation runs at two layers: ` + "`inventory.Validate()`" + ` rejects multi-admin inventories before plan probes, and ` + "`Manager.DeployCluster`" + ` rejects multi-admin specs before any SSH session opens. Zero admins remains allowed (cluster without the admin UI).

## Implementation

Each logic change in its own commit:

| Commit | What |
| --- | --- |
| ` + "`d40adb7`" + ` | ` + "`WorkerServerSpec`" + ` gains a ` + "`JobType`" + ` field; ` + "`WriteToBuffer`" + ` fills in ` + "`DefaultWorkerJobType`" + ` (` + "`\"all\"`" + `) when empty; reserved-keys filter blocks duplicate emission via ` + "`Config:`" + `; plan synthesis stamps ` + "`JobType: \"all\"`" + ` on every emitted worker entry. |
| ` + "`4bc5098`" + ` | ` + "`validateSingleAdminServer`" + ` runs first in ` + "`DeployCluster`" + ` (catches hand-written specs). |
| ` + "`9600645`" + ` | ` + "`inventory.Validate()`" + ` refuses inventories with more than one ` + "`admin`" + ` role bearer (catches plan-driven specs earlier). |
| ` + "`b2054d8`" + ` | Design doc updated with both rules under "Resolved design decisions". |

## Test plan

- [x] ` + "`TestWorkerServerSpec_WriteToBuffer_*`" + ` — 5 cases: ExplicitAdmin / FallbackAdmin (updated), NoAdminStillEmitsJobType, ExplicitJobType, JobTypeInConfigSuppressed
- [x] ` + "`TestValidateSingleAdminServer_zeroOrOneOK`" + ` and ` + "`_rejectsTwo`" + ` (deploy-side)
- [x] ` + "`TestValidate_rejectsMultipleAdminHosts`" + `, ` + "`_singleAdminAllowed`" + `, ` + "`_zeroAdminsAllowed`" + ` (inventory)
- [x] ` + "`go build -tags=integration ./...`" + `, ` + "`go vet -tags=integration ./...`" + `, ` + "`go test ./...`" + ` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker servers now include explicit job type specification (defaults to "all") with configurable per-pool overrides for transparent task coverage configuration.

* **Bug Fixes**
  * Enforces single-instance admin deployment validation at both inventory and deployment stages, rejecting configurations with multiple admin hosts and providing detailed error messages with affected host information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->