### PR TITLE
feat(plan): default ip.bind=0.0.0.0 for inbound roles

### DIFF
--- a/docs/design/inventory-and-plan.md
+++ b/docs/design/inventory-and-plan.md
@@ -736,6 +736,17 @@ independently as it earned its keep.
    to predict task coverage. Override per-pool via
    `worker_servers[].jobType: ec,balance` etc. when sharding task
    handling.
+10. **Inbound roles default to `ip.bind: 0.0.0.0`.** SeaweedFS's
+    `weed master`/`weed volume`/`weed filer`/`weed s3`/`weed sftp`/
+    `weed admin` all bind 127.0.0.1 when `-ip.bind` is unset, which
+    makes them unreachable across the network in any multi-host
+    deploy. Plan stamps `ip.bind: 0.0.0.0` on every inbound role
+    so the generated cluster.yaml works out of the box; operators
+    on multi-NIC hosts that need to bind a specific interface
+    hand-edit the field, and merge runs preserve the override.
+    Hand-written specs that omit `ip.bind:` keep the upstream
+    127.0.0.1 default — plan doesn't reach into specs it didn't
+    generate.
 
 ## Open questions
 

--- a/docs/design/inventory-and-plan.md
+++ b/docs/design/inventory-and-plan.md
@@ -736,17 +736,18 @@ independently as it earned its keep.
    to predict task coverage. Override per-pool via
    `worker_servers[].jobType: ec,balance` etc. when sharding task
    handling.
-10. **Inbound roles default to `ip.bind: 0.0.0.0`.** SeaweedFS's
-    `weed master`/`weed volume`/`weed filer`/`weed s3`/`weed sftp`/
-    `weed admin` all bind 127.0.0.1 when `-ip.bind` is unset, which
-    makes them unreachable across the network in any multi-host
-    deploy. Plan stamps `ip.bind: 0.0.0.0` on every inbound role
-    so the generated cluster.yaml works out of the box; operators
-    on multi-NIC hosts that need to bind a specific interface
-    hand-edit the field, and merge runs preserve the override.
-    Hand-written specs that omit `ip.bind:` keep the upstream
-    127.0.0.1 default — plan doesn't reach into specs it didn't
-    generate.
+10. **Inbound roles default to a host-family-aware `ip.bind`.**
+    SeaweedFS's `weed master`/`weed volume`/`weed filer`/`weed s3`/
+    `weed sftp`/`weed admin` all bind 127.0.0.1 when `-ip.bind` is
+    unset, which makes them unreachable across the network in any
+    multi-host deploy. Plan picks `0.0.0.0` for v4 hosts and `::`
+    for v6 hosts (so IPv6-only inventories don't refuse to bind);
+    DNS-name hosts that don't parse as either family fall back to
+    the v4 wildcard. Operators on multi-NIC hosts that need to
+    bind a specific interface hand-edit the field, and merge runs
+    preserve the override. Hand-written specs that omit
+    `ip.bind:` keep the upstream 127.0.0.1 default — plan doesn't
+    reach into specs it didn't generate.
 
 ## Open questions
 

--- a/pkg/cluster/plan/generate.go
+++ b/pkg/cluster/plan/generate.go
@@ -350,7 +350,7 @@ const DefaultIpBindV6 = "::"
 // the box on both v4 and v6 single-stack networks.
 func defaultIpBindFor(ip string) string {
 	parsed := net.ParseIP(ip)
-	if parsed != nil && parsed.To4() == nil && parsed.To16() != nil {
+	if parsed != nil && parsed.To4() == nil {
 		return DefaultIpBindV6
 	}
 	return DefaultIpBind

--- a/pkg/cluster/plan/generate.go
+++ b/pkg/cluster/plan/generate.go
@@ -322,23 +322,45 @@ func sshTargetKey(ip string, port int) string {
 
 // --- per-role constructors ------------------------------------------------
 
-// DefaultIpBind is the value plan synthesis stamps on every inbound
-// role's `ip.bind` field (master, volume, filer, s3, sftp, admin).
-// SeaweedFS components default to binding 127.0.0.1 when -ip.bind is
-// unset, which leaves them unreachable across the network in any
+// DefaultIpBind is the IPv4 wildcard bind plan synthesis falls back
+// to when the host's declared IP isn't a v6 literal. SeaweedFS
+// components default to binding 127.0.0.1 when -ip.bind is unset,
+// which leaves them unreachable across the network in any
 // multi-host deploy — peer masters can't form raft quorum, volumes
 // can't register with masters, filers can't be reached by S3 or
-// clients. Operators with a multi-NIC host who need bind to a
+// clients. Operators with a multi-NIC host who need to bind a
 // specific NIC override per-host in the generated cluster.yaml;
 // hand-written specs keep whatever IpBind they declared (or weed's
 // own default when omitted).
 const DefaultIpBind = "0.0.0.0"
 
+// DefaultIpBindV6 is the v6 counterpart. Bound on IPv6-only hosts
+// where 0.0.0.0 would refuse to bind. On dual-stack Linux this
+// also accepts v4 traffic (default net.ipv6.bindv6only=0), but
+// we don't switch every host to "::" because that would hide v4
+// bind failures on hosts where the operator intentionally wants v4
+// only.
+const DefaultIpBindV6 = "::"
+
+// defaultIpBindFor returns the wildcard bind address appropriate
+// for the host's declared IP family. v6-only hosts get "::" so
+// SeaweedFS doesn't refuse to bind 0.0.0.0; v4 and DNS-name hosts
+// (which we can't classify confidently) get "0.0.0.0", the safer
+// default. Net effect: a planner-emitted cluster.yaml works out of
+// the box on both v4 and v6 single-stack networks.
+func defaultIpBindFor(ip string) string {
+	parsed := net.ParseIP(ip)
+	if parsed != nil && parsed.To4() == nil && parsed.To16() != nil {
+		return DefaultIpBindV6
+	}
+	return DefaultIpBind
+}
+
 func newMasterSpec(h *inventory.Host, ssh inventory.SSHConfig) *spec.MasterServerSpec {
 	return &spec.MasterServerSpec{
 		Ip:       h.IP,
 		PortSsh:  ssh.Port,
-		IpBind:   DefaultIpBind,
+		IpBind:   defaultIpBindFor(h.IP),
 		Port:     DefaultMasterPort,
 		PortGrpc: DefaultMasterGrpcPort,
 	}
@@ -348,7 +370,7 @@ func newVolumeSpec(h *inventory.Host, ssh inventory.SSHConfig, folders []*spec.F
 	return &spec.VolumeServerSpec{
 		Ip:         h.IP,
 		PortSsh:    ssh.Port,
-		IpBind:     DefaultIpBind,
+		IpBind:     defaultIpBindFor(h.IP),
 		Port:       DefaultVolumePort,
 		PortGrpc:   DefaultVolumeGrpcPort,
 		DataCenter: h.Labels["zone"],
@@ -361,7 +383,7 @@ func newFilerSpec(h *inventory.Host, ssh inventory.SSHConfig, backend map[string
 	f := &spec.FilerServerSpec{
 		Ip:         h.IP,
 		PortSsh:    ssh.Port,
-		IpBind:     DefaultIpBind,
+		IpBind:     defaultIpBindFor(h.IP),
 		Port:       DefaultFilerPort,
 		PortGrpc:   DefaultFilerGrpcPort,
 		DataCenter: h.Labels["zone"],
@@ -382,7 +404,7 @@ func newS3Spec(h *inventory.Host, ssh inventory.SSHConfig) *spec.S3ServerSpec {
 	return &spec.S3ServerSpec{
 		Ip:      h.IP,
 		PortSsh: ssh.Port,
-		IpBind:  DefaultIpBind,
+		IpBind:  defaultIpBindFor(h.IP),
 		Port:    DefaultS3Port,
 	}
 }
@@ -391,7 +413,7 @@ func newSftpSpec(h *inventory.Host, ssh inventory.SSHConfig) *spec.SftpServerSpe
 	return &spec.SftpServerSpec{
 		Ip:      h.IP,
 		PortSsh: ssh.Port,
-		IpBind:  DefaultIpBind,
+		IpBind:  defaultIpBindFor(h.IP),
 		Port:    DefaultSftpPort,
 	}
 }
@@ -411,7 +433,7 @@ func newAdminSpec(h *inventory.Host, ssh inventory.SSHConfig) *spec.AdminServerS
 	return &spec.AdminServerSpec{
 		Ip:            h.IP,
 		PortSsh:       ssh.Port,
-		IpBind:        DefaultIpBind,
+		IpBind:        defaultIpBindFor(h.IP),
 		Port:          DefaultAdminPort,
 		AdminUser:     "admin",
 		AdminPassword: AdminPasswordPlaceholder,

--- a/pkg/cluster/plan/generate.go
+++ b/pkg/cluster/plan/generate.go
@@ -322,10 +322,23 @@ func sshTargetKey(ip string, port int) string {
 
 // --- per-role constructors ------------------------------------------------
 
+// DefaultIpBind is the value plan synthesis stamps on every inbound
+// role's `ip.bind` field (master, volume, filer, s3, sftp, admin).
+// SeaweedFS components default to binding 127.0.0.1 when -ip.bind is
+// unset, which leaves them unreachable across the network in any
+// multi-host deploy — peer masters can't form raft quorum, volumes
+// can't register with masters, filers can't be reached by S3 or
+// clients. Operators with a multi-NIC host who need bind to a
+// specific NIC override per-host in the generated cluster.yaml;
+// hand-written specs keep whatever IpBind they declared (or weed's
+// own default when omitted).
+const DefaultIpBind = "0.0.0.0"
+
 func newMasterSpec(h *inventory.Host, ssh inventory.SSHConfig) *spec.MasterServerSpec {
 	return &spec.MasterServerSpec{
 		Ip:       h.IP,
 		PortSsh:  ssh.Port,
+		IpBind:   DefaultIpBind,
 		Port:     DefaultMasterPort,
 		PortGrpc: DefaultMasterGrpcPort,
 	}
@@ -335,6 +348,7 @@ func newVolumeSpec(h *inventory.Host, ssh inventory.SSHConfig, folders []*spec.F
 	return &spec.VolumeServerSpec{
 		Ip:         h.IP,
 		PortSsh:    ssh.Port,
+		IpBind:     DefaultIpBind,
 		Port:       DefaultVolumePort,
 		PortGrpc:   DefaultVolumeGrpcPort,
 		DataCenter: h.Labels["zone"],
@@ -347,6 +361,7 @@ func newFilerSpec(h *inventory.Host, ssh inventory.SSHConfig, backend map[string
 	f := &spec.FilerServerSpec{
 		Ip:         h.IP,
 		PortSsh:    ssh.Port,
+		IpBind:     DefaultIpBind,
 		Port:       DefaultFilerPort,
 		PortGrpc:   DefaultFilerGrpcPort,
 		DataCenter: h.Labels["zone"],
@@ -367,6 +382,7 @@ func newS3Spec(h *inventory.Host, ssh inventory.SSHConfig) *spec.S3ServerSpec {
 	return &spec.S3ServerSpec{
 		Ip:      h.IP,
 		PortSsh: ssh.Port,
+		IpBind:  DefaultIpBind,
 		Port:    DefaultS3Port,
 	}
 }
@@ -375,6 +391,7 @@ func newSftpSpec(h *inventory.Host, ssh inventory.SSHConfig) *spec.SftpServerSpe
 	return &spec.SftpServerSpec{
 		Ip:      h.IP,
 		PortSsh: ssh.Port,
+		IpBind:  DefaultIpBind,
 		Port:    DefaultSftpPort,
 	}
 }
@@ -394,6 +411,7 @@ func newAdminSpec(h *inventory.Host, ssh inventory.SSHConfig) *spec.AdminServerS
 	return &spec.AdminServerSpec{
 		Ip:            h.IP,
 		PortSsh:       ssh.Port,
+		IpBind:        DefaultIpBind,
 		Port:          DefaultAdminPort,
 		AdminUser:     "admin",
 		AdminPassword: AdminPasswordPlaceholder,

--- a/pkg/cluster/plan/generate_test.go
+++ b/pkg/cluster/plan/generate_test.go
@@ -342,6 +342,52 @@ func TestGenerate_hostWithProbeErrorIsSkippedEntirely(t *testing.T) {
 	}
 }
 
+// TestGenerate_stampsIpBindOnInboundRoles pins the
+// ip.bind=DefaultIpBind default. SeaweedFS components default to
+// binding 127.0.0.1 when -ip.bind is unset, which makes them
+// unreachable across the network in any multi-host deploy. Plan
+// stamps "0.0.0.0" on every role that accepts inbound connections
+// (master, volume, filer, s3, sftp, admin) so the rendered
+// cluster.yaml is reachable out of the box.
+func TestGenerate_stampsIpBindOnInboundRoles(t *testing.T) {
+	inv := &inventory.Inventory{
+		Hosts: []inventory.Host{
+			{IP: "10.0.0.11", Roles: []string{"master"}},
+			{IP: "10.0.0.21", Roles: []string{"volume"}},
+			{IP: "10.0.0.22", Roles: []string{"filer"}},
+			{IP: "10.0.0.31", Roles: []string{"s3"}},
+			{IP: "10.0.0.32", Roles: []string{"sftp"}},
+			{IP: "10.0.0.41", Roles: []string{"admin"}},
+		},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Fatalf("inventory.Validate: %v", err)
+	}
+	facts := map[string]probe.HostFacts{
+		"10.0.0.21:22": {IP: "10.0.0.21", SSHPort: 22, Disks: synthesizeDisks(1, 100)},
+	}
+	spec, _, err := Generate(inv, facts, Options{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	checks := []struct {
+		role string
+		got  string
+	}{
+		{"master", spec.MasterServers[0].IpBind},
+		{"volume", spec.VolumeServers[0].IpBind},
+		{"filer", spec.FilerServers[0].IpBind},
+		{"s3", spec.S3Servers[0].IpBind},
+		{"sftp", spec.SftpServers[0].IpBind},
+		{"admin", spec.AdminServers[0].IpBind},
+	}
+	for _, c := range checks {
+		if c.got != DefaultIpBind {
+			t.Errorf("%s.IpBind = %q, want %q", c.role, c.got, DefaultIpBind)
+		}
+	}
+}
+
 func TestGenerate_adminGetsChangeMePlaceholders(t *testing.T) {
 	// admin_servers require admin_user / admin_password. Leaving them
 	// empty starts the admin UI unauthenticated because

--- a/pkg/cluster/plan/generate_test.go
+++ b/pkg/cluster/plan/generate_test.go
@@ -388,6 +388,61 @@ func TestGenerate_stampsIpBindOnInboundRoles(t *testing.T) {
 	}
 }
 
+// TestGenerate_stampsIpBindV6OnIPv6Hosts: the per-family bind
+// helper picks "::" for v6-only inventory hosts so SeaweedFS
+// doesn't refuse to bind 0.0.0.0 on a v6-only network. Mixed-family
+// inventories produce a per-host result.
+func TestGenerate_stampsIpBindV6OnIPv6Hosts(t *testing.T) {
+	inv := &inventory.Inventory{
+		Hosts: []inventory.Host{
+			{IP: "10.0.0.11", Roles: []string{"master"}},
+			{IP: "2001:db8::1", Roles: []string{"master"}},
+			{IP: "fd00:abcd::5", Roles: []string{"filer"}},
+		},
+	}
+	if err := inv.Validate(); err != nil {
+		t.Fatalf("inventory.Validate: %v", err)
+	}
+	spec, _, err := Generate(inv, nil, Options{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if got := spec.MasterServers[0].IpBind; got != DefaultIpBind {
+		t.Errorf("v4 master.IpBind = %q, want %q", got, DefaultIpBind)
+	}
+	if got := spec.MasterServers[1].IpBind; got != DefaultIpBindV6 {
+		t.Errorf("v6 master.IpBind = %q, want %q", got, DefaultIpBindV6)
+	}
+	if got := spec.FilerServers[0].IpBind; got != DefaultIpBindV6 {
+		t.Errorf("v6 filer.IpBind = %q, want %q", got, DefaultIpBindV6)
+	}
+}
+
+// TestDefaultIpBindFor covers the family-detection helper directly:
+// v4 / v6 / DNS-name / unparseable inputs.
+func TestDefaultIpBindFor(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"10.0.0.11", DefaultIpBind},
+		{"127.0.0.1", DefaultIpBind},
+		{"2001:db8::1", DefaultIpBindV6},
+		{"::1", DefaultIpBindV6},
+		{"fd00:abcd::5", DefaultIpBindV6},
+		// DNS-name and unparseable strings fall back to v4 — we
+		// can't classify the bind family confidently, and v4 is
+		// the safer "definitely fails on v6-only" default.
+		{"db.internal", DefaultIpBind},
+		{"", DefaultIpBind},
+		{"not-an-ip", DefaultIpBind},
+	}
+	for _, tc := range cases {
+		if got := defaultIpBindFor(tc.in); got != tc.want {
+			t.Errorf("defaultIpBindFor(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestGenerate_adminGetsChangeMePlaceholders(t *testing.T) {
 	// admin_servers require admin_user / admin_password. Leaving them
 	// empty starts the admin UI unauthenticated because

--- a/pkg/cluster/plan/testdata/mixed_five.cluster.yaml
+++ b/pkg/cluster/plan/testdata/mixed_five.cluster.yaml
@@ -12,11 +12,13 @@ global:
 master_servers:
     - ip: 10.0.0.11
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 9333
       port.grpc: 19333
 volume_servers:
     - ip: 10.0.0.21
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8080
       port.grpc: 18080
       folders:
@@ -28,6 +30,7 @@ volume_servers:
           max: 102
     - ip: 10.0.0.22
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8080
       port.grpc: 18080
       folders:
@@ -40,6 +43,7 @@ volume_servers:
 filer_servers:
     - ip: 10.0.0.11
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8888
       port.grpc: 18888
       config:
@@ -53,5 +57,6 @@ filer_servers:
 s3_servers:
     - ip: 10.0.0.31
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8333
       filer: 10.0.0.11:8888

--- a/pkg/cluster/plan/testdata/one_host_dev.cluster.yaml
+++ b/pkg/cluster/plan/testdata/one_host_dev.cluster.yaml
@@ -15,11 +15,13 @@ global:
 master_servers:
     - ip: 10.0.0.1
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 9333
       port.grpc: 19333
 volume_servers:
     - ip: 10.0.0.1
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8080
       port.grpc: 18080
       folders:
@@ -29,5 +31,6 @@ volume_servers:
 filer_servers:
     - ip: 10.0.0.1
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8888
       port.grpc: 18888

--- a/pkg/cluster/plan/testdata/three_three_three.cluster.yaml
+++ b/pkg/cluster/plan/testdata/three_three_three.cluster.yaml
@@ -15,19 +15,23 @@ global:
 master_servers:
     - ip: 10.0.0.11
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 9333
       port.grpc: 19333
     - ip: 10.0.0.12
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 9333
       port.grpc: 19333
     - ip: 10.0.0.13
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 9333
       port.grpc: 19333
 volume_servers:
     - ip: 10.0.0.21
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8080
       port.grpc: 18080
       folders:
@@ -47,6 +51,7 @@ volume_servers:
       rack: r1
     - ip: 10.0.0.22
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8080
       port.grpc: 18080
       folders:
@@ -66,6 +71,7 @@ volume_servers:
       rack: r2
     - ip: 10.0.0.23
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8080
       port.grpc: 18080
       folders:
@@ -86,18 +92,21 @@ volume_servers:
 filer_servers:
     - ip: 10.0.0.11
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8888
       port.grpc: 18888
       dataCenter: a
       rack: r1
     - ip: 10.0.0.12
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8888
       port.grpc: 18888
       dataCenter: b
       rack: r2
     - ip: 10.0.0.13
       port.ssh: 22
+      ip.bind: 0.0.0.0
       port: 8888
       port.grpc: 18888
       dataCenter: c


### PR DESCRIPTION
## Summary

SeaweedFS's ` + "`weed master`" + `/` + "`volume`" + `/` + "`filer`" + `/` + "`s3`" + `/` + "`sftp`" + `/` + "`admin`" + ` all bind ` + "`127.0.0.1`" + ` when ` + "`-ip.bind`" + ` is unset, which makes them unreachable across the network in any multi-host deploy. The Docker walkthrough I ran a couple of turns ago reproduced this — masters listened on ` + "`127.0.0.1:9333`" + ` and the controller container couldn't reach them across the bridge network.

Plan synthesis now stamps ` + "`ip.bind: 0.0.0.0`" + ` on every inbound role's spec entry so the generated ` + "`cluster.yaml`" + ` works out of the box. Operators on multi-NIC hosts that need a specific interface hand-edit the field, and merge runs preserve the override (existing byte-stability guarantee).

Hand-written specs that omit ` + "`ip.bind:`" + ` keep upstream's 127.0.0.1 default — plan doesn't reach into specs it didn't generate.

## Implementation

- New ` + "`DefaultIpBind = \"0.0.0.0\"`" + ` constant in ` + "`pkg/cluster/plan`" + `, threaded through ` + "`newMasterSpec`" + ` / ` + "`newVolumeSpec`" + ` / ` + "`newFilerSpec`" + ` / ` + "`newS3Spec`" + ` / ` + "`newSftpSpec`" + ` / ` + "`newAdminSpec`" + `.
- Worker and envoy don't accept inbound traffic in the same way and don't carry an ` + "`IpBind`" + ` field, so they're skipped.
- ` + "`TestGenerate_stampsIpBindOnInboundRoles`" + ` pins the default across all six roles.
- Existing golden files regenerated.

## Test plan

- [x] ` + "`TestGenerate_stampsIpBindOnInboundRoles`" + ` (new)
- [x] Three golden files refreshed with the new ` + "`ip.bind: 0.0.0.0`" + ` lines under each emitted entry
- [x] ` + "`go build -tags=integration ./...`" + `, ` + "`go vet -tags=integration ./...`" + `, ` + "`go test ./...`" + ` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where SeaweedFS services were unreachable in multi-host deployments by ensuring generated cluster configurations explicitly bind to all network interfaces instead of defaulting to localhost-only binding.

* **Documentation**
  * Updated specifications to clarify network binding behavior for auto-generated and manually authored cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->