### PR TITLE
fix: aggregate security.toml + volume errors instead of fail-fast

### DIFF
--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -254,15 +254,20 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	// when TLS is enabled (cluster cert init already wrote security.toml
 	// with both [grpc.*] and [jwt.filer_signing*]).
 	//
-	// Failure here aborts the deploy: starting filer pods without the
-	// JWT key would silently leave the Admin UI Users tab broken in
-	// exactly the same way the fix is meant to prevent.
+	// Failure here skips the filer goroutines: starting filer pods
+	// without the JWT key would silently leave the Admin UI Users tab
+	// broken in exactly the same way the fix is meant to prevent. The
+	// error is recorded and aggregated with any volume errgroup
+	// failures already in flight so operators see every host that
+	// went wrong, not just the first.
+	var securityErr error
 	if m.shouldInstall("filer") || m.shouldInstall("admin") {
 		if err := m.EnsureSecurityToml(specification); err != nil {
-			return err
+			securityErr = err
+			recordErr(err)
 		}
 	}
-	if m.shouldInstall("filer") {
+	if m.shouldInstall("filer") && securityErr == nil {
 		for index, filerSpec := range specification.FilerServers {
 			eg.Go(func() error {
 				if err := m.DeployFilerServer(masters, filerSpec, index); err != nil {

--- a/pkg/cluster/manager/manager_deploy_test.go
+++ b/pkg/cluster/manager/manager_deploy_test.go
@@ -7,6 +7,47 @@ import (
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
 )
 
+// TestDeployCluster_SecurityTomlFailureSkipsFilers locks in the contract
+// from the integration suite's TestDeployErrorAggregation at the unit
+// level: when EnsureSecurityToml fails, DeployCluster must
+//
+//  1. NOT start the filer goroutines (otherwise filer pods boot without
+//     the JWT signing key and silently break the Admin UI Users tab —
+//     the exact failure mode the security.toml install was added to
+//     prevent), and
+//  2. still return the security.toml error to the caller via the
+//     aggregated-error path, so operators see what went wrong.
+//
+// We drive (1) and (2) with Name="" — EnsureSecurityToml's loud
+// pre-SSH guard for a missing cluster name. The filer IP is a
+// non-routable RFC 6890 reserved address so that if branch (1)
+// regressed and the filer goroutine actually ran, the error would
+// mention "deploy filer server <ip>" instead of the JWT message.
+func TestDeployCluster_SecurityTomlFailureSkipsFilers(t *testing.T) {
+	m := NewManager()
+	m.User = "root" // skip sudo password prompt in m.prepare
+	m.ComponentToDeploy = "filer"
+	sp := &spec.Specification{
+		Name: "", // forces EnsureSecurityToml to fail before SSH
+		FilerServers: []*spec.FilerServerSpec{
+			{Ip: "240.0.0.1", Port: 8888, PortSsh: 22},
+		},
+	}
+	err := m.DeployCluster(sp)
+	if err == nil {
+		t.Fatal("expected DeployCluster to fail when EnsureSecurityToml fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "jwt") {
+		t.Errorf("error should surface the EnsureSecurityToml JWT failure, got: %v", err)
+	}
+	// Hard guardrail for the safety goal: the filer goroutine must not
+	// have run. If it had, DeployFilerServer would wrap its SSH failure
+	// as "deploy filer server <ip>:<port>: ...".
+	if strings.Contains(err.Error(), "deploy filer server") {
+		t.Errorf("filer goroutine must not run after EnsureSecurityToml fails, got: %v", err)
+	}
+}
+
 func TestValidateSingleAdminServer_zeroOrOneOK(t *testing.T) {
 	// Zero admins: cluster runs without the admin UI. Allowed.
 	if err := validateSingleAdminServer(&spec.Specification{}); err != nil {


### PR DESCRIPTION
## Summary
- The recent fail-fast change to `EnsureSecurityToml` (3e38806) made `DeployCluster` `return err` immediately, abandoning the volume errgroup goroutines that had already been kicked off. Only the security.toml host appeared in the combined error.
- `TestDeployErrorAggregation` ([CI run](https://github.com/seaweedfs/seaweed-up/actions/runs/25904415709/job/76134739187)) caught this: it stops sshd on both the volume and filer hosts and asserts both IPs appear in the deploy error.
- Fix: on `EnsureSecurityToml` failure, record the error via `recordErr` and skip the filer goroutines, then fall through to the existing `eg.Wait()` so volume failures get joined into the same aggregated return. The original safety goal — never start a filer pod without the JWT signing key — is preserved by the `securityErr == nil` guard on the filer fan-out.

## Test plan
- [x] `go test ./pkg/cluster/manager/` — new `TestDeployCluster_SecurityTomlFailureSkipsFilers` plus the existing suite pass locally.
- [ ] CI: `TestDeployErrorAggregation` in the integration-harness workflow goes green (requires Linux runner; can't be reproduced on macOS because Docker bridge IPs aren't routable from the host).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during cluster deployment so security configuration failures no longer halt the entire process. Dependent components are properly skipped when prerequisites fail, while operators receive comprehensive error reporting.

* **Tests**
  * Added test coverage for security configuration failure scenarios in deployment workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweed-up/pull/81)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->