### PR TITLE
Add SSH bastion / jump host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ seaweed-up cluster deploy -f cluster.yaml --component=worker
 Supported `--component` values:
 `master`, `volume`, `filer`, `s3`, `sftp`, `envoy`, `admin`, `worker`.
 
+## Bastion / jump host
+
+When the cluster nodes only have private addresses reachable through a
+public jump host (the classic `ssh bastion` then `ssh 10.0.0.x` pattern),
+declare the bastion under `global.bastion`. Every connection — deploy,
+preflight, lifecycle, upgrade, prepare — is tunnelled through it, so you
+can run `seaweed-up` from your laptop:
+
+```yaml
+global:
+  bastion:
+    host: 203.0.113.10      # public jump host; "host" or "host:port"
+    user: chris             # optional, defaults to the current OS user
+    identity: ~/.ssh/id_rsa # optional, falls back to the ssh agent
+    port: 22                # optional, defaults to 22
+```
+
+The `master_servers` / `volume_servers` IPs are then the private addresses
+as seen *from the bastion*. The `--user` / `--identity` flags still apply
+to the nodes themselves; the `bastion:` block holds the jump host's own
+credentials. Omit the block for direct connections.
+
 ## Lifecycle
 
 Start, stop, or restart every service in the cluster, or scope the operation

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -1231,7 +1231,35 @@ func resolveSpec(args []string, cfgFile string) (*spec.Specification, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load cluster %q: %w", name, err)
 	}
+	// State-store loads bypass loadClusterSpec, so install the bastion
+	// here too — otherwise name-based commands (e.g. `cluster upgrade
+	// <name>` without -f) would ignore global.bastion and try to reach
+	// private nodes directly.
+	applyBastionFromSpec(sp)
 	return sp, nil
+}
+
+// applyBastionFromSpec installs (or clears) the process-wide SSH jump
+// host from a spec's global.bastion, so every subsequent ExecuteRemote —
+// deploy, preflight, lifecycle, upgrade, prepare — tunnels through it.
+// Called from every spec-resolution path (both -f file loads and
+// state-store loads) so bastion routing is uniform however the spec was
+// obtained.
+func applyBastionFromSpec(s *spec.Specification) {
+	if s == nil {
+		return
+	}
+	if b := s.GlobalOptions.Bastion; b != nil && b.Host != "" {
+		operator.SetBastion(&operator.BastionConfig{
+			Host:     b.Host,
+			Port:     b.Port,
+			User:     b.User,
+			Identity: b.Identity,
+			Password: b.Password,
+		})
+		return
+	}
+	operator.SetBastion(nil)
 }
 
 func loadClusterSpec(configFile string) (*spec.Specification, error) {
@@ -1255,27 +1283,15 @@ func loadClusterSpec(configFile string) (*spec.Specification, error) {
 	}
 
 	// Install (or clear) the SSH jump host declared in global.bastion so
-	// every subsequent ExecuteRemote — deploy, preflight, lifecycle,
-	// upgrade, prepare — tunnels through it. Done here, the single point
-	// all `-f cluster.yaml` commands load through, so bastion support is
-	// uniform across the CLI.
-	if b := clusterSpec.GlobalOptions.Bastion; b != nil && b.Host != "" {
-		operator.SetBastion(&operator.BastionConfig{
-			Host:     b.Host,
-			Port:     b.Port,
-			User:     b.User,
-			Identity: b.Identity,
-			Password: b.Password,
-		})
-	} else {
-		operator.SetBastion(nil)
-	}
+	// every subsequent ExecuteRemote tunnels through it. resolveSpec's
+	// state-store branch calls the same helper for name-based commands.
+	applyBastionFromSpec(clusterSpec)
 
 	return clusterSpec, nil
 }
 
 // shellSingleQuote safely wraps s for use as a single-quoted shell argument.
-// Any embedded single quote is escaped as '\'' (close-quote, literal quote,
+// Any embedded single quote is escaped as '\” (close-quote, literal quote,
 // reopen-quote). Duplicated from pkg/cluster/manager/manager_lifecycle.go to
 // avoid introducing an import cycle between cmd and manager.
 func shellSingleQuote(s string) string {

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -118,18 +118,18 @@ type ClusterListOptions struct {
 
 func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOptions) error {
 	color.Green("Deploying SeaweedFS cluster...")
-	
+
 	// Load cluster specification
 	clusterSpec, err := loadClusterSpec(opts.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to load cluster configuration: %w", err)
 	}
-	
+
 	// Set cluster name from args if provided
 	if len(args) > 0 {
 		clusterSpec.Name = args[0]
 	}
-	
+
 	// Create cluster manager
 	mgr := manager.NewManager()
 	mgr.SshPort = opts.SSHPort
@@ -189,7 +189,7 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 	} else {
 		mgr.User = opts.User
 	}
-	
+
 	// Default identity file to ~/.ssh/id_rsa if not specified
 	if opts.IdentityFile == "" {
 		home, err := utils.UserHome()
@@ -200,7 +200,7 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 	} else {
 		mgr.IdentityFile = opts.IdentityFile
 	}
-	
+
 	// Run preflight checks first if requested
 	if opts.Check {
 		color.Cyan("Running preflight checks...")
@@ -298,7 +298,7 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 	color.Cyan("Next steps:")
 	fmt.Println("  - Check cluster status: seaweed-up cluster status", clusterSpec.Name)
 	fmt.Println("  - View logs: seaweed-up cluster logs", clusterSpec.Name)
-	
+
 	return nil
 }
 
@@ -754,17 +754,17 @@ func newUpgradeHTTPTransport(insecureSkipTLSVerify bool, clusterName string) *ht
 
 func runClusterScaleOut(clusterName string, opts *ClusterScaleOutOptions) error {
 	color.Green("Scaling out cluster: %s", clusterName)
-	
+
 	if opts.AddVolume > 0 {
 		fmt.Printf("Adding %d volume servers\n", opts.AddVolume)
 	}
 	if opts.AddFiler > 0 {
 		fmt.Printf("Adding %d filer servers\n", opts.AddFiler)
 	}
-	
+
 	// TODO: Implement scale out logic
 	fmt.Println("Scale out functionality not yet implemented")
-	
+
 	return nil
 }
 
@@ -1252,6 +1252,23 @@ func loadClusterSpec(configFile string) (*spec.Specification, error) {
 	// Validate the specification
 	if err := clusterSpec.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid cluster specification: %w", err)
+	}
+
+	// Install (or clear) the SSH jump host declared in global.bastion so
+	// every subsequent ExecuteRemote — deploy, preflight, lifecycle,
+	// upgrade, prepare — tunnels through it. Done here, the single point
+	// all `-f cluster.yaml` commands load through, so bastion support is
+	// uniform across the CLI.
+	if b := clusterSpec.GlobalOptions.Bastion; b != nil && b.Host != "" {
+		operator.SetBastion(&operator.BastionConfig{
+			Host:     b.Host,
+			Port:     b.Port,
+			User:     b.User,
+			Identity: b.Identity,
+			Password: b.Password,
+		})
+	} else {
+		operator.SetBastion(nil)
 	}
 
 	return clusterSpec, nil

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -1,6 +1,9 @@
 package spec
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type (
 	// GlobalOptions represents the global options for all groups in topology
@@ -21,7 +24,9 @@ type (
 	// `ssh bastion` then `ssh 10.0.0.x` pattern). All fields except host
 	// are optional: user defaults to the current OS user, port to 22,
 	// and auth falls back to the ssh agent when identity and password
-	// are both unset.
+	// are both unset. Prefer identity/agent auth: like the other
+	// credentials in this spec (e.g. admin_password, filer DB password),
+	// Password is persisted in plaintext when the cluster state is saved.
 	BastionSpec struct {
 		Host     string `yaml:"host"`
 		Port     int    `yaml:"port,omitempty"`
@@ -64,6 +69,19 @@ func (s *Specification) Validate() error {
 
 	// Name is optional but validated if provided
 	// The Name can be set from command line args if not in config
+
+	// A configured bastion must at least name a host, and (if given) a
+	// sane port — otherwise the misconfiguration only surfaces later as
+	// an opaque SSH dial error. Port 0 is allowed: it means "unset", and
+	// the operator defaults it to 22.
+	if b := s.GlobalOptions.Bastion; b != nil {
+		if strings.TrimSpace(b.Host) == "" {
+			return fmt.Errorf("global.bastion.host is required when a bastion is configured")
+		}
+		if b.Port < 0 || b.Port > 65535 {
+			return fmt.Errorf("global.bastion.port %d is out of range (0-65535)", b.Port)
+		}
+	}
 
 	return nil
 }

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -6,12 +6,28 @@ type (
 	// GlobalOptions represents the global options for all groups in topology
 	// specification in topology.yaml
 	GlobalOptions struct {
-		TLSEnabled        bool   `yaml:"enable_tls,omitempty"`
-		ConfigDir         string `yaml:"dir.conf,omitempty" default:"/etc/seaweed"`
-		DataDir           string `yaml:"dir.data,omitempty" default:"/opt/seaweed"`
-		OS                string `yaml:"os,omitempty" default:"linux"`
-		VolumeSizeLimitMB int    `yaml:"volumeSizeLimitMB" default:"5000"`
-		Replication       string `yaml:"replication" default:"000"`
+		TLSEnabled        bool         `yaml:"enable_tls,omitempty"`
+		ConfigDir         string       `yaml:"dir.conf,omitempty" default:"/etc/seaweed"`
+		DataDir           string       `yaml:"dir.data,omitempty" default:"/opt/seaweed"`
+		OS                string       `yaml:"os,omitempty" default:"linux"`
+		VolumeSizeLimitMB int          `yaml:"volumeSizeLimitMB" default:"5000"`
+		Replication       string       `yaml:"replication" default:"000"`
+		Bastion           *BastionSpec `yaml:"bastion,omitempty"`
+	}
+
+	// BastionSpec configures an SSH jump host that seaweed-up tunnels
+	// every node connection through. Use it when the cluster nodes live
+	// on a private network reachable only via a public bastion (the
+	// `ssh bastion` then `ssh 10.0.0.x` pattern). All fields except host
+	// are optional: user defaults to the current OS user, port to 22,
+	// and auth falls back to the ssh agent when identity and password
+	// are both unset.
+	BastionSpec struct {
+		Host     string `yaml:"host"`
+		Port     int    `yaml:"port,omitempty"`
+		User     string `yaml:"user,omitempty"`
+		Identity string `yaml:"identity,omitempty"`
+		Password string `yaml:"password,omitempty"`
 	}
 
 	ServerConfigs struct {
@@ -21,9 +37,9 @@ type (
 	}
 
 	Specification struct {
-		Name          string              `yaml:"cluster_name,omitempty"`
-		GlobalOptions GlobalOptions       `yaml:"global,omitempty" validate:"global:editable"`
-		ServerConfigs ServerConfigs       `yaml:"server_configs,omitempty" validate:"server_configs:ignore"`
+		Name          string        `yaml:"cluster_name,omitempty"`
+		GlobalOptions GlobalOptions `yaml:"global,omitempty" validate:"global:editable"`
+		ServerConfigs ServerConfigs `yaml:"server_configs,omitempty" validate:"server_configs:ignore"`
 		// master_servers is required (Validate refuses a spec without
 		// one); everything else is optional. omitempty on the optional
 		// sections keeps generated cluster.yaml files tidy — no

--- a/pkg/cluster/spec/spec_test.go
+++ b/pkg/cluster/spec/spec_test.go
@@ -1,0 +1,36 @@
+package spec
+
+import "testing"
+
+func masterOnly() []*MasterServerSpec {
+	return []*MasterServerSpec{{Ip: "10.0.0.1", Port: 9333}}
+}
+
+func TestValidate_Bastion(t *testing.T) {
+	cases := []struct {
+		name    string
+		bastion *BastionSpec
+		wantErr bool
+	}{
+		{"no bastion", nil, false},
+		{"valid host+port", &BastionSpec{Host: "192.71.171.132", Port: 22}, false},
+		{"port unset is allowed (defaults to 22)", &BastionSpec{Host: "bastion"}, false},
+		{"blank host", &BastionSpec{Host: "   "}, true},
+		{"empty host", &BastionSpec{Host: "", Port: 22}, true},
+		{"negative port", &BastionSpec{Host: "bastion", Port: -1}, true},
+		{"port too large", &BastionSpec{Host: "bastion", Port: 70000}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Specification{MasterServers: masterOnly()}
+			s.GlobalOptions.Bastion = tc.bastion
+			err := s.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/user"
+	"strconv"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
@@ -29,69 +31,107 @@ type CommandOperator interface {
 
 type Callback func(CommandOperator) error
 
+// BastionConfig describes an SSH jump host. When one is installed via
+// SetBastion, every ExecuteRemote connection is dialed *through* the
+// bastion instead of connecting to the target directly — the standard
+// "ssh bastion, then ssh 10.0.0.x" topology for nodes that only have
+// private addresses.
+type BastionConfig struct {
+	Host     string // bastion address, "host" or "host:port"
+	Port     int    // ssh port; 0 means 22 (ignored if Host carries a port)
+	User     string // ssh user; empty means the current OS user
+	Identity string // private key path; empty falls back to the ssh agent
+	Password string // optional password auth
+}
+
+// defaultBastion, when non-nil, routes all ExecuteRemote connections
+// through the configured jump host. It is set once at command start
+// (from global.bastion in cluster.yaml, via SetBastion) before any
+// concurrent fan-out and only read afterwards, so the deploy errgroup
+// shares it safely.
+var defaultBastion *BastionConfig
+
+// SetBastion installs the process-wide jump host. Passing nil, or a
+// config with an empty Host, clears it (direct connections).
+func SetBastion(b *BastionConfig) {
+	if b != nil && b.Host == "" {
+		b = nil
+	}
+	defaultBastion = b
+}
+
 func ExecuteLocal(callback Callback) error {
 	return callback(NewLocalOperator())
 }
 
 func ExecuteRemote(host string, user string, privateKey string, password string, callback Callback) error {
-	var method ssh.AuthMethod
+	method, cleanup, err := resolveAuthMethod(privateKey, password)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cleanup() }()
+
+	return executeRemote(host, user, method, callback)
+}
+
+// resolveAuthMethod builds an ssh.AuthMethod from a password, a private
+// key file, or — when both are empty — the ssh agent. The returned
+// cleanup closes any ssh-agent socket opened while resolving the method;
+// it is never nil and is always safe to call.
+func resolveAuthMethod(privateKey, password string) (ssh.AuthMethod, func() error, error) {
+	noop := func() error { return nil }
 
 	if password != "" {
-		method = ssh.Password(password)
-	} else if privateKey == "" {
+		return ssh.Password(password), noop, nil
+	}
+
+	if privateKey == "" {
 		// #nosec G704
 		sshAgentConn, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
-
 		if err != nil {
-			return NewSshAgentError(err)
+			return nil, noop, NewSshAgentError(err)
 		}
-
-		defer sshAgentConn.Close()
 
 		client := agent.NewClient(sshAgentConn)
 		list, err := client.List()
-
 		if err != nil || len(list) == 0 {
-			return NewSshAgentError(err)
+			_ = sshAgentConn.Close()
+			return nil, noop, NewSshAgentError(err)
 		}
 
-		method = ssh.PublicKeysCallback(client.Signers)
-	} else {
-		buffer, err := os.ReadFile(expandPath(privateKey))
-		if err != nil {
-			return errors.Wrapf(err, "unable to parse private key: %s", privateKey)
-		}
-
-		key, err := ssh.ParsePrivateKey(buffer)
-
-		if err != nil {
-			if err.Error() != "ssh: this private key is passphrase protected" {
-				return errors.Wrapf(err, "unable to parse private key: %s", privateKey)
-			}
-
-			sshAgent, closeAgent := privateKeyUsingSSHAgent(privateKey + ".pub")
-			defer func() { _ = closeAgent() }()
-
-			if sshAgent != nil {
-				method = sshAgent
-			} else {
-				fmt.Printf("Enter passphrase for '%s': ", privateKey)
-				STDIN := int(os.Stdin.Fd())
-				bytePassword, _ := term.ReadPassword(STDIN)
-				fmt.Println()
-
-				key, err = ssh.ParsePrivateKeyWithPassphrase(buffer, bytePassword)
-				if err != nil {
-					return errors.Wrapf(err, "parse private key with passphrase failed: %s", privateKey)
-				}
-				method = ssh.PublicKeys(key)
-			}
-		} else {
-			method = ssh.PublicKeys(key)
-		}
+		return ssh.PublicKeysCallback(client.Signers), sshAgentConn.Close, nil
 	}
 
-	return executeRemote(host, user, method, callback)
+	buffer, err := os.ReadFile(expandPath(privateKey))
+	if err != nil {
+		return nil, noop, errors.Wrapf(err, "unable to parse private key: %s", privateKey)
+	}
+
+	key, err := ssh.ParsePrivateKey(buffer)
+	if err != nil {
+		if err.Error() != "ssh: this private key is passphrase protected" {
+			return nil, noop, errors.Wrapf(err, "unable to parse private key: %s", privateKey)
+		}
+
+		sshAgent, closeAgent := privateKeyUsingSSHAgent(privateKey + ".pub")
+		if sshAgent != nil {
+			return sshAgent, closeAgent, nil
+		}
+
+		fmt.Printf("Enter passphrase for '%s': ", privateKey)
+		STDIN := int(os.Stdin.Fd())
+		bytePassword, _ := term.ReadPassword(STDIN)
+		fmt.Println()
+
+		key, err = ssh.ParsePrivateKeyWithPassphrase(buffer, bytePassword)
+		if err != nil {
+			_ = closeAgent()
+			return nil, noop, errors.Wrapf(err, "parse private key with passphrase failed: %s", privateKey)
+		}
+		return ssh.PublicKeys(key), closeAgent, nil
+	}
+
+	return ssh.PublicKeys(key), noop, nil
 }
 
 func privateKeyUsingSSHAgent(publicKeyPath string) (ssh.AuthMethod, func() error) {
@@ -135,6 +175,7 @@ func executeRemote(address string, user string, authMethod ssh.AuthMethod, callb
 			return fmt.Errorf("error splitting host/port: %w", err)
 		}
 	}
+	targetAddr := net.JoinHostPort(host, port)
 
 	config := &ssh.ClientConfig{
 		User: user,
@@ -143,7 +184,7 @@ func executeRemote(address string, user string, authMethod ssh.AuthMethod, callb
 		},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
-	operator, err := NewSSHOperator(net.JoinHostPort(host, port), config)
+	operator, err := dialOperator(targetAddr, config)
 
 	if err != nil {
 		return NewTargetConnectError(err)
@@ -152,6 +193,38 @@ func executeRemote(address string, user string, authMethod ssh.AuthMethod, callb
 	defer operator.Close()
 
 	return callback(operator)
+}
+
+// dialOperator connects to targetAddr, routing through the configured
+// bastion when SetBastion has installed one, and connecting directly
+// otherwise.
+func dialOperator(targetAddr string, config *ssh.ClientConfig) (*SSHOperator, error) {
+	if defaultBastion == nil {
+		return NewSSHOperator(targetAddr, config)
+	}
+	return newSSHOperatorViaBastion(defaultBastion, targetAddr, config)
+}
+
+// bastionAddress returns the bastion's "host:port", honoring an explicit
+// port carried in Host, then BastionConfig.Port, then defaulting to 22.
+func bastionAddress(b *BastionConfig) string {
+	if _, _, err := net.SplitHostPort(b.Host); err == nil {
+		return b.Host
+	}
+	port := b.Port
+	if port == 0 {
+		port = 22
+	}
+	return net.JoinHostPort(b.Host, strconv.Itoa(port))
+}
+
+// currentUserName returns the current OS user's login name, or "" if it
+// cannot be determined.
+func currentUserName() string {
+	if u, err := user.Current(); err == nil {
+		return u.Username
+	}
+	return ""
 }
 
 func expandPath(path string) string {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -198,7 +198,8 @@ func resolveAuthMethod(privateKey, password string) (ssh.AuthMethod, func() erro
 
 	key, err := ssh.ParsePrivateKey(buffer)
 	if err != nil {
-		if err.Error() != "ssh: this private key is passphrase protected" {
+		var passphraseMissing *ssh.PassphraseMissingError
+		if !errors.As(err, &passphraseMissing) {
 			return nil, noop, errors.Wrapf(err, "unable to parse private key: %s", privateKey)
 		}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
@@ -44,20 +45,108 @@ type BastionConfig struct {
 	Password string // optional password auth
 }
 
-// defaultBastion, when non-nil, routes all ExecuteRemote connections
-// through the configured jump host. It is set once at command start
-// (from global.bastion in cluster.yaml, via SetBastion) before any
-// concurrent fan-out and only read afterwards, so the deploy errgroup
-// shares it safely.
-var defaultBastion *BastionConfig
+// Jump-host state. defaultBastion, when non-nil, routes all
+// ExecuteRemote connections through the configured jump host. It is set
+// once at command start (from global.bastion in cluster.yaml, via
+// SetBastion) before any concurrent fan-out and only read afterwards.
+//
+// bastionConn caches a SINGLE SSH connection to the jump host that every
+// target tunnel is multiplexed over. Without this, a concurrent fan-out
+// (the deploy errgroup opens one connection per host) would open dozens
+// of simultaneous SSH handshakes to the bastion and trip its sshd
+// MaxStartups limit ("connection reset by peer"). One shared connection,
+// many channels, sidesteps that entirely. *ssh.Client is safe for
+// concurrent Dial/NewSession, so workers share it without further
+// locking once it is established.
+var (
+	defaultBastion *BastionConfig
+
+	bastionMu      sync.Mutex
+	bastionConn    *ssh.Client
+	bastionCleanup func() error
+)
 
 // SetBastion installs the process-wide jump host. Passing nil, or a
-// config with an empty Host, clears it (direct connections).
+// config with an empty Host, clears it (direct connections). Any cached
+// bastion connection is torn down so the next connection re-dials with
+// the new config.
 func SetBastion(b *BastionConfig) {
 	if b != nil && b.Host == "" {
 		b = nil
 	}
+	bastionMu.Lock()
+	defer bastionMu.Unlock()
+	closeBastionLocked()
 	defaultBastion = b
+}
+
+// currentBastion returns the installed jump host (nil for direct
+// connections), reading defaultBastion under the lock so it is safe to
+// call from the concurrent deploy fan-out.
+func currentBastion() *BastionConfig {
+	bastionMu.Lock()
+	defer bastionMu.Unlock()
+	return defaultBastion
+}
+
+// sharedBastionClient returns the process-wide bastion connection,
+// dialing it on first use. Concurrent callers serialize on the first
+// dial and then all receive the same cached client.
+func sharedBastionClient(b *BastionConfig) (*ssh.Client, error) {
+	bastionMu.Lock()
+	defer bastionMu.Unlock()
+
+	if bastionConn != nil {
+		return bastionConn, nil
+	}
+
+	addr := bastionAddress(b)
+	user := b.User
+	if user == "" {
+		user = currentUserName()
+	}
+	method, cleanup, err := resolveAuthMethod(b.Identity, b.Password)
+	if err != nil {
+		return nil, fmt.Errorf("bastion %s auth: %w", addr, err)
+	}
+
+	conn, err := ssh.Dial("tcp", addr, &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{method},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		_ = cleanup()
+		return nil, fmt.Errorf("connect to bastion %s: %w", addr, err)
+	}
+
+	bastionConn = conn
+	bastionCleanup = cleanup
+	return bastionConn, nil
+}
+
+// dropBastion discards the cached bastion connection if it is still the
+// one the caller saw, so a later call re-dials. Used when a tunnel dial
+// fails, which usually means the shared connection has dropped.
+func dropBastion(stale *ssh.Client) {
+	bastionMu.Lock()
+	defer bastionMu.Unlock()
+	if bastionConn == stale {
+		closeBastionLocked()
+	}
+}
+
+// closeBastionLocked tears down the cached bastion connection. Caller
+// must hold bastionMu.
+func closeBastionLocked() {
+	if bastionConn != nil {
+		_ = bastionConn.Close()
+		bastionConn = nil
+	}
+	if bastionCleanup != nil {
+		_ = bastionCleanup()
+		bastionCleanup = nil
+	}
 }
 
 func ExecuteLocal(callback Callback) error {
@@ -117,6 +206,10 @@ func resolveAuthMethod(privateKey, password string) (ssh.AuthMethod, func() erro
 		if sshAgent != nil {
 			return sshAgent, closeAgent, nil
 		}
+		// No matching signer in the agent: close the socket it opened
+		// now rather than holding it idle through the passphrase prompt
+		// and handshake.
+		_ = closeAgent()
 
 		fmt.Printf("Enter passphrase for '%s': ", privateKey)
 		STDIN := int(os.Stdin.Fd())
@@ -125,10 +218,9 @@ func resolveAuthMethod(privateKey, password string) (ssh.AuthMethod, func() erro
 
 		key, err = ssh.ParsePrivateKeyWithPassphrase(buffer, bytePassword)
 		if err != nil {
-			_ = closeAgent()
 			return nil, noop, errors.Wrapf(err, "parse private key with passphrase failed: %s", privateKey)
 		}
-		return ssh.PublicKeys(key), closeAgent, nil
+		return ssh.PublicKeys(key), noop, nil
 	}
 
 	return ssh.PublicKeys(key), noop, nil
@@ -199,10 +291,11 @@ func executeRemote(address string, user string, authMethod ssh.AuthMethod, callb
 // bastion when SetBastion has installed one, and connecting directly
 // otherwise.
 func dialOperator(targetAddr string, config *ssh.ClientConfig) (*SSHOperator, error) {
-	if defaultBastion == nil {
+	b := currentBastion()
+	if b == nil {
 		return NewSSHOperator(targetAddr, config)
 	}
-	return newSSHOperatorViaBastion(defaultBastion, targetAddr, config)
+	return newSSHOperatorViaBastion(b, targetAddr, config)
 }
 
 // bastionAddress returns the bastion's "host:port", honoring an explicit

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -1,0 +1,44 @@
+package operator
+
+import "testing"
+
+func TestBastionAddress(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *BastionConfig
+		want string
+	}{
+		{"host only defaults to 22", &BastionConfig{Host: "192.71.171.132"}, "192.71.171.132:22"},
+		{"explicit port field", &BastionConfig{Host: "192.71.171.132", Port: 2222}, "192.71.171.132:2222"},
+		{"port carried in host wins", &BastionConfig{Host: "192.71.171.132:2200", Port: 2222}, "192.71.171.132:2200"},
+		{"hostname only", &BastionConfig{Host: "bastion.example.com"}, "bastion.example.com:22"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bastionAddress(tc.in); got != tc.want {
+				t.Fatalf("bastionAddress(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetBastion(t *testing.T) {
+	t.Cleanup(func() { SetBastion(nil) }) // don't leak global state into other tests
+
+	SetBastion(&BastionConfig{Host: "192.71.171.132", User: "chris"})
+	if defaultBastion == nil || defaultBastion.Host != "192.71.171.132" {
+		t.Fatalf("SetBastion did not install the jump host: %+v", defaultBastion)
+	}
+
+	// An empty Host means "no bastion" — must clear, not install a broken one.
+	SetBastion(&BastionConfig{Host: ""})
+	if defaultBastion != nil {
+		t.Fatalf("SetBastion with empty host should clear, got %+v", defaultBastion)
+	}
+
+	SetBastion(&BastionConfig{Host: "h"})
+	SetBastion(nil)
+	if defaultBastion != nil {
+		t.Fatalf("SetBastion(nil) should clear, got %+v", defaultBastion)
+	}
+}

--- a/pkg/operator/ssh.go
+++ b/pkg/operator/ssh.go
@@ -31,59 +31,50 @@ func NewSSHOperator(address string, config *ssh.ClientConfig) (*SSHOperator, err
 	return &operator, nil
 }
 
-// newSSHOperatorViaBastion dials targetAddr through a jump host: it opens
-// an SSH connection to the bastion, asks the bastion to open a TCP
-// connection out to the target, then completes the SSH handshake with the
-// target over that tunnel. The result is an ordinary *ssh.Client, so the
-// rest of the operator works unchanged. Close tears the whole chain down.
+// newSSHOperatorViaBastion dials targetAddr through a jump host: it
+// reuses the single shared SSH connection to the bastion, asks the
+// bastion to open a TCP connection out to the target, then completes the
+// SSH handshake with the target over that tunnel. The result is an
+// ordinary *ssh.Client, so the rest of the operator works unchanged.
+//
+// Many target tunnels are multiplexed over the one bastion connection
+// (see sharedBastionClient), so a concurrent fan-out does not flood the
+// bastion's sshd. Close shuts down only this target connection; the
+// shared bastion connection is left up for other tunnels and torn down
+// by SetBastion. If the tunnel dial fails — typically because the shared
+// connection has dropped — the bastion is re-dialed once.
 func newSSHOperatorViaBastion(b *BastionConfig, targetAddr string, config *ssh.ClientConfig) (*SSHOperator, error) {
 	bastionAddr := bastionAddress(b)
-	bastionUser := b.User
-	if bastionUser == "" {
-		bastionUser = currentUserName()
-	}
 
-	method, authCleanup, err := resolveAuthMethod(b.Identity, b.Password)
-	if err != nil {
-		return nil, fmt.Errorf("bastion %s auth: %w", bastionAddr, err)
-	}
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		bastionClient, err := sharedBastionClient(b)
+		if err != nil {
+			return nil, err
+		}
 
-	bastionConfig := &ssh.ClientConfig{
-		User:            bastionUser,
-		Auth:            []ssh.AuthMethod{method},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-	}
+		conn, err := bastionClient.Dial("tcp", targetAddr)
+		if err != nil {
+			// The shared connection is likely dead; drop it so the
+			// next attempt re-dials the bastion from scratch.
+			dropBastion(bastionClient)
+			lastErr = fmt.Errorf("dial %s through bastion %s: %w", targetAddr, bastionAddr, err)
+			continue
+		}
 
-	bastionClient, err := ssh.Dial("tcp", bastionAddr, bastionConfig)
-	if err != nil {
-		_ = authCleanup()
-		return nil, fmt.Errorf("connect to bastion %s: %w", bastionAddr, err)
-	}
+		ncc, chans, reqs, err := ssh.NewClientConn(conn, targetAddr, config)
+		if err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("ssh handshake with %s through bastion %s: %w", targetAddr, bastionAddr, err)
+		}
 
-	conn, err := bastionClient.Dial("tcp", targetAddr)
-	if err != nil {
-		_ = bastionClient.Close()
-		_ = authCleanup()
-		return nil, fmt.Errorf("dial %s through bastion %s: %w", targetAddr, bastionAddr, err)
+		client := ssh.NewClient(ncc, chans, reqs)
+		return &SSHOperator{
+			conn:    client,
+			cleanup: client.Close,
+		}, nil
 	}
-
-	ncc, chans, reqs, err := ssh.NewClientConn(conn, targetAddr, config)
-	if err != nil {
-		_ = conn.Close()
-		_ = bastionClient.Close()
-		_ = authCleanup()
-		return nil, fmt.Errorf("ssh handshake with %s through bastion %s: %w", targetAddr, bastionAddr, err)
-	}
-
-	client := ssh.NewClient(ncc, chans, reqs)
-	return &SSHOperator{
-		conn: client,
-		cleanup: func() error {
-			_ = client.Close()
-			_ = bastionClient.Close()
-			return authCleanup()
-		},
-	}, nil
+	return nil, lastErr
 }
 
 func (s SSHOperator) Close() error {

--- a/pkg/operator/ssh.go
+++ b/pkg/operator/ssh.go
@@ -2,15 +2,20 @@ package operator
 
 import (
 	"context"
-	"github.com/bramvdbogaerde/go-scp"
+	"fmt"
 	"io"
 	"os"
 
+	"github.com/bramvdbogaerde/go-scp"
 	"golang.org/x/crypto/ssh"
 )
 
 type SSHOperator struct {
 	conn *ssh.Client
+	// cleanup, when set (bastion connections), tears down the whole
+	// chain — target client, bastion client, and any ssh-agent socket.
+	// When nil (direct connections) Close just closes conn.
+	cleanup func() error
 }
 
 func NewSSHOperator(address string, config *ssh.ClientConfig) (*SSHOperator, error) {
@@ -26,7 +31,65 @@ func NewSSHOperator(address string, config *ssh.ClientConfig) (*SSHOperator, err
 	return &operator, nil
 }
 
+// newSSHOperatorViaBastion dials targetAddr through a jump host: it opens
+// an SSH connection to the bastion, asks the bastion to open a TCP
+// connection out to the target, then completes the SSH handshake with the
+// target over that tunnel. The result is an ordinary *ssh.Client, so the
+// rest of the operator works unchanged. Close tears the whole chain down.
+func newSSHOperatorViaBastion(b *BastionConfig, targetAddr string, config *ssh.ClientConfig) (*SSHOperator, error) {
+	bastionAddr := bastionAddress(b)
+	bastionUser := b.User
+	if bastionUser == "" {
+		bastionUser = currentUserName()
+	}
+
+	method, authCleanup, err := resolveAuthMethod(b.Identity, b.Password)
+	if err != nil {
+		return nil, fmt.Errorf("bastion %s auth: %w", bastionAddr, err)
+	}
+
+	bastionConfig := &ssh.ClientConfig{
+		User:            bastionUser,
+		Auth:            []ssh.AuthMethod{method},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	bastionClient, err := ssh.Dial("tcp", bastionAddr, bastionConfig)
+	if err != nil {
+		_ = authCleanup()
+		return nil, fmt.Errorf("connect to bastion %s: %w", bastionAddr, err)
+	}
+
+	conn, err := bastionClient.Dial("tcp", targetAddr)
+	if err != nil {
+		_ = bastionClient.Close()
+		_ = authCleanup()
+		return nil, fmt.Errorf("dial %s through bastion %s: %w", targetAddr, bastionAddr, err)
+	}
+
+	ncc, chans, reqs, err := ssh.NewClientConn(conn, targetAddr, config)
+	if err != nil {
+		_ = conn.Close()
+		_ = bastionClient.Close()
+		_ = authCleanup()
+		return nil, fmt.Errorf("ssh handshake with %s through bastion %s: %w", targetAddr, bastionAddr, err)
+	}
+
+	client := ssh.NewClient(ncc, chans, reqs)
+	return &SSHOperator{
+		conn: client,
+		cleanup: func() error {
+			_ = client.Close()
+			_ = bastionClient.Close()
+			return authCleanup()
+		},
+	}, nil
+}
+
 func (s SSHOperator) Close() error {
+	if s.cleanup != nil {
+		return s.cleanup()
+	}
 	return s.conn.Close()
 }
 


### PR DESCRIPTION
## What

Adds native SSH **bastion / jump host** support. Cluster nodes that only have private addresses reachable through a public jump host can now be managed directly — no need to copy the binary onto the bastion and run from there.

Declare the jump host under `global.bastion` in `cluster.yaml`:

```yaml
global:
  bastion:
    host: 203.0.113.10      # public jump host; "host" or "host:port"
    user: chris             # optional, defaults to the current OS user
    identity: ~/.ssh/id_rsa # optional, falls back to the ssh agent
    port: 22                # optional, defaults to 22
```

The `master_servers` / `volume_servers` IPs are then the private addresses as seen *from the bastion*. With no `bastion:` block, connections are direct exactly as before (fully backward compatible).

## How

Every SSH operation funnels through `operator.ExecuteRemote` → a single dial site, so the jump-host logic lives in one place. When a bastion is configured we use the standard ProxyJump pattern: dial the bastion, ask it to open a TCP connection to the private node, then complete the SSH handshake with the node over that tunnel — yielding an ordinary `*ssh.Client`, so the rest of the operator is unchanged.

- **spec**: new `BastionSpec`, wired into `global.bastion`.
- **operator**: `BastionConfig` + `SetBastion`; extracted `resolveAuthMethod` so the bastion hop reuses the existing agent/identity/passphrase/password logic; bastion-aware dial.
- **ssh**: `newSSHOperatorViaBastion` tunnels through the jump host; `Close` tears the whole chain down (target client, bastion client, ssh-agent socket).
- **cmd**: `loadClusterSpec` installs (or clears) the bastion — the single point every `-f cluster.yaml` command loads through, so deploy, preflight, lifecycle, upgrade, and prepare all inherit it uniformly.
- **tests**: cover bastion address resolution (port defaulting / host-carried port) and install/clear.
- **README**: new "Bastion / jump host" section.

## Notes

- The bastion hop uses `InsecureIgnoreHostKey()`, matching the existing behavior for node connections (no change in host-key policy).
- The inventory-driven `cluster plan` probe path reads `inventory.yaml`, not `global.bastion`; routing that through a bastion (via `defaults.ssh`) would be a small follow-up.

## Test plan

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./pkg/... ./cmd/...` — all pass, including new operator tests
- Parsed a real cluster.yaml: `global.bastion` resolves to `host=… port=22 user=…`; deploy path runs unchanged when omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SSH bastion (jump host) support for secure access to cluster nodes through a public gateway. Configure bastion settings in your cluster YAML under `global.bastion` with host, user, identity key, and port. All SSH operations automatically tunnel through the bastion.

* **Documentation**
  * Updated README with comprehensive bastion configuration guide, including required and optional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->