### PR TITLE
Add opt-in SSH host-key verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ as seen *from the bastion*. The `--user` / `--identity` flags still apply
 to the nodes themselves; the `bastion:` block holds the jump host's own
 credentials. Omit the block for direct connections.
 
+## SSH host-key verification
+
+By default seaweed-up does not verify SSH host keys. To enforce a real
+trust boundary (against a man-in-the-middle on the path to the bastion or
+the nodes), set `global.ssh_host_key_check`:
+
+```yaml
+global:
+  ssh_host_key_check: accept-new   # ignore (default) | accept-new | strict
+```
+
+- `ignore` (default) — no verification; preserves historical behavior.
+- `accept-new` — trust-on-first-use: unknown hosts are learned and
+  appended to `~/.ssh/known_hosts`, but a host whose key has *changed* is
+  rejected. Good for first deploys.
+- `strict` — every host (bastion and nodes) must already be in
+  `~/.ssh/known_hosts`; anything else is refused.
+
+The policy applies to both the direct node connections and the bastion hop.
+
 ## Lifecycle
 
 Start, stop, or restart every service in the cluster, or scope the operation

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -1239,16 +1239,17 @@ func resolveSpec(args []string, cfgFile string) (*spec.Specification, error) {
 	return sp, nil
 }
 
-// applyBastionFromSpec installs (or clears) the process-wide SSH jump
-// host from a spec's global.bastion, so every subsequent ExecuteRemote —
-// deploy, preflight, lifecycle, upgrade, prepare — tunnels through it.
-// Called from every spec-resolution path (both -f file loads and
-// state-store loads) so bastion routing is uniform however the spec was
-// obtained.
+// applyBastionFromSpec installs (or clears) the process-wide SSH settings
+// — jump host (global.bastion) and host-key verification policy
+// (global.ssh_host_key_check) — from a spec, so every subsequent
+// ExecuteRemote (deploy, preflight, lifecycle, upgrade, prepare) honors
+// them. Called from every spec-resolution path (both -f file loads and
+// state-store loads) so behavior is uniform however the spec was obtained.
 func applyBastionFromSpec(s *spec.Specification) {
 	if s == nil {
 		return
 	}
+	operator.SetHostKeyPolicy(s.GlobalOptions.SSHHostKeyCheck)
 	if b := s.GlobalOptions.Bastion; b != nil && b.Host != "" {
 		operator.SetBastion(&operator.BastionConfig{
 			Host:     b.Host,

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -16,6 +16,12 @@ type (
 		VolumeSizeLimitMB int          `yaml:"volumeSizeLimitMB" default:"5000"`
 		Replication       string       `yaml:"replication" default:"000"`
 		Bastion           *BastionSpec `yaml:"bastion,omitempty"`
+		// SSHHostKeyCheck controls verification of remote SSH host keys
+		// for every connection (direct and through the bastion). One of:
+		//   ""/"ignore"  - no verification (default; backward compatible)
+		//   "accept-new" - learn unknown hosts (TOFU), reject changed keys
+		//   "strict"     - host must already be in ~/.ssh/known_hosts
+		SSHHostKeyCheck string `yaml:"ssh_host_key_check,omitempty"`
 	}
 
 	// BastionSpec configures an SSH jump host that seaweed-up tunnels
@@ -81,6 +87,15 @@ func (s *Specification) Validate() error {
 		if b.Port < 0 || b.Port > 65535 {
 			return fmt.Errorf("global.bastion.port %d is out of range (0-65535)", b.Port)
 		}
+	}
+
+	// Keep these values in sync with operator.ValidHostKeyPolicy; checked
+	// inline here to avoid the spec package importing operator.
+	switch s.GlobalOptions.SSHHostKeyCheck {
+	case "", "ignore", "accept-new", "strict":
+	default:
+		return fmt.Errorf("global.ssh_host_key_check %q is invalid (want ignore, accept-new, or strict)",
+			s.GlobalOptions.SSHHostKeyCheck)
 	}
 
 	return nil

--- a/pkg/cluster/spec/spec_test.go
+++ b/pkg/cluster/spec/spec_test.go
@@ -34,3 +34,30 @@ func TestValidate_Bastion(t *testing.T) {
 		})
 	}
 }
+
+func TestValidate_SSHHostKeyCheck(t *testing.T) {
+	cases := []struct {
+		val     string
+		wantErr bool
+	}{
+		{"", false},
+		{"ignore", false},
+		{"accept-new", false},
+		{"strict", false},
+		{"STRICT", true},
+		{"tofu", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			s := &Specification{MasterServers: masterOnly()}
+			s.GlobalOptions.SSHHostKeyCheck = tc.val
+			err := s.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.val)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error for %q, got %v", tc.val, err)
+			}
+		})
+	}
+}

--- a/pkg/operator/hostkey.go
+++ b/pkg/operator/hostkey.go
@@ -1,0 +1,175 @@
+package operator
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// SSH host-key verification policies. The historical — and default —
+// behavior is "ignore": host keys are not checked at all. Operators who
+// want a real SSH trust boundary (protection against a MITM on the path
+// to the bastion or the nodes) can opt into knownhosts-backed
+// verification via global.ssh_host_key_check in cluster.yaml.
+const (
+	HostKeyIgnore    = "ignore"     // no verification (default; backward compatible)
+	HostKeyAcceptNew = "accept-new" // trust-on-first-use: learn new hosts, reject changed keys
+	HostKeyStrict    = "strict"     // every host must already be in known_hosts
+)
+
+var (
+	hostKeyMu     sync.Mutex
+	hostKeyPolicy string
+
+	// knownHostsFile is the file consulted for accept-new/strict. It is a
+	// var (not a const) so tests can point it at a temp file.
+	knownHostsFile = "~/.ssh/known_hosts"
+
+	// knownHostsWriteMu serializes appends so the concurrent deploy
+	// fan-out does not interleave writes when learning new hosts.
+	knownHostsWriteMu sync.Mutex
+)
+
+// SetHostKeyPolicy installs the process-wide host-key verification
+// policy. An empty string resets to the default ("ignore").
+func SetHostKeyPolicy(policy string) {
+	hostKeyMu.Lock()
+	defer hostKeyMu.Unlock()
+	hostKeyPolicy = policy
+}
+
+func currentHostKeyPolicy() string {
+	hostKeyMu.Lock()
+	defer hostKeyMu.Unlock()
+	if hostKeyPolicy == "" {
+		return HostKeyIgnore
+	}
+	return hostKeyPolicy
+}
+
+// ValidHostKeyPolicy reports whether p is a recognized policy. The empty
+// string is valid and means the default ("ignore").
+func ValidHostKeyPolicy(p string) bool {
+	switch p {
+	case "", HostKeyIgnore, HostKeyAcceptNew, HostKeyStrict:
+		return true
+	}
+	return false
+}
+
+// hostKeyCallback builds the ssh.HostKeyCallback for the active policy.
+// Both the direct dial and the bastion hop use it, so the policy applies
+// to every connection seaweed-up opens.
+func hostKeyCallback() (ssh.HostKeyCallback, error) {
+	switch currentHostKeyPolicy() {
+	case HostKeyIgnore:
+		return ssh.InsecureIgnoreHostKey(), nil
+	case HostKeyAcceptNew:
+		return knownHostsVerifier(true)
+	case HostKeyStrict:
+		return knownHostsVerifier(false)
+	default:
+		return nil, fmt.Errorf("unknown ssh host key policy %q (want %s, %s, or %s)",
+			currentHostKeyPolicy(), HostKeyIgnore, HostKeyAcceptNew, HostKeyStrict)
+	}
+}
+
+// knownHostsVerifier returns a callback backed by the known_hosts file.
+// When acceptNew is true an unknown host is learned (appended) and
+// accepted, but a host whose key has CHANGED is still rejected. When
+// false (strict) any host not already present is rejected.
+func knownHostsVerifier(acceptNew bool) (ssh.HostKeyCallback, error) {
+	path, err := homedir.Expand(knownHostsFile)
+	if err != nil {
+		return nil, fmt.Errorf("resolve known_hosts path: %w", err)
+	}
+
+	// knownhosts.New fails on a missing file. Under accept-new, create
+	// an empty one so a first-ever deploy can populate it. Under strict,
+	// leave it: a missing file legitimately means "nothing trusted yet".
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) && acceptNew {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return nil, fmt.Errorf("create ssh dir: %w", err)
+		}
+		f, err := os.OpenFile(path, os.O_CREATE, 0o600)
+		if err != nil {
+			return nil, fmt.Errorf("create known_hosts: %w", err)
+		}
+		_ = f.Close()
+	}
+
+	verify, err := knownhosts.New(path)
+	if err != nil {
+		return nil, fmt.Errorf("load known_hosts %s: %w", path, err)
+	}
+	if !acceptNew {
+		return verify, nil
+	}
+
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		err := verify(hostname, remote, key)
+		if err == nil {
+			return nil
+		}
+		// A KeyError with an empty Want means the host is simply unknown
+		// — learn it. A non-empty Want means the presented key differs
+		// from a recorded one (possible MITM); accept-new must still
+		// reject that.
+		var keyErr *knownhosts.KeyError
+		if errors.As(err, &keyErr) && len(keyErr.Want) == 0 {
+			return appendKnownHost(path, hostname, remote, key)
+		}
+		return err
+	}, nil
+}
+
+// appendKnownHost records a newly-seen host key in the known_hosts file.
+func appendKnownHost(path, hostname string, remote net.Addr, key ssh.PublicKey) error {
+	knownHostsWriteMu.Lock()
+	defer knownHostsWriteMu.Unlock()
+
+	addrs := []string{knownhosts.Normalize(hostname)}
+	// Record the remote IP too, but only when it is meaningful. Bastion
+	// tunnels present a synthetic 0.0.0.0:0 remote (the channel has no
+	// real TCP peer), which would just be noise in known_hosts.
+	if usefulRemoteAddr(remote) {
+		if ra := knownhosts.Normalize(remote.String()); ra != addrs[0] {
+			addrs = append(addrs, ra)
+		}
+	}
+	line := knownhosts.Line(addrs, key)
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o600)
+	if err != nil {
+		return fmt.Errorf("open known_hosts for append: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		return fmt.Errorf("append to known_hosts: %w", err)
+	}
+	return nil
+}
+
+// usefulRemoteAddr reports whether a net.Addr carries a real routable
+// peer worth recording in known_hosts. Bastion tunnels hand back a
+// synthetic 0.0.0.0:0 addr, which is filtered out.
+func usefulRemoteAddr(remote net.Addr) bool {
+	if remote == nil {
+		return false
+	}
+	host, port, err := net.SplitHostPort(remote.String())
+	if err != nil || port == "" || port == "0" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+		return false
+	}
+	return true
+}

--- a/pkg/operator/hostkey.go
+++ b/pkg/operator/hostkey.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -8,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 )
@@ -98,7 +98,7 @@ func knownHostsVerifier(acceptNew bool) (ssh.HostKeyCallback, error) {
 		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 			return nil, fmt.Errorf("create ssh dir: %w", err)
 		}
-		f, err := os.OpenFile(path, os.O_CREATE, 0o600)
+		f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0o600)
 		if err != nil {
 			return nil, fmt.Errorf("create known_hosts: %w", err)
 		}
@@ -122,18 +122,39 @@ func knownHostsVerifier(acceptNew bool) (ssh.HostKeyCallback, error) {
 		// — learn it. A non-empty Want means the presented key differs
 		// from a recorded one (possible MITM); accept-new must still
 		// reject that.
-		var keyErr *knownhosts.KeyError
-		if errors.As(err, &keyErr) && len(keyErr.Want) == 0 {
-			return appendKnownHost(path, hostname, remote, key)
+		if isUnknownHost(err) {
+			return learnHost(path, hostname, remote, key)
 		}
 		return err
 	}, nil
 }
 
-// appendKnownHost records a newly-seen host key in the known_hosts file.
-func appendKnownHost(path, hostname string, remote net.Addr, key ssh.PublicKey) error {
+// isUnknownHost reports whether err is a knownhosts "host not found"
+// error (as opposed to a key mismatch, which carries a non-empty Want).
+func isUnknownHost(err error) bool {
+	var keyErr *knownhosts.KeyError
+	return errors.As(err, &keyErr) && len(keyErr.Want) == 0
+}
+
+// learnHost records a newly-seen host key in known_hosts. It re-checks
+// the file while holding knownHostsWriteMu to close the TOCTOU window
+// between the verifier snapshot and the append: if a concurrent handshake
+// recorded the same key first it is a no-op, and if a *different* key was
+// recorded in the meantime the mismatch is returned (rejected) rather
+// than appended.
+func learnHost(path, hostname string, remote net.Addr, key ssh.PublicKey) error {
 	knownHostsWriteMu.Lock()
 	defer knownHostsWriteMu.Unlock()
+
+	// Re-verify against the current file under the lock.
+	if verify, err := knownhosts.New(path); err == nil {
+		switch verr := verify(hostname, remote, key); {
+		case verr == nil:
+			return nil // another goroutine already learned this exact key
+		case !isUnknownHost(verr):
+			return verr // a different key was recorded first -> reject
+		}
+	}
 
 	addrs := []string{knownhosts.Normalize(hostname)}
 	// Record the remote IP too, but only when it is meaningful. Bastion

--- a/pkg/operator/hostkey_test.go
+++ b/pkg/operator/hostkey_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
@@ -84,6 +85,45 @@ func TestKnownHostsVerifier_AcceptNew(t *testing.T) {
 	// A CHANGED key for a known host must be rejected even under accept-new.
 	if err := cb2("10.0.0.2:22", remote, testHostKey(t)); err == nil {
 		t.Fatal("a changed host key must be rejected under accept-new")
+	}
+}
+
+// TestKnownHostsVerifier_AcceptNew_ConcurrentSameHost locks down the
+// TOCTOU fix: when many first-time handshakes to the SAME host race with
+// DIFFERENT keys, exactly one key must be trusted and the rest rejected.
+func TestKnownHostsVerifier_AcceptNew_ConcurrentSameHost(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	old := knownHostsFile
+	knownHostsFile = path
+	t.Cleanup(func() { knownHostsFile = old })
+
+	cb, err := knownHostsVerifier(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 8
+	remote := &net.TCPAddr{IP: net.ParseIP("10.0.0.9"), Port: 22}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	success := 0
+	for i := 0; i < n; i++ {
+		key := testHostKey(t) // distinct key per goroutine
+		wg.Add(1)
+		go func(k ssh.PublicKey) {
+			defer wg.Done()
+			if cb("10.0.0.9:22", remote, k) == nil {
+				mu.Lock()
+				success++
+				mu.Unlock()
+			}
+		}(key)
+	}
+	wg.Wait()
+
+	if success != 1 {
+		t.Fatalf("expected exactly 1 trusted key for the same host under a race, got %d", success)
 	}
 }
 

--- a/pkg/operator/hostkey_test.go
+++ b/pkg/operator/hostkey_test.go
@@ -1,0 +1,108 @@
+package operator
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func testHostKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signer.PublicKey()
+}
+
+func TestValidHostKeyPolicy(t *testing.T) {
+	for _, p := range []string{"", "ignore", "accept-new", "strict"} {
+		if !ValidHostKeyPolicy(p) {
+			t.Errorf("expected %q to be valid", p)
+		}
+	}
+	for _, p := range []string{"yes", "no", "STRICT", "tofu"} {
+		if ValidHostKeyPolicy(p) {
+			t.Errorf("expected %q to be invalid", p)
+		}
+	}
+}
+
+func TestHostKeyPolicyDefault(t *testing.T) {
+	t.Cleanup(func() { SetHostKeyPolicy("") })
+	if got := currentHostKeyPolicy(); got != HostKeyIgnore {
+		t.Fatalf("default policy = %q, want %q", got, HostKeyIgnore)
+	}
+	SetHostKeyPolicy("strict")
+	if got := currentHostKeyPolicy(); got != HostKeyStrict {
+		t.Fatalf("policy = %q, want strict", got)
+	}
+	SetHostKeyPolicy("")
+	if got := currentHostKeyPolicy(); got != HostKeyIgnore {
+		t.Fatalf("reset policy = %q, want ignore", got)
+	}
+}
+
+func TestKnownHostsVerifier_AcceptNew(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	old := knownHostsFile
+	knownHostsFile = path
+	t.Cleanup(func() { knownHostsFile = old })
+
+	key := testHostKey(t)
+	remote := &net.TCPAddr{IP: net.ParseIP("10.0.0.2"), Port: 22}
+
+	cb, err := knownHostsVerifier(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Unknown host: accept-new learns and accepts it.
+	if err := cb("10.0.0.2:22", remote, key); err != nil {
+		t.Fatalf("accept-new should learn an unknown host: %v", err)
+	}
+	if data, _ := os.ReadFile(path); len(data) == 0 {
+		t.Fatal("expected the learned host to be appended to known_hosts")
+	}
+
+	// A fresh verifier loads the learned host and accepts the same key.
+	cb2, err := knownHostsVerifier(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cb2("10.0.0.2:22", remote, key); err != nil {
+		t.Fatalf("known host with unchanged key should pass: %v", err)
+	}
+	// A CHANGED key for a known host must be rejected even under accept-new.
+	if err := cb2("10.0.0.2:22", remote, testHostKey(t)); err == nil {
+		t.Fatal("a changed host key must be rejected under accept-new")
+	}
+}
+
+func TestKnownHostsVerifier_Strict(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	old := knownHostsFile
+	knownHostsFile = path
+	t.Cleanup(func() { knownHostsFile = old })
+
+	// Empty (but present) known_hosts: strict trusts nothing yet.
+	if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cb, err := knownHostsVerifier(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remote := &net.TCPAddr{IP: net.ParseIP("10.0.0.3"), Port: 22}
+	if err := cb("10.0.0.3:22", remote, testHostKey(t)); err == nil {
+		t.Fatal("strict must reject a host that is not in known_hosts")
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -110,10 +110,16 @@ func sharedBastionClient(b *BastionConfig) (*ssh.Client, error) {
 		return nil, fmt.Errorf("bastion %s auth: %w", addr, err)
 	}
 
+	hostKey, err := hostKeyCallback()
+	if err != nil {
+		_ = cleanup()
+		return nil, fmt.Errorf("bastion %s host key verification: %w", addr, err)
+	}
+
 	conn, err := ssh.Dial("tcp", addr, &ssh.ClientConfig{
 		User:            user,
 		Auth:            []ssh.AuthMethod{method},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKey,
 	})
 	if err != nil {
 		_ = cleanup()
@@ -270,12 +276,16 @@ func executeRemote(address string, user string, authMethod ssh.AuthMethod, callb
 	}
 	targetAddr := net.JoinHostPort(host, port)
 
+	hostKey, err := hostKeyCallback()
+	if err != nil {
+		return fmt.Errorf("ssh host key verification: %w", err)
+	}
 	config := &ssh.ClientConfig{
 		User: user,
 		Auth: []ssh.AuthMethod{
 			authMethod,
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKey,
 	}
 	operator, err := dialOperator(targetAddr, config)
 


### PR DESCRIPTION
## What

Follow-up to #84 (SSH bastion support). Adds an **opt-in** SSH host-key trust boundary. Previously every SSH connection used `ssh.InsecureIgnoreHostKey()`, so both the bastion hop and the node connections were exposed to MITM. This was flagged in the #84 review and deferred as a separate, tool-wide change — here it is.

Controlled by a new `global.ssh_host_key_check` in `cluster.yaml`:

```yaml
global:
  ssh_host_key_check: accept-new   # ignore (default) | accept-new | strict
```

- **`ignore`** (default) — no verification; **fully backward compatible**.
- **`accept-new`** — trust-on-first-use: unknown hosts are learned and appended to `~/.ssh/known_hosts`; a host whose key has *changed* is rejected. Practical for first deploys.
- **`strict`** — every host (bastion + nodes) must already be in `~/.ssh/known_hosts`; anything else is refused.

## How

- `pkg/operator/hostkey.go` — policy state (`SetHostKeyPolicy`) + `hostKeyCallback()` backed by `golang.org/x/crypto/ssh/knownhosts` (already a dependency — no new deps). Both dial sites (direct node dial in `executeRemote`, bastion dial in `sharedBastionClient`) use it, so the policy is uniform. The target-over-bastion handshake reuses the same target `ClientConfig`, so tunneled targets are verified too.
- Wired from the spec in `applyBastionFromSpec` (the single helper both `-f` and state-store load paths call), so name-based commands honor it as well.
- Validated in `Specification.Validate()` (rejects unknown policy values).
- `accept-new` appends under a mutex (safe for the concurrent deploy fan-out) and filters the synthetic `0.0.0.0:0` remote that bastion tunnels present, so learned entries are keyed on the real hostname.

## Test plan

- `go build ./...`, `go vet ./...` — clean
- `go test -race ./pkg/operator/... ./pkg/cluster/spec/...` — pass (policy validation; accept-new learn/reuse/reject-changed; strict reject-unknown)
- Full `go test ./pkg/... ./cmd/...` — pass
- **End-to-end through a real bastion**: `accept-new` learned the bastion + node host keys into `known_hosts`; `strict` then accepted the known node and **rejected** an unlearned node (`knownhosts: key is unknown`).

## Notes

- Default is `ignore`, so existing deployments are unaffected until they opt in.
- The other deferred #84 item (encrypting persisted spec secrets at rest — `admin_password`, filer creds, `bastion.password`) is broader and still worth a separate pass; not included here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SSH host-key verification is now configurable via `global.ssh_host_key_check` with three policies: `ignore`, `accept-new`, and `strict`, applying to both direct and bastion connections.

* **Documentation**
  * Added SSH host-key verification configuration guide to README.

* **Tests**
  * Added comprehensive tests for SSH host-key verification and policy validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->