### PR TITLE
Fix: use passwordless sudo for non-root users

### DIFF
--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -152,8 +152,17 @@ func info(message string) {
 
 func (m *Manager) sudo(op operator.CommandOperator, cmd string) error {
 	info("[execute] " + cmd)
-	if m.sudoPass == "" {
+	// Already root: run the command directly (the box may not even have
+	// sudo installed).
+	if m.User == "root" {
 		return op.Execute(cmd)
+	}
+	// Non-root without a sudo password: assume passwordless (NOPASSWD)
+	// sudo and elevate non-interactively. Running bare here was a bug —
+	// privileged commands (mkdir under /, writes to /etc/seaweed, ...)
+	// would fail with permission denied for a normal login user.
+	if m.sudoPass == "" {
+		return op.Execute("sudo -n " + cmd)
 	}
 	defer fmt.Println()
 	return op.Execute(fmt.Sprintf("echo %s | sudo -S %s", shellSingleQuote(m.sudoPass), cmd))

--- a/pkg/cluster/tls/bootstrap.go
+++ b/pkg/cluster/tls/bootstrap.go
@@ -250,10 +250,10 @@ func UploadBundle(op operator.CommandOperator, component string, b *Bundle, jwtF
 //   - When the SSH user is root, the script is piped straight into `sh`:
 //     the session already has root privileges and the host may not even
 //     have sudo installed.
-//   - When sudoPass is empty, we assume NOPASSWD sudo is configured or
-//     the caller is running as root in another guise, and we execute
-//     without sudo. (The caller should pass a non-empty sudoPass only
-//     when sudo is actually required.)
+//   - When the user is non-root and no sudoPass is supplied, we elevate
+//     non-interactively with `sudo -n` (passwordless/NOPASSWD sudo). The
+//     script writes into root-owned locations (/etc/seaweed, certs), so
+//     running it without sudo would fail with permission denied.
 //   - Otherwise we pipe the password into `sudo -S`. sudoPass is
 //     single-quote-escaped via shellSingleQuote so passwords containing
 //     single quotes cannot break out of the quoted literal.
@@ -262,8 +262,17 @@ func runInstallScript(op operator.CommandOperator, script, sshUser, sudoPass str
 	// safely inside the remote shell command.
 	encoded := base64Encode([]byte(script))
 
-	if sshUser == "root" || sudoPass == "" {
+	if sshUser == "root" {
 		cmd := fmt.Sprintf("echo %s | base64 -d | sh", encoded)
+		return op.Execute(cmd)
+	}
+
+	// Non-root without a sudo password: assume passwordless (NOPASSWD)
+	// sudo and elevate non-interactively. Running the script bare here
+	// was a bug — its `install -o root` / writes under /etc/seaweed fail
+	// with permission denied for a normal login user.
+	if sudoPass == "" {
+		cmd := fmt.Sprintf("echo %s | base64 -d | sudo -n sh", encoded)
 		return op.Execute(cmd)
 	}
 

--- a/pkg/cluster/tls/tls_test.go
+++ b/pkg/cluster/tls/tls_test.go
@@ -272,6 +272,29 @@ func TestUploadSecurityTOMLOnly(t *testing.T) {
 	}
 }
 
+// TestUploadSecurityTOMLOnly_PasswordlessSudo verifies the non-root,
+// no-password path elevates with `sudo -n` rather than running the
+// install script bare (which would fail writing into /etc/seaweed).
+func TestUploadSecurityTOMLOnly_PasswordlessSudo(t *testing.T) {
+	op := newFakeOperator()
+	if err := UploadSecurityTOMLOnly(op, "filer", "write-key", "read-key", "chris", ""); err != nil {
+		t.Fatalf("UploadSecurityTOMLOnly: %v", err)
+	}
+	var sawSudo bool
+	for _, cmd := range op.executed {
+		if strings.Contains(cmd, "base64 -d | sudo -n sh") {
+			sawSudo = true
+		}
+		// must NOT run the script bare (no sudo) for a non-root user
+		if strings.Contains(cmd, "base64 -d | sh") {
+			t.Errorf("install script ran without sudo for a non-root user: %q", cmd)
+		}
+	}
+	if !sawSudo {
+		t.Errorf("expected the install script to run via `sudo -n sh`; commands=%v", op.executed)
+	}
+}
+
 func TestFilerAndAdminHosts(t *testing.T) {
 	s := &spec.Specification{
 		MasterServers: []*spec.MasterServerSpec{{Ip: "10.0.0.1"}},

--- a/pkg/cluster/tls/tls_test.go
+++ b/pkg/cluster/tls/tls_test.go
@@ -285,8 +285,11 @@ func TestUploadSecurityTOMLOnly_PasswordlessSudo(t *testing.T) {
 		if strings.Contains(cmd, "base64 -d | sudo -n sh") {
 			sawSudo = true
 		}
-		// must NOT run the script bare (no sudo) for a non-root user
-		if strings.Contains(cmd, "base64 -d | sh") {
+		// Must NOT run the script bare (no sudo) for a non-root user. Use
+		// HasSuffix so this matches only the bare `… | base64 -d | sh`
+		// form and not the legitimate `… | base64 -d | sudo -n sh`, which
+		// ends in `sudo -n sh`.
+		if strings.HasSuffix(cmd, "base64 -d | sh") {
 			t.Errorf("install script ran without sudo for a non-root user: %q", cmd)
 		}
 	}


### PR DESCRIPTION
## What

Two privileged-operation paths treated **"no sudo password" as "run without sudo at all"**. For the very common case of a non-root SSH login with **NOPASSWD sudo**, that ran root-only operations as the unprivileged user, so they failed:

- `Manager.sudo()` → `ensureVolumeFolders` did `mkdir -p /data/...` as the login user → *permission denied*.
- `runInstallScript` (TLS bootstrap) → the IAM-gRPC `security.toml` install ran `install -o root -g root … /etc/seaweed/security.toml` without sudo → *exited status 1*, which blocked deploying **filers** and the **admin** server entirely.

(The `weed` install.sh itself was unaffected because it always elevates via its own `$SUDO`.)

## Fix

For a non-root user with no password, elevate non-interactively with **`sudo -n`** (passwordless/NOPASSWD). Behavior matrix now:

| SSH user | sudo password | command |
|---|---|---|
| `root` | — | run directly (host may not even have sudo) |
| non-root | empty | `sudo -n …` (NOPASSWD) |
| non-root | set | `echo <pass> \| sudo -S …` |

This lets a normal NOPASSWD-sudo operator deploy volume servers, filers, and the admin server without hand-creating root-owned directories first.

## How it surfaced

Found while deploying a real cluster as a non-root user (`chris`, NOPASSWD sudo) through a bastion: masters/volumes installed (install.sh elevates), but `ensureVolumeFolders` and the `security.toml` install failed. With this fix a full deploy (masters, 12 volumes, 3 filers, 6 s3, 1 admin, 6 workers) completes cleanly and S3 round-trips across gateways.

## Test plan

- `go build ./...`, `go test ./pkg/... ./cmd/...` — pass
- Added `TestUploadSecurityTOMLOnly_PasswordlessSudo`: a non-root, no-password install must run via `sudo -n sh` and must **not** run the script bare. Existing root-path test still passes.
- Verified end-to-end on a live 6-host cluster behind a bastion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sudo command execution handling for non-root users without sudo passwords, preventing permission-denied failures during cluster operations and certificate installation.
  * Enhanced command invocation logic to better support passwordless sudo environments.

* **Tests**
  * Added test coverage for passwordless sudo execution in security certificate installation and bootstrap operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->