### PR TITLE
Don't persist plaintext secrets in cluster state

### DIFF
--- a/pkg/cluster/state/redact.go
+++ b/pkg/cluster/state/redact.go
@@ -1,0 +1,111 @@
+package state
+
+import (
+	"strings"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+	"gopkg.in/yaml.v3"
+)
+
+// redactedSpec returns a deep copy of sp with every secret value cleared,
+// so credentials are never written to the on-disk cluster state. The
+// original sp is left untouched — callers keep using it (with real
+// secrets) for the in-flight deploy; only the persisted copy is scrubbed.
+//
+// Redacted:
+//   - global.bastion.password
+//   - admin_servers[].admin_password
+//   - any secret-looking key (password, secret, *_key, token, ...) inside
+//     a component's free-form config / s3_config map, at any nesting depth
+//     (filer DB credentials, the s3.json identities -> secretKey tree, ...)
+//
+// Consequence: name-based commands that re-render configs from saved state
+// (e.g. `cluster upgrade <name>` without -f) will not have these secrets.
+// Re-run such operations with -f <cluster.yaml> when they are needed.
+func redactedSpec(sp *spec.Specification) (*spec.Specification, error) {
+	// Deep copy via a YAML round-trip so redaction can't mutate the
+	// caller's spec or alias its nested maps.
+	b, err := yaml.Marshal(sp)
+	if err != nil {
+		return nil, err
+	}
+	clone := &spec.Specification{}
+	if err := yaml.Unmarshal(b, clone); err != nil {
+		return nil, err
+	}
+
+	if clone.GlobalOptions.Bastion != nil {
+		clone.GlobalOptions.Bastion.Password = ""
+	}
+	for _, a := range clone.AdminServers {
+		if a != nil {
+			a.AdminPassword = ""
+			redactMap(a.Config)
+		}
+	}
+	for _, m := range clone.MasterServers {
+		if m != nil {
+			redactMap(m.Config)
+		}
+	}
+	for _, v := range clone.VolumeServers {
+		if v != nil {
+			redactMap(v.Config)
+		}
+	}
+	for _, f := range clone.FilerServers {
+		if f != nil {
+			redactMap(f.Config)
+		}
+	}
+	for _, w := range clone.WorkerServers {
+		if w != nil {
+			redactMap(w.Config)
+		}
+	}
+	for _, s := range clone.SftpServers {
+		if s != nil {
+			redactMap(s.Config)
+		}
+	}
+	for _, s := range clone.S3Servers {
+		if s != nil {
+			redactMap(s.S3Config)
+		}
+	}
+
+	return clone, nil
+}
+
+// redactMap blanks the value of any secret-looking key in m, recursing
+// into nested maps and slices.
+func redactMap(m map[string]interface{}) {
+	for k, v := range m {
+		if isSecretKey(k) {
+			m[k] = ""
+			continue
+		}
+		redactWalk(v)
+	}
+}
+
+func redactWalk(v interface{}) {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		redactMap(t)
+	case []interface{}:
+		for _, e := range t {
+			redactWalk(e)
+		}
+	}
+}
+
+// isSecretKey reports whether a config key name denotes a credential.
+func isSecretKey(k string) bool {
+	switch strings.ToLower(strings.TrimSpace(k)) {
+	case "password", "passwd", "secret", "secret_key", "secretkey",
+		"secretaccesskey", "access_key_secret", "token", "jwt_signing_key":
+		return true
+	}
+	return false
+}

--- a/pkg/cluster/state/redact.go
+++ b/pkg/cluster/state/redact.go
@@ -37,6 +37,10 @@ func redactedSpec(sp *spec.Specification) (*spec.Specification, error) {
 	if clone.GlobalOptions.Bastion != nil {
 		clone.GlobalOptions.Bastion.Password = ""
 	}
+	// Global per-role default config maps can also carry secrets.
+	redactMap(clone.ServerConfigs.MasterServer)
+	redactMap(clone.ServerConfigs.VolumeServer)
+	redactMap(clone.ServerConfigs.FilerServer)
 	for _, a := range clone.AdminServers {
 		if a != nil {
 			a.AdminPassword = ""
@@ -101,10 +105,21 @@ func redactWalk(v interface{}) {
 }
 
 // isSecretKey reports whether a config key name denotes a credential.
+// Matching is by substring so prefixed/suffixed variants are caught too
+// (db_password, access_token, client_secret, secretKey, ...).
 func isSecretKey(k string) bool {
-	switch strings.ToLower(strings.TrimSpace(k)) {
-	case "password", "passwd", "secret", "secret_key", "secretkey",
-		"secretaccesskey", "access_key_secret", "token", "jwt_signing_key":
+	k = strings.ToLower(strings.TrimSpace(k))
+	for _, s := range []string{"password", "passwd", "passphrase", "secret", "token", "apikey", "api_key"} {
+		if strings.Contains(k, s) {
+			return true
+		}
+	}
+	// "key" alone is too broad — accessKey / publicKey / hostKey are
+	// identifiers or paths, not secrets. Only redact a key when it is
+	// qualified as a private/crypto/signing key (private_key,
+	// signing_key, encryption_key, ...).
+	if strings.Contains(k, "key") &&
+		(strings.Contains(k, "private") || strings.Contains(k, "crypt") || strings.Contains(k, "sign")) {
 		return true
 	}
 	return false

--- a/pkg/cluster/state/redact_internal_test.go
+++ b/pkg/cluster/state/redact_internal_test.go
@@ -1,0 +1,27 @@
+package state
+
+import "testing"
+
+func TestIsSecretKey(t *testing.T) {
+	secret := []string{
+		"password", "Password", "db_password", "passwd", "passphrase",
+		"secret", "client_secret", "secretKey", "secret_key",
+		"token", "access_token", "apikey", "api_key",
+		"private_key", "signing_key", "encryption_key",
+	}
+	notSecret := []string{
+		"type", "hostname", "port", "database", "username", "user",
+		"accessKey", "access_key", "publicKey", "host_key_path",
+		"key_prefix", "dir", "address",
+	}
+	for _, k := range secret {
+		if !isSecretKey(k) {
+			t.Errorf("isSecretKey(%q) = false, want true", k)
+		}
+	}
+	for _, k := range notSecret {
+		if isSecretKey(k) {
+			t.Errorf("isSecretKey(%q) = true, want false", k)
+		}
+	}
+}

--- a/pkg/cluster/state/state.go
+++ b/pkg/cluster/state/state.go
@@ -98,16 +98,26 @@ func (s *Store) Save(name string, sp *spec.Specification, meta Meta) error {
 	}
 
 	dir := s.clusterDir(name)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// 0700: the persisted topology can reference hosts and (pre-redaction)
+	// credentials, so keep the state tree owner-only.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create cluster dir %s: %w", dir, err)
 	}
 
+	// Persist a redacted copy: secrets in the spec (admin/bastion
+	// passwords, filer DB and s3.json credentials) must not be written to
+	// disk in plaintext. The caller's sp is left intact.
+	redacted, err := redactedSpec(sp)
+	if err != nil {
+		return fmt.Errorf("redact topology secrets: %w", err)
+	}
+
 	topoPath := filepath.Join(dir, "topology.yaml")
-	topoBytes, err := yaml.Marshal(sp)
+	topoBytes, err := yaml.Marshal(redacted)
 	if err != nil {
 		return fmt.Errorf("marshal topology: %w", err)
 	}
-	if err := writeFileAtomic(topoPath, topoBytes, 0o644); err != nil {
+	if err := writeFileAtomic(topoPath, topoBytes, 0o600); err != nil {
 		return fmt.Errorf("write topology: %w", err)
 	}
 
@@ -116,7 +126,7 @@ func (s *Store) Save(name string, sp *spec.Specification, meta Meta) error {
 	if err != nil {
 		return fmt.Errorf("marshal state: %w", err)
 	}
-	if err := writeFileAtomic(statePath, stateBytes, 0o644); err != nil {
+	if err := writeFileAtomic(statePath, stateBytes, 0o600); err != nil {
 		return fmt.Errorf("write state: %w", err)
 	}
 	return nil

--- a/pkg/cluster/state/state.go
+++ b/pkg/cluster/state/state.go
@@ -105,7 +105,11 @@ func (s *Store) Save(name string, sp *spec.Specification, meta Meta) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create cluster dir %s: %w", dir, err)
 	}
-	if err := os.Chmod(dir, 0o700); err != nil {
+	// gosec G302 wants <=0600, but this is a directory: it needs the
+	// owner execute bit (0700) to be traversable; 0600 would make it
+	// unusable. (MkdirAll's G301 is already excluded in CI; chmod's G302
+	// is not, hence the inline suppression.)
+	if err := os.Chmod(dir, 0o700); err != nil { // #nosec G302 -- directory needs the 0700 traverse bit
 		return fmt.Errorf("secure cluster dir %s: %w", dir, err)
 	}
 

--- a/pkg/cluster/state/state.go
+++ b/pkg/cluster/state/state.go
@@ -99,9 +99,14 @@ func (s *Store) Save(name string, sp *spec.Specification, meta Meta) error {
 
 	dir := s.clusterDir(name)
 	// 0700: the persisted topology can reference hosts and (pre-redaction)
-	// credentials, so keep the state tree owner-only.
+	// credentials, so keep the state tree owner-only. Chmod as well as
+	// MkdirAll because MkdirAll leaves an existing dir's mode untouched —
+	// older installs may have created it 0755.
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create cluster dir %s: %w", dir, err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("secure cluster dir %s: %w", dir, err)
 	}
 
 	// Persist a redacted copy: secrets in the spec (admin/bastion

--- a/pkg/cluster/state/state_test.go
+++ b/pkg/cluster/state/state_test.go
@@ -176,7 +176,12 @@ func TestSaveRedactsSecretsAndPerms(t *testing.T) {
 	sp.GlobalOptions.Bastion = &spec.BastionSpec{Host: "203.0.113.10", User: "chris", Password: "BASTION_SECRET"}
 	sp.AdminServers = []*spec.AdminServerSpec{{Ip: "10.0.0.1", AdminUser: "admin", AdminPassword: "ADMIN_SECRET"}}
 	sp.FilerServers[0].Config = map[string]interface{}{
-		"type": "postgres", "hostname": "10.0.0.9", "password": "FILER_DB_SECRET",
+		"type": "postgres", "hostname": "10.0.0.9",
+		"password": "FILER_DB_SECRET", "db_password": "FILER_DB_SECRET2",
+	}
+	// global per-role default config map (ServerConfigs) can also hold secrets
+	sp.ServerConfigs.MasterServer = map[string]interface{}{
+		"jwt_signing_key": "GLOBAL_JWT_SECRET",
 	}
 	// nested secret, like s3.json identities -> credentials -> secretKey
 	sp.S3Servers = []*spec.S3ServerSpec{{Ip: "10.0.0.1", S3Config: map[string]interface{}{
@@ -203,7 +208,7 @@ func TestSaveRedactsSecretsAndPerms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read topology: %v", err)
 	}
-	for _, secret := range []string{"BASTION_SECRET", "ADMIN_SECRET", "FILER_DB_SECRET", "S3_SECRET"} {
+	for _, secret := range []string{"BASTION_SECRET", "ADMIN_SECRET", "FILER_DB_SECRET", "FILER_DB_SECRET2", "GLOBAL_JWT_SECRET", "S3_SECRET"} {
 		if strings.Contains(string(raw), secret) {
 			t.Errorf("persisted topology leaked secret %q:\n%s", secret, raw)
 		}

--- a/pkg/cluster/state/state_test.go
+++ b/pkg/cluster/state/state_test.go
@@ -1,7 +1,9 @@
 package state_test
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -158,6 +160,67 @@ func TestHostsFromSpecDedupe(t *testing.T) {
 	for i := 1; i < len(hosts); i++ {
 		if hosts[i-1] >= hosts[i] {
 			t.Errorf("HostsFromSpec not sorted: %v", hosts)
+		}
+	}
+}
+
+func TestSaveRedactsSecretsAndPerms(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(state.EnvHome, tmp)
+	s, err := state.NewStore("")
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	sp := newTestSpec()
+	sp.GlobalOptions.Bastion = &spec.BastionSpec{Host: "203.0.113.10", User: "chris", Password: "BASTION_SECRET"}
+	sp.AdminServers = []*spec.AdminServerSpec{{Ip: "10.0.0.1", AdminUser: "admin", AdminPassword: "ADMIN_SECRET"}}
+	sp.FilerServers[0].Config = map[string]interface{}{
+		"type": "postgres", "hostname": "10.0.0.9", "password": "FILER_DB_SECRET",
+	}
+	// nested secret, like s3.json identities -> credentials -> secretKey
+	sp.S3Servers = []*spec.S3ServerSpec{{Ip: "10.0.0.1", S3Config: map[string]interface{}{
+		"identities": []interface{}{
+			map[string]interface{}{"name": "u1", "credentials": []interface{}{
+				map[string]interface{}{"accessKey": "AKIA", "secretKey": "S3_SECRET"},
+			}},
+		},
+	}}}
+
+	if err := s.Save("c1", sp, state.Meta{Version: "1"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// 1) original spec must NOT be mutated.
+	if sp.GlobalOptions.Bastion.Password != "BASTION_SECRET" ||
+		sp.AdminServers[0].AdminPassword != "ADMIN_SECRET" ||
+		sp.FilerServers[0].Config["password"] != "FILER_DB_SECRET" {
+		t.Fatalf("Save mutated the caller's spec secrets")
+	}
+
+	// 2) the on-disk topology must contain none of the secret values.
+	raw, err := os.ReadFile(filepath.Join(tmp, "clusters", "c1", "topology.yaml"))
+	if err != nil {
+		t.Fatalf("read topology: %v", err)
+	}
+	for _, secret := range []string{"BASTION_SECRET", "ADMIN_SECRET", "FILER_DB_SECRET", "S3_SECRET"} {
+		if strings.Contains(string(raw), secret) {
+			t.Errorf("persisted topology leaked secret %q:\n%s", secret, raw)
+		}
+	}
+	// non-secret config is preserved.
+	if !strings.Contains(string(raw), "postgres") || !strings.Contains(string(raw), "AKIA") {
+		t.Errorf("redaction removed non-secret config:\n%s", raw)
+	}
+
+	// 3) files are owner-only (0600).
+	for _, f := range []string{"topology.yaml", "state.json"} {
+		fi, err := os.Stat(filepath.Join(tmp, "clusters", "c1", f))
+		if err != nil {
+			t.Fatalf("stat %s: %v", f, err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Errorf("%s perm = %04o, want 0600", f, perm)
 		}
 	}
 }


### PR DESCRIPTION
## What

The cluster state store wrote the **full spec** to `~/.seaweed-up/clusters/<name>/topology.yaml` at **0644**, including plaintext secrets:

- `global.bastion.password`
- `admin_servers[].admin_password`
- filer DB credentials (`filer_servers[].config.password`)
- S3 IAM credentials (`s3_servers[].s3_config` → `identities[].credentials[].secretKey`)

This is the deferred follow-up from the bastion review (#84). Two changes:

1. **Redact before persisting.** `Save` now writes a **redacted deep copy** of the spec: the two password struct fields are cleared, and any secret-looking key (`password`, `secret`, `*_key`, `token`, …) inside a component's free-form `config`/`s3_config` map is blanked **at any nesting depth** (so the nested `secretKey` in an s3.json tree is caught). The caller's in-memory spec is **not** mutated — it keeps real secrets for the in-flight deploy; only the on-disk copy is scrubbed.
2. **Tighten permissions.** `topology.yaml` and `state.json` are now `0600` and the cluster directory `0700` (was `0644`/`0755`).

## Trade-off

Name-based commands that re-render configs from saved state (e.g. `cluster upgrade <name>` without `-f`) will no longer have these secrets. Run such operations with `-f <cluster.yaml>` when they're needed. This is the redaction approach (vs. encryption-at-rest, which would need a key-management story); documented in the code.

## Test plan

- `go build ./...`, `go test ./pkg/cluster/state/...` — pass
- New `TestSaveRedactsSecretsAndPerms`: asserts none of the secret values (incl. a nested s3.json `secretKey`) appear in the on-disk `topology.yaml`, the caller's spec is left intact, non-secret config (e.g. `postgres`, the S3 `accessKey`) is preserved, and both files are `0600`.

## Notes

- Scope is the persisted **state** store. Locally-cached TLS material under `~/.seaweed-up/clusters/<name>/certs/` is already written `0600`.
- Independent of #86 (passwordless-sudo fix); both branch off `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sensitive configuration data (passwords, secrets, tokens) is now automatically redacted from persisted state files to enhance data confidentiality.

* **Security Improvements**
  * State files are created with stricter, owner-only access permissions instead of world-readable permissions.

* **Tests**
  * Added tests validating secret redaction and file permission enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->