### PR TITLE
Emit -metricsPort for master/volume/filer

### DIFF
--- a/pkg/cluster/spec/filer_server_spec.go
+++ b/pkg/cluster/spec/filer_server_spec.go
@@ -46,4 +46,5 @@ func (f *FilerServerSpec) WriteToBuffer(masters []string, buf *bytes.Buffer) {
 	addToBufferInt(buf, "s3.port", f.S3Port, 8333)
 	addToBufferBool(buf, "webdav", f.Webdav, false)
 	addToBufferInt(buf, "webdav.port", f.WebdavPort, 7333)
+	addToBufferInt(buf, "metricsPort", f.MetricsPort, 0)
 }

--- a/pkg/cluster/spec/master_server_spec.go
+++ b/pkg/cluster/spec/master_server_spec.go
@@ -29,7 +29,7 @@ func (masterSpec *MasterServerSpec) WriteToBuffer(masters []string, buf *bytes.B
 	addToBufferInt(buf, "port.grpc", masterSpec.PortGrpc, 10000+masterSpec.Port)
 	addToBufferInt(buf, "volumeSizeLimitMB", masterSpec.VolumeSizeLimitMB, 30000)
 	addToBuffer(buf, "defaultReplication", masterSpec.DefaultReplication)
-
+	addToBufferInt(buf, "metricsPort", masterSpec.MetricsPort, 0)
 }
 
 func addToBuffer(buf *bytes.Buffer, name, value string) {

--- a/pkg/cluster/spec/metrics_port_test.go
+++ b/pkg/cluster/spec/metrics_port_test.go
@@ -1,0 +1,41 @@
+package spec
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// metricsPort must reach the rendered weed options for master, volume and
+// filer (it previously only did for s3), so Prometheus can scrape them.
+func TestWriteToBuffer_MetricsPort(t *testing.T) {
+	masters := []string{"10.0.0.1:9333"}
+
+	t.Run("master emits when set, omits when zero", func(t *testing.T) {
+		var set, unset bytes.Buffer
+		(&MasterServerSpec{Ip: "10.0.0.1", MetricsPort: 9324}).WriteToBuffer(masters, &set)
+		(&MasterServerSpec{Ip: "10.0.0.1"}).WriteToBuffer(masters, &unset)
+		if !strings.Contains(set.String(), "metricsPort=9324") {
+			t.Errorf("master: missing metricsPort=9324\n%s", set.String())
+		}
+		if strings.Contains(unset.String(), "metricsPort") {
+			t.Errorf("master: should omit metricsPort when unset\n%s", unset.String())
+		}
+	})
+
+	t.Run("volume emits when set", func(t *testing.T) {
+		var b bytes.Buffer
+		(&VolumeServerSpec{Ip: "10.0.0.1", MetricsPort: 9325}).WriteToBuffer(masters, &b)
+		if !strings.Contains(b.String(), "metricsPort=9325") {
+			t.Errorf("volume: missing metricsPort=9325\n%s", b.String())
+		}
+	})
+
+	t.Run("filer emits when set", func(t *testing.T) {
+		var b bytes.Buffer
+		(&FilerServerSpec{Ip: "10.0.0.1", MetricsPort: 9327}).WriteToBuffer(masters, &b)
+		if !strings.Contains(b.String(), "metricsPort=9327") {
+			t.Errorf("filer: missing metricsPort=9327\n%s", b.String())
+		}
+	})
+}

--- a/pkg/cluster/spec/volume_server_spec.go
+++ b/pkg/cluster/spec/volume_server_spec.go
@@ -62,4 +62,5 @@ func (vs *VolumeServerSpec) WriteToBuffer(masters []string, buf *bytes.Buffer) {
 	// each -dir entry. Used to keep indexes on a small fast disk while
 	// data lives on bulk HDDs.
 	addToBuffer(buf, "dir.idx", vs.IdxFolder)
+	addToBufferInt(buf, "metricsPort", vs.MetricsPort, 0)
 }


### PR DESCRIPTION
## What

`cluster prometheus-config` renders scrape targets for master/volume/filer metrics ports (defaults 9324/9325/9326), but the deploy never actually told `weed` to listen there: only the **s3** spec's `WriteToBuffer` emitted `metricsPort`. So those Prometheus jobs pointed at dead ports and SeaweedFS app metrics were never exposed.

This emits `metricsPort` for **master**, **volume**, and **filer** too (omitted when 0, matching the existing s3 convention), so setting `metrics_port:` on those components actually starts their Prometheus endpoint.

## Why

Found while wiring up Grafana for a live cluster: `curl :9324/metrics` (master), `:9325` (volume) were connection-refused, and `:9333/metrics` etc. returned 404 — no component exposed metrics. With this change + `metrics_port:` set in the spec, the components serve `/metrics` and the bundled Grafana dashboard's app panels populate.

## Test plan

- `go build ./...`, `go test ./pkg/cluster/spec/...` — pass
- Added `TestWriteToBuffer_MetricsPort`: master/volume/filer emit `metricsPort=<n>` when set, and master omits it when unset.
- Verified end-to-end on a live cluster: after setting `metrics_port` and redeploying, Prometheus scrapes the master/volume/filer targets successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics port configuration support to master, volume, and filer servers. Each server type can now be configured with a custom metrics port for monitoring.

* **Tests**
  * Added test coverage verifying metrics port configuration is correctly written to server configuration output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->