### PR TITLE
Deploy Prometheus + Grafana monitoring as part of the cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ seaweed-up cluster deploy -f cluster.yaml --component=worker
 ```
 
 Supported `--component` values:
-`master`, `volume`, `filer`, `s3`, `sftp`, `envoy`, `admin`, `worker`.
+`master`, `volume`, `filer`, `s3`, `sftp`, `envoy`, `admin`, `worker`, `monitoring`.
 
 ## Bastion / jump host
 
@@ -125,8 +125,12 @@ With `bind: 127.0.0.1` (the default) Grafana isn't exposed publicly — reach
 it over a tunnel:
 
 ```bash
-ssh -L 3000:<monitoring-host> chris@<bastion>   # then open http://localhost:3000
+ssh -L 3000:localhost:3000 chris@<monitoring-host>   # then open http://localhost:3000
 ```
+
+(Grafana binds to `127.0.0.1` on the monitoring host, so the tunnel must
+terminate there; add `-J chris@<bastion>` if the host is only reachable
+through a jump host.)
 
 Monitoring participates in the lifecycle commands too:
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,48 @@ global:
 
 The policy applies to both the direct node connections and the bastion hop.
 
+## Monitoring (Prometheus + Grafana)
+
+Declare a `monitoring:` block and `cluster deploy` will stand up the full
+observability stack as part of the cluster: node_exporter on every host,
+Prometheus and Grafana on the monitoring host, the SeaweedFS metrics ports
+auto-enabled on master/volume/filer, and the bundled SeaweedFS dashboard
+pre-loaded against a provisioned Prometheus datasource.
+
+```yaml
+monitoring:
+  host: 10.0.0.1               # runs Prometheus + Grafana
+  bind: 127.0.0.1             # localhost by default — reach Grafana via SSH tunnel
+  grafana_admin_user: admin
+  grafana_admin_password: CHANGE_ME
+  # prometheus_port: 9090     # optional
+  # grafana_port: 3000        # optional
+  # retention: 15d            # optional Prometheus retention
+  # node_exporter: true       # optional (default true)
+```
+
+```bash
+seaweed-up cluster deploy -f cluster.yaml                 # whole cluster + monitoring
+seaweed-up cluster deploy -f cluster.yaml --component=monitoring   # just the stack
+```
+
+With `bind: 127.0.0.1` (the default) Grafana isn't exposed publicly — reach
+it over a tunnel:
+
+```bash
+ssh -L 3000:<monitoring-host> chris@<bastion>   # then open http://localhost:3000
+```
+
+Monitoring participates in the lifecycle commands too:
+
+```bash
+seaweed-up cluster restart -f cluster.yaml --component=monitoring
+```
+
+The lower-level building blocks remain available if you run your own
+Prometheus/Grafana: `cluster prometheus-config`, `cluster node-exporter
+install`, and `cluster dashboard install`.
+
 ## Lifecycle
 
 Start, stop, or restart every service in the cluster, or scope the operation

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -18,7 +18,7 @@ This command group provides comprehensive cluster lifecycle management including
 - Monitor cluster status and health
 - Perform rolling upgrades and scaling operations
 - Manage cluster configurations and settings`,
-		
+
 		Example: `  # Deploy a new cluster
   seaweed-up cluster deploy -f production.yaml
   
@@ -31,7 +31,7 @@ This command group provides comprehensive cluster lifecycle management including
   # Scale out cluster
   seaweed-up cluster scale out prod-cluster --add-volume=2`,
 	}
-	
+
 	// Add cluster subcommands
 	cmd.AddCommand(newClusterDeployCmd())
 	cmd.AddCommand(newClusterCheckCmd())
@@ -58,7 +58,7 @@ func newClusterDeployCmd() *cobra.Command {
 		SSHPort:    22,
 		MountDisks: true,
 	}
-	
+
 	cmd := &cobra.Command{
 		Use:   "deploy [cluster-name]",
 		Short: "Deploy a new SeaweedFS cluster",
@@ -66,7 +66,7 @@ func newClusterDeployCmd() *cobra.Command {
 
 This command reads a YAML configuration file and deploys the specified
 SeaweedFS components across the target hosts using SSH.`,
-		
+
 		Example: `  # Deploy from config file
   seaweed-up cluster deploy -f cluster.yaml
   
@@ -75,19 +75,19 @@ SeaweedFS components across the target hosts using SSH.`,
   
   # Deploy only master components
   seaweed-up cluster deploy -f cluster.yaml --component=master`,
-		
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runClusterDeploy(cmd, args, opts)
 		},
 	}
-	
+
 	cmd.Flags().StringVarP(&opts.ConfigFile, "file", "f", "", "cluster configuration file (required)")
 	cmd.Flags().StringVarP(&opts.User, "user", "u", "", "SSH user (default: current user)")
 	cmd.Flags().IntVarP(&opts.SSHPort, "port", "p", 22, "SSH port")
 	cmd.Flags().StringVarP(&opts.IdentityFile, "identity", "i", "", "SSH identity file")
 	cmd.Flags().StringVar(&opts.Version, "version", "", "SeaweedFS version to deploy")
 	cmd.Flags().StringVar(&opts.EnvoyVersion, "envoy-version", "", "envoy release to pin (skips the GitHub latest-release lookup)")
-	cmd.Flags().StringVarP(&opts.Component, "component", "c", "", "specific component to deploy [master|volume|filer|s3|sftp|admin|envoy|worker]")
+	cmd.Flags().StringVarP(&opts.Component, "component", "c", "", "specific component to deploy [master|volume|filer|s3|sftp|admin|envoy|worker|monitoring]")
 	cmd.Flags().BoolVar(&opts.MountDisks, "mount-disks", true, "auto mount disks on volume servers")
 	cmd.Flags().BoolVar(&opts.HostPrep, "host-prep", false, "run host preparation (ulimits, sysctls, firewall, time sync) before deploy")
 	cmd.Flags().BoolVar(&opts.ForceRestart, "restart", false, "force restart services")
@@ -107,7 +107,7 @@ func newClusterStatusCmd() *cobra.Command {
 	opts := &ClusterStatusOptions{
 		Timeout: "30s",
 	}
-	
+
 	cmd := &cobra.Command{
 		Use:   "status [cluster-name]",
 		Short: "Show cluster status and health information",
@@ -118,7 +118,7 @@ Shows real-time information about cluster components including:
 - Resource usage (CPU, memory, disk)
 - Network connectivity and performance
 - Component versions and configurations`,
-		
+
 		Example: `  # Show status for all clusters
   seaweed-up cluster status
   
@@ -147,7 +147,7 @@ Shows real-time information about cluster components including:
 	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "show detailed information")
 	cmd.Flags().StringVar(&opts.Timeout, "timeout", "30s", "timeout for status collection")
 	cmd.Flags().IntVar(&opts.Refresh, "refresh", 0, "auto-refresh interval in seconds")
-	
+
 	return cmd
 }
 
@@ -213,16 +213,16 @@ func newClusterScaleCmd() *cobra.Command {
 Supports both scale-out (adding nodes) and scale-in (removing nodes)
 operations with automatic data rebalancing and health verification.`,
 	}
-	
+
 	cmd.AddCommand(newClusterScaleOutCmd())
 	cmd.AddCommand(newClusterScaleInCmd())
-	
+
 	return cmd
 }
 
 func newClusterScaleOutCmd() *cobra.Command {
 	opts := &ClusterScaleOutOptions{}
-	
+
 	cmd := &cobra.Command{
 		Use:   "out <cluster-name>",
 		Short: "Scale out cluster by adding components",
@@ -230,30 +230,30 @@ func newClusterScaleOutCmd() *cobra.Command {
 
 This command adds new volume servers, filer servers, or other components
 to increase cluster capacity and performance.`,
-		
+
 		Example: `  # Add 2 volume servers
   seaweed-up cluster scale out prod-cluster --add-volume=2
   
   # Add 1 filer server
   seaweed-up cluster scale out prod-cluster --add-filer=1`,
-		
+
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runClusterScaleOut(args[0], opts)
 		},
 	}
-	
+
 	cmd.Flags().StringVarP(&opts.ConfigFile, "file", "f", "", "cluster configuration file")
 	cmd.Flags().IntVar(&opts.AddVolume, "add-volume", 0, "number of volume servers to add")
 	cmd.Flags().IntVar(&opts.AddFiler, "add-filer", 0, "number of filer servers to add")
 	cmd.Flags().BoolVarP(&opts.SkipConfirm, "yes", "y", false, "skip confirmation prompts")
-	
+
 	return cmd
 }
 
 func newClusterScaleInCmd() *cobra.Command {
 	opts := &ClusterScaleInOptions{SSHPort: 22}
-	
+
 	cmd := &cobra.Command{
 		Use:   "in <cluster-name>",
 		Short: "Scale in cluster by removing components",
@@ -261,16 +261,16 @@ func newClusterScaleInCmd() *cobra.Command {
 
 This command safely removes components after ensuring data is
 properly migrated and cluster health is maintained.`,
-		
+
 		Example: `  # Remove specific nodes
   seaweed-up cluster scale in prod-cluster --remove-node=node1,node2`,
-		
+
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runClusterScaleIn(args[0], opts)
 		},
 	}
-	
+
 	cmd.Flags().StringVarP(&opts.ConfigFile, "file", "f", "", "cluster configuration file")
 	cmd.Flags().StringSliceVar(&opts.RemoveNodes, "remove-node", nil, "nodes to remove (comma-separated)")
 	cmd.Flags().StringVarP(&opts.User, "user", "u", "", "SSH user (default: current user)")
@@ -292,39 +292,39 @@ func newClusterDestroyCmd() *cobra.Command {
 
 WARNING: This operation is irreversible. All cluster components will be
 stopped and removed. Use --remove-data to also delete all stored data.`,
-		
+
 		Example: `  # Destroy cluster but keep data
   seaweed-up cluster destroy prod-cluster
   
   # Destroy cluster and remove all data
   seaweed-up cluster destroy prod-cluster --remove-data`,
-		
+
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runClusterDestroy(args[0], opts)
 		},
 	}
-	
+
 	cmd.Flags().StringVarP(&opts.ConfigFile, "file", "f", "", "cluster configuration file")
 	cmd.Flags().StringVarP(&opts.User, "user", "u", "", "SSH user (default: current user)")
 	cmd.Flags().IntVarP(&opts.SSHPort, "port", "p", 22, "SSH port")
 	cmd.Flags().StringVarP(&opts.IdentityFile, "identity", "i", "", "SSH identity file")
 	cmd.Flags().BoolVarP(&opts.SkipConfirm, "yes", "y", false, "skip confirmation prompts")
 	cmd.Flags().BoolVar(&opts.RemoveData, "remove-data", false, "remove all cluster data (WARNING: irreversible)")
-	
+
 	return cmd
 }
 
 func newClusterListCmd() *cobra.Command {
 	opts := &ClusterListOptions{}
-	
+
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all managed clusters",
 		Long: `Display a list of all SeaweedFS clusters managed by seaweed-up.
 
 Shows cluster names, status, versions, and basic configuration information.`,
-		
+
 		Example: `  # List all clusters
   seaweed-up cluster list
   
@@ -333,14 +333,14 @@ Shows cluster names, status, versions, and basic configuration information.`,
   
   # Output in JSON format
   seaweed-up cluster list --json`,
-		
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runClusterList(opts)
 		},
 	}
-	
+
 	cmd.Flags().BoolVar(&opts.JSONOutput, "json", false, "output in JSON format")
 	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "show detailed information")
-	
+
 	return cmd
 }

--- a/cmd/cluster_lifecycle.go
+++ b/cmd/cluster_lifecycle.go
@@ -81,7 +81,7 @@ func newClusterRestartCmd() *cobra.Command {
 
 func addLifecycleFlags(cmd *cobra.Command, opts *ClusterLifecycleOptions) {
 	cmd.Flags().StringVarP(&opts.ConfigFile, "file", "f", "", "cluster configuration file (required)")
-	cmd.Flags().StringVarP(&opts.Component, "component", "c", "", "specific component to target [master|volume|filer|envoy|s3|sftp|admin|worker]")
+	cmd.Flags().StringVarP(&opts.Component, "component", "c", "", "specific component to target [master|volume|filer|envoy|s3|sftp|admin|worker|monitoring]")
 	cmd.Flags().StringVarP(&opts.User, "user", "u", "", "SSH user (default: current user)")
 	cmd.Flags().IntVarP(&opts.SSHPort, "port", "p", 22, "SSH port")
 	cmd.Flags().StringVarP(&opts.IdentityFile, "identity", "i", "", "SSH identity file")

--- a/cmd/cluster_lifecycle.go
+++ b/cmd/cluster_lifecycle.go
@@ -95,9 +95,9 @@ func runClusterLifecycle(verb manager.LifecycleVerb, opts *ClusterLifecycleOptio
 	}
 
 	switch opts.Component {
-	case "", "master", "volume", "filer", "envoy", "s3", "sftp", "admin", "worker":
+	case "", "master", "volume", "filer", "envoy", "s3", "sftp", "admin", "worker", "monitoring":
 	default:
-		return fmt.Errorf("invalid --component value %q (want master|volume|filer|envoy|s3|sftp|admin|worker)", opts.Component)
+		return fmt.Errorf("invalid --component value %q (want master|volume|filer|envoy|s3|sftp|admin|worker|monitoring)", opts.Component)
 	}
 
 	if !opts.SkipConfirm {

--- a/cmd/cluster_observability.go
+++ b/cmd/cluster_observability.go
@@ -206,7 +206,7 @@ func runNodeExporterInstall(cmd *cobra.Command, s *spec.Specification, opts *Obs
 			mu.Unlock()
 			addr := fmt.Sprintf("%s:%d", h.IP, h.SSHPort)
 			err := operator.ExecuteRemote(addr, opts.User, opts.IdentityFile, "", func(op operator.CommandOperator) error {
-				return observability.InstallNodeExporter(op)
+				return observability.InstallNodeExporter(op, opts.User, "")
 			})
 			if err != nil {
 				mu.Lock()

--- a/pkg/cluster/manager/deploy_monitoring.go
+++ b/pkg/cluster/manager/deploy_monitoring.go
@@ -1,0 +1,207 @@
+package manager
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/observability"
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+	"github.com/seaweedfs/seaweed-up/pkg/operator"
+	"github.com/seaweedfs/seaweed-up/pkg/utils"
+	"golang.org/x/sync/errgroup"
+)
+
+// metricsPortBase is the first port assigned to a component's Prometheus
+// metrics endpoint when one isn't set explicitly.
+const metricsPortBase = 9324
+
+// assignMetricsPorts gives every master/volume/filer without an explicit
+// metrics_port a per-host-unique one (so two volume servers on the same
+// host don't collide), starting at metricsPortBase. Explicitly-set ports
+// are preserved and reserved. The same spec drives both the deploy
+// (-metricsPort) and the rendered Prometheus scrape config, so they stay
+// in sync. Only called when monitoring is enabled.
+func assignMetricsPorts(s *spec.Specification) {
+	if s == nil {
+		return
+	}
+	used := map[string]map[int]bool{}
+	mark := func(ip string, p int) {
+		if p == 0 {
+			return
+		}
+		if used[ip] == nil {
+			used[ip] = map[int]bool{}
+		}
+		used[ip][p] = true
+	}
+	for _, m := range s.MasterServers {
+		if m != nil {
+			mark(m.Ip, m.MetricsPort)
+		}
+	}
+	for _, v := range s.VolumeServers {
+		if v != nil {
+			mark(v.Ip, v.MetricsPort)
+		}
+	}
+	for _, f := range s.FilerServers {
+		if f != nil {
+			mark(f.Ip, f.MetricsPort)
+		}
+	}
+
+	next := map[string]int{}
+	alloc := func(ip string) int {
+		if used[ip] == nil {
+			used[ip] = map[int]bool{}
+		}
+		p := next[ip]
+		if p < metricsPortBase {
+			p = metricsPortBase
+		}
+		for used[ip][p] {
+			p++
+		}
+		used[ip][p] = true
+		next[ip] = p + 1
+		return p
+	}
+	for _, m := range s.MasterServers {
+		if m != nil && m.MetricsPort == 0 {
+			m.MetricsPort = alloc(m.Ip)
+		}
+	}
+	for _, v := range s.VolumeServers {
+		if v != nil && v.MetricsPort == 0 {
+			v.MetricsPort = alloc(v.Ip)
+		}
+	}
+	for _, f := range s.FilerServers {
+		if f != nil && f.MetricsPort == 0 {
+			f.MetricsPort = alloc(f.Ip)
+		}
+	}
+}
+
+type monHost struct {
+	ip   string
+	port int
+}
+
+// monitoringNodeHosts returns the deduplicated (ip, ssh-port) set of hosts
+// that should run node_exporter — every host carrying a master, volume, or
+// filer.
+func monitoringNodeHosts(s *spec.Specification) []monHost {
+	seen := map[string]struct{}{}
+	var out []monHost
+	add := func(ip string, port int) {
+		if ip == "" {
+			return
+		}
+		if port == 0 {
+			port = 22
+		}
+		key := fmt.Sprintf("%s:%d", ip, port)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, monHost{ip: ip, port: port})
+	}
+	for _, m := range s.MasterServers {
+		if m != nil {
+			add(m.Ip, m.PortSsh)
+		}
+	}
+	for _, v := range s.VolumeServers {
+		if v != nil {
+			add(v.Ip, v.PortSsh)
+		}
+	}
+	for _, f := range s.FilerServers {
+		if f != nil {
+			add(f.Ip, f.PortSsh)
+		}
+	}
+	return out
+}
+
+// DeployMonitoring installs node_exporter on every host (unless disabled)
+// and the Prometheus + Grafana stack on the monitoring host, with the
+// scrape config rendered from the spec and the bundled SeaweedFS dashboard
+// provisioned.
+func (m *Manager) DeployMonitoring(s *spec.Specification) error {
+	mon := s.Monitoring
+	if mon == nil {
+		return nil
+	}
+
+	if mon.InstallNodeExporter() {
+		hosts := monitoringNodeHosts(s)
+		var eg errgroup.Group
+		eg.SetLimit(8)
+		var (
+			mu   sync.Mutex
+			errs []error
+		)
+		for _, h := range hosts {
+			h := h
+			eg.Go(func() error {
+				info(fmt.Sprintf("Installing node_exporter on %s...", h.ip))
+				addr := fmt.Sprintf("%s:%d", h.ip, h.port)
+				err := operator.ExecuteRemote(addr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+					return observability.InstallNodeExporter(op, m.User, m.sudoPass)
+				})
+				if err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Errorf("node_exporter on %s: %w", h.ip, err))
+					mu.Unlock()
+				}
+				return nil
+			})
+		}
+		_ = eg.Wait()
+		if len(errs) > 0 {
+			return errs[0]
+		}
+		info(fmt.Sprintf("node_exporter installed on %d host(s)", len(hosts)))
+	}
+
+	monAddr := fmt.Sprintf("%s:%d", mon.Host, utils.NvlInt(mon.PortSsh, m.SshPort, 22))
+
+	var promCfg bytes.Buffer
+	promCfg.WriteString("global:\n  scrape_interval: 15s\n  evaluation_interval: 15s\n\n")
+	promCfg.WriteString(observability.RenderPromConfig(s))
+
+	info("Installing Prometheus on " + mon.Host)
+	if err := operator.ExecuteRemote(monAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+		return observability.InstallPrometheus(op, m.User, m.sudoPass, observability.PrometheusOptions{
+			ConfigYAML: promCfg.String(),
+			Bind:       mon.EffectiveBind(),
+			Port:       mon.EffectivePrometheusPort(),
+			Retention:  mon.EffectiveRetention(),
+		})
+	}); err != nil {
+		return fmt.Errorf("install prometheus on %s: %w", mon.Host, err)
+	}
+
+	info("Installing Grafana on " + mon.Host)
+	if err := operator.ExecuteRemote(monAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+		return observability.InstallGrafana(op, m.User, m.sudoPass, observability.GrafanaOptions{
+			Bind:          mon.EffectiveBind(),
+			Port:          mon.EffectiveGrafanaPort(),
+			AdminUser:     mon.EffectiveGrafanaAdminUser(),
+			AdminPassword: mon.GrafanaAdminPassword,
+			PrometheusURL: fmt.Sprintf("http://127.0.0.1:%d", mon.EffectivePrometheusPort()),
+			ClusterName:   s.Name,
+		})
+	}); err != nil {
+		return fmt.Errorf("install grafana on %s: %w", mon.Host, err)
+	}
+
+	info(fmt.Sprintf("Monitoring deployed: Grafana on %s:%d (bind %s), Prometheus :%d",
+		mon.Host, mon.EffectiveGrafanaPort(), mon.EffectiveBind(), mon.EffectivePrometheusPort()))
+	return nil
+}

--- a/pkg/cluster/manager/deploy_monitoring_test.go
+++ b/pkg/cluster/manager/deploy_monitoring_test.go
@@ -1,0 +1,86 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+)
+
+func TestAssignMetricsPorts_PerHostUnique(t *testing.T) {
+	s := &spec.Specification{
+		Monitoring: &spec.MonitoringSpec{Host: "10.0.0.1"},
+		MasterServers: []*spec.MasterServerSpec{
+			{Ip: "10.0.0.1"}, {Ip: "10.0.0.2"},
+		},
+		VolumeServers: []*spec.VolumeServerSpec{
+			{Ip: "10.0.0.1", Port: 8080}, {Ip: "10.0.0.1", Port: 8081}, // two on the same host
+			{Ip: "10.0.0.2", Port: 8080},
+		},
+		FilerServers: []*spec.FilerServerSpec{
+			{Ip: "10.0.0.1"},
+		},
+	}
+	assignMetricsPorts(s)
+
+	// collect ports per host; each host's ports must be unique and >= base
+	perHost := map[string][]int{}
+	for _, m := range s.MasterServers {
+		perHost[m.Ip] = append(perHost[m.Ip], m.MetricsPort)
+	}
+	for _, v := range s.VolumeServers {
+		perHost[v.Ip] = append(perHost[v.Ip], v.MetricsPort)
+	}
+	for _, f := range s.FilerServers {
+		perHost[f.Ip] = append(perHost[f.Ip], f.MetricsPort)
+	}
+	for ip, ports := range perHost {
+		seen := map[int]bool{}
+		for _, p := range ports {
+			if p < metricsPortBase {
+				t.Errorf("host %s got port %d below base %d", ip, p, metricsPortBase)
+			}
+			if seen[p] {
+				t.Errorf("host %s has duplicate metrics port %d (%v)", ip, p, ports)
+			}
+			seen[p] = true
+		}
+	}
+	// host 10.0.0.1 has 4 components -> 4 distinct ports
+	if len(perHost["10.0.0.1"]) != 4 || len(map[int]bool{
+		perHost["10.0.0.1"][0]: true, perHost["10.0.0.1"][1]: true,
+		perHost["10.0.0.1"][2]: true, perHost["10.0.0.1"][3]: true,
+	}) != 4 {
+		t.Errorf("expected 4 distinct ports on 10.0.0.1, got %v", perHost["10.0.0.1"])
+	}
+}
+
+func TestAssignMetricsPorts_PreservesExplicit(t *testing.T) {
+	s := &spec.Specification{
+		Monitoring: &spec.MonitoringSpec{Host: "10.0.0.1"},
+		MasterServers: []*spec.MasterServerSpec{
+			{Ip: "10.0.0.1", MetricsPort: 9999},
+		},
+		VolumeServers: []*spec.VolumeServerSpec{
+			{Ip: "10.0.0.1", Port: 8080}, // must not be assigned 9999
+		},
+	}
+	assignMetricsPorts(s)
+	if s.MasterServers[0].MetricsPort != 9999 {
+		t.Errorf("explicit master metrics port changed: %d", s.MasterServers[0].MetricsPort)
+	}
+	if s.VolumeServers[0].MetricsPort == 9999 || s.VolumeServers[0].MetricsPort == 0 {
+		t.Errorf("volume should get a fresh non-conflicting port, got %d", s.VolumeServers[0].MetricsPort)
+	}
+}
+
+func TestMonitoringNodeHosts_Dedup(t *testing.T) {
+	s := &spec.Specification{
+		MasterServers: []*spec.MasterServerSpec{{Ip: "10.0.0.1", PortSsh: 22}},
+		VolumeServers: []*spec.VolumeServerSpec{{Ip: "10.0.0.1", PortSsh: 22}, {Ip: "10.0.0.2", PortSsh: 22}},
+		FilerServers:  []*spec.FilerServerSpec{{Ip: "10.0.0.1", PortSsh: 22}},
+	}
+	hosts := monitoringNodeHosts(s)
+	if len(hosts) != 2 {
+		t.Fatalf("expected 2 unique hosts, got %d: %+v", len(hosts), hosts)
+	}
+}

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -517,6 +517,12 @@ func (m *Manager) prepare(specification *spec.Specification) {
 	for _, workerSpec := range specification.WorkerServers {
 		workerSpec.PortSsh = utils.NvlInt(workerSpec.PortSsh, m.SshPort, 22)
 	}
+	// The monitoring host's SSH port isn't a struct-tag default, so normalize
+	// it here like every other server; otherwise lifecycle commands would dial
+	// it on port 0 when not set explicitly.
+	if specification.Monitoring != nil {
+		specification.Monitoring.PortSsh = utils.NvlInt(specification.Monitoring.PortSsh, m.SshPort, 22)
+	}
 }
 
 func (m *Manager) deployComponentInstance(op operator.CommandOperator, component string, componentInstance string, cliOptions *bytes.Buffer, extras ...extraConfigFile) error {

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -182,6 +182,13 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	}
 	m.prepare(specification)
 
+	// When monitoring is enabled, give master/volume/filer a metrics port
+	// (if not set) before they are deployed, so weed exposes /metrics and
+	// the rendered Prometheus scrape config matches.
+	if specification.Monitoring != nil {
+		assignMetricsPorts(specification)
+	}
+
 	if m.HostPrep {
 		if err := m.PrepareAllHosts(specification); err != nil {
 			return err
@@ -444,6 +451,12 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 			if err := m.DeployEnvoyServer(specification.FilerServers, envoySpec, index); err != nil {
 				return fmt.Errorf("deploy to envoy server %s:%d :%v", envoySpec.Ip, envoySpec.PortSsh, err)
 			}
+		}
+	}
+
+	if m.shouldInstall("monitoring") && specification.Monitoring != nil {
+		if err := m.DeployMonitoring(specification); err != nil {
+			return fmt.Errorf("deploy monitoring: %w", err)
 		}
 	}
 	return nil

--- a/pkg/cluster/manager/manager_deploy_test.go
+++ b/pkg/cluster/manager/manager_deploy_test.go
@@ -48,6 +48,37 @@ func TestDeployCluster_SecurityTomlFailureSkipsFilers(t *testing.T) {
 	}
 }
 
+// TestPrepareDefaultsMonitoringSSHPort locks in that prepare normalizes the
+// monitoring host's SSH port. Unlike the other servers it has no struct-tag
+// default, so without this the lifecycle commands (start/stop/restart) would
+// dial the monitoring host on port 0.
+func TestPrepareDefaultsMonitoringSSHPort(t *testing.T) {
+	m := NewManager()
+	m.User = "root" // skip sudo password prompt in m.prepare
+
+	// Unset -> defaults to 22.
+	sp := &spec.Specification{Monitoring: &spec.MonitoringSpec{Host: "10.0.0.1"}}
+	m.prepare(sp)
+	if sp.Monitoring.PortSsh != 22 {
+		t.Errorf("unset monitoring ssh port: got %d, want 22", sp.Monitoring.PortSsh)
+	}
+
+	// Explicit value preserved.
+	sp = &spec.Specification{Monitoring: &spec.MonitoringSpec{Host: "10.0.0.1", PortSsh: 2222}}
+	m.prepare(sp)
+	if sp.Monitoring.PortSsh != 2222 {
+		t.Errorf("explicit monitoring ssh port: got %d, want 2222", sp.Monitoring.PortSsh)
+	}
+
+	// Manager-wide SshPort applies when the host value is unset.
+	m.SshPort = 2200
+	sp = &spec.Specification{Monitoring: &spec.MonitoringSpec{Host: "10.0.0.1"}}
+	m.prepare(sp)
+	if sp.Monitoring.PortSsh != 2200 {
+		t.Errorf("monitoring ssh port from manager SshPort: got %d, want 2200", sp.Monitoring.PortSsh)
+	}
+}
+
 func TestValidateSingleAdminServer_zeroOrOneOK(t *testing.T) {
 	// Zero admins: cluster runs without the admin UI. Allowed.
 	if err := validateSingleAdminServer(&spec.Specification{}); err != nil {

--- a/pkg/cluster/manager/manager_lifecycle.go
+++ b/pkg/cluster/manager/manager_lifecycle.go
@@ -79,6 +79,23 @@ func componentServiceNames(s *spec.Specification, component, ip string) []string
 				names = append(names, fmt.Sprintf("seaweed_worker%d.service", i))
 			}
 		}
+	case "monitoring":
+		// Monitoring units are not seaweed_* — node_exporter runs on every
+		// cluster host; Prometheus + Grafana on the monitoring host.
+		if s.Monitoring == nil {
+			break
+		}
+		if s.Monitoring.InstallNodeExporter() {
+			for _, h := range monitoringNodeHosts(s) {
+				if h.ip == ip {
+					names = append(names, "node_exporter.service")
+					break
+				}
+			}
+		}
+		if s.Monitoring.Host == ip {
+			names = append(names, "prometheus.service", "grafana.service")
+		}
 	}
 	return names
 }
@@ -88,7 +105,7 @@ func componentServiceNames(s *spec.Specification, component, ip string) []string
 // "envoy" / "s3" / "sftp" / "admin" / "worker").
 func servicesForHost(s *spec.Specification, ip, component string) []string {
 	var names []string
-	comps := []string{"master", "volume", "filer", "envoy", "s3", "sftp", "admin", "worker"}
+	comps := []string{"master", "volume", "filer", "envoy", "s3", "sftp", "admin", "worker", "monitoring"}
 	if component != "" {
 		comps = []string{component}
 	}
@@ -153,6 +170,14 @@ func uniqueHosts(s *spec.Specification, component string) []hostEntry {
 		for _, w := range s.WorkerServers {
 			add(w.Ip, w.PortSsh)
 		}
+	}
+	if (component == "" || component == "monitoring") && s.Monitoring != nil {
+		if s.Monitoring.InstallNodeExporter() {
+			for _, h := range monitoringNodeHosts(s) {
+				add(h.ip, h.port)
+			}
+		}
+		add(s.Monitoring.Host, s.Monitoring.PortSsh)
 	}
 
 	return order

--- a/pkg/cluster/observability/install.go
+++ b/pkg/cluster/observability/install.go
@@ -1,0 +1,281 @@
+package observability
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/seaweedfs/seaweed-up/pkg/operator"
+)
+
+// prepareDashboard returns the bundled dashboard JSON ready for Grafana
+// file provisioning: "id" removed (Grafana assigns one) and, when
+// clusterName is set, the title suffixed so multiple clusters coexist.
+// Unlike buildDashboardPayload (the API path), this returns the bare
+// dashboard model, which is what the file provider expects. Falls back to
+// the raw bytes if the JSON can't be parsed.
+func prepareDashboard(raw []byte, clusterName string) []byte {
+	var dash map[string]interface{}
+	if err := json.Unmarshal(raw, &dash); err != nil {
+		return raw
+	}
+	delete(dash, "id")
+	if clusterName != "" {
+		if title, ok := dash["title"].(string); ok && title != "" {
+			dash["title"] = title + " - " + clusterName
+		}
+	}
+	out, err := json.Marshal(dash)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// Pinned versions for the bundled monitoring stack. node_exporter is
+// pinned in observability.go (NodeExporterVersion).
+const (
+	PrometheusVersion = "2.55.1"
+	GrafanaVersion    = "11.6.6"
+)
+
+// PrometheusOptions configures InstallPrometheus.
+type PrometheusOptions struct {
+	// ConfigYAML is the full prometheus.yml content (global + scrape_configs).
+	ConfigYAML string
+	// Bind is the listen address (e.g. 127.0.0.1); Port the listen port.
+	Bind string
+	Port int
+	// Retention is the tsdb retention window, e.g. "15d".
+	Retention string
+}
+
+// GrafanaOptions configures InstallGrafana.
+type GrafanaOptions struct {
+	Bind          string
+	Port          int
+	AdminUser     string
+	AdminPassword string
+	// PrometheusURL is the datasource URL provisioned in Grafana.
+	PrometheusURL string
+	// ClusterName, when set, is appended to the dashboard title.
+	ClusterName string
+}
+
+// shellQuote single-quotes s for safe embedding in a POSIX shell command.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// runScript runs script on the remote host, elevating to root the same
+// way pkg/cluster/tls.runInstallScript does: direct when the SSH user is
+// root, `sudo -n` when a non-root user has passwordless sudo, and
+// `sudo -S` when a sudo password is supplied. The script is base64-encoded
+// so its contents (heredocs, embedded files) survive shell quoting.
+func runScript(op operator.CommandOperator, sshUser, sudoPass, script string) error {
+	enc := base64.StdEncoding.EncodeToString([]byte(script))
+	var cmd string
+	switch {
+	case sshUser == "root":
+		cmd = fmt.Sprintf("echo %s | base64 -d | sh", enc)
+	case sudoPass == "":
+		cmd = fmt.Sprintf("echo %s | base64 -d | sudo -n sh", enc)
+	default:
+		cmd = fmt.Sprintf("(echo %s; echo %s | base64 -d) | sudo -S -p '' sh", shellQuote(sudoPass), enc)
+	}
+	return op.Execute(cmd)
+}
+
+// writeFileCmd returns a shell snippet that writes content to path with
+// the given mode, embedding content as base64 so arbitrary bytes are safe.
+func writeFileCmd(path, content, mode string) string {
+	enc := base64.StdEncoding.EncodeToString([]byte(content))
+	return fmt.Sprintf("echo %s | base64 -d > %s\nchmod %s %s", enc, shellQuote(path), mode, shellQuote(path))
+}
+
+// PrometheusInstallScript renders the shell script that installs and
+// starts Prometheus. Exposed (and pure) so it can be unit-tested.
+func PrometheusInstallScript(goArch string, opts PrometheusOptions) string {
+	bind := opts.Bind
+	if bind == "" {
+		bind = "127.0.0.1"
+	}
+	port := opts.Port
+	if port == 0 {
+		port = 9090
+	}
+	retention := opts.Retention
+	if retention == "" {
+		retention = "15d"
+	}
+	tb := fmt.Sprintf("prometheus-%s.linux-%s", PrometheusVersion, goArch)
+	url := fmt.Sprintf("https://github.com/prometheus/prometheus/releases/download/v%s/%s.tar.gz",
+		PrometheusVersion, tb)
+
+	unit := fmt.Sprintf(`[Unit]
+Description=Prometheus
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=prometheus
+Group=prometheus
+ExecStart=/usr/local/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus --storage.tsdb.retention.time=%s --web.listen-address=%s:%d
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`, retention, bind, port)
+
+	return strings.Join([]string{
+		"set -e",
+		"cd /tmp",
+		fmt.Sprintf("if [ ! -x /usr/local/bin/prometheus ]; then curl -fsSL -o %s.tar.gz %q && tar -xzf %s.tar.gz && install -m0755 %s/prometheus /usr/local/bin/prometheus && install -m0755 %s/promtool /usr/local/bin/promtool && rm -rf %s.tar.gz %s; fi", tb, url, tb, tb, tb, tb, tb),
+		"id prometheus >/dev/null 2>&1 || useradd --system --no-create-home --shell /usr/sbin/nologin prometheus",
+		"mkdir -p /etc/prometheus /var/lib/prometheus",
+		writeFileCmd("/etc/prometheus/prometheus.yml", opts.ConfigYAML, "0644"),
+		"chown -R prometheus:prometheus /etc/prometheus /var/lib/prometheus",
+		"/usr/local/bin/promtool check config /etc/prometheus/prometheus.yml",
+		writeFileCmd("/etc/systemd/system/prometheus.service", unit, "0644"),
+		"systemctl daemon-reload",
+		"systemctl enable prometheus.service >/dev/null 2>&1",
+		"systemctl restart prometheus.service",
+	}, "\n")
+}
+
+// InstallPrometheus installs and starts Prometheus on the host behind op.
+func InstallPrometheus(op operator.CommandOperator, sshUser, sudoPass string, opts PrometheusOptions) error {
+	if op == nil {
+		return fmt.Errorf("observability: nil CommandOperator")
+	}
+	goArch, err := remoteGoArch(op)
+	if err != nil {
+		return err
+	}
+	if err := runScript(op, sshUser, sudoPass, PrometheusInstallScript(goArch, opts)); err != nil {
+		return fmt.Errorf("install prometheus: %w", err)
+	}
+	return nil
+}
+
+// GrafanaInstallScript renders the shell script that installs and starts
+// Grafana with the Prometheus datasource and bundled dashboard
+// provisioned. Pure, for unit tests.
+func GrafanaInstallScript(goArch string, dashboard []byte, opts GrafanaOptions) string {
+	bind := opts.Bind
+	if bind == "" {
+		bind = "127.0.0.1"
+	}
+	port := opts.Port
+	if port == 0 {
+		port = 3000
+	}
+	user := opts.AdminUser
+	if user == "" {
+		user = "admin"
+	}
+	promURL := opts.PrometheusURL
+	if promURL == "" {
+		promURL = "http://127.0.0.1:9090"
+	}
+	dir := fmt.Sprintf("grafana-v%s", GrafanaVersion)
+	url := fmt.Sprintf("https://dl.grafana.com/oss/release/grafana-%s.linux-%s.tar.gz",
+		GrafanaVersion, goArch)
+
+	ini := fmt.Sprintf(`[server]
+http_addr = %s
+http_port = %d
+[security]
+admin_user = %s
+admin_password = %s
+[paths]
+data = /var/lib/grafana
+logs = /var/log/grafana
+provisioning = /etc/grafana/provisioning
+[analytics]
+reporting_enabled = false
+check_for_updates = false
+`, bind, port, user, opts.AdminPassword)
+
+	datasource := `apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    uid: seaweedprom
+    url: ` + promURL + `
+    isDefault: true
+`
+	provider := `apiVersion: 1
+providers:
+  - name: seaweedfs
+    type: file
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false
+`
+	unit := fmt.Sprintf(`[Unit]
+Description=Grafana
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=grafana
+Group=grafana
+ExecStart=/opt/grafana/bin/grafana server --homepath=/opt/grafana --config=/etc/grafana/grafana.ini
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`)
+
+	return strings.Join([]string{
+		"set -e",
+		"cd /tmp",
+		fmt.Sprintf("if [ ! -x /opt/grafana/bin/grafana ]; then curl -fsSL -o grafana.tar.gz %q && tar -xzf grafana.tar.gz && rm -rf /opt/grafana && mv %s /opt/grafana && rm -f grafana.tar.gz; fi", url, dir),
+		"id grafana >/dev/null 2>&1 || useradd --system --no-create-home --shell /usr/sbin/nologin grafana",
+		"mkdir -p /etc/grafana/provisioning/datasources /etc/grafana/provisioning/dashboards /var/lib/grafana/dashboards /var/log/grafana",
+		writeFileCmd("/etc/grafana/grafana.ini", ini, "0640"),
+		writeFileCmd("/etc/grafana/provisioning/datasources/prometheus.yml", datasource, "0644"),
+		writeFileCmd("/etc/grafana/provisioning/dashboards/seaweedfs.yml", provider, "0644"),
+		writeFileCmd("/var/lib/grafana/dashboards/seaweedfs.json", string(prepareDashboard(dashboard, opts.ClusterName)), "0644"),
+		"chown -R grafana:grafana /etc/grafana /var/lib/grafana /var/log/grafana",
+		writeFileCmd("/etc/systemd/system/grafana.service", unit, "0644"),
+		"systemctl daemon-reload",
+		"systemctl enable grafana.service >/dev/null 2>&1",
+		"systemctl restart grafana.service",
+	}, "\n")
+}
+
+// InstallGrafana installs and starts Grafana on the host behind op.
+func InstallGrafana(op operator.CommandOperator, sshUser, sudoPass string, opts GrafanaOptions) error {
+	if op == nil {
+		return fmt.Errorf("observability: nil CommandOperator")
+	}
+	goArch, err := remoteGoArch(op)
+	if err != nil {
+		return err
+	}
+	if err := runScript(op, sshUser, sudoPass, GrafanaInstallScript(goArch, DashboardJSON(), opts)); err != nil {
+		return fmt.Errorf("install grafana: %w", err)
+	}
+	return nil
+}
+
+// remoteGoArch maps the remote `uname -m` to a Go/release arch token.
+func remoteGoArch(op operator.CommandOperator) (string, error) {
+	arch, err := op.Output("uname -m")
+	if err != nil {
+		return "", fmt.Errorf("detect arch: %w", err)
+	}
+	switch strings.TrimSpace(string(arch)) {
+	case "aarch64", "arm64":
+		return "arm64", nil
+	default:
+		return "amd64", nil
+	}
+}

--- a/pkg/cluster/observability/install.go
+++ b/pkg/cluster/observability/install.go
@@ -180,7 +180,9 @@ func GrafanaInstallScript(goArch string, dashboard []byte, opts GrafanaOptions) 
 	if promURL == "" {
 		promURL = "http://127.0.0.1:9090"
 	}
-	dir := fmt.Sprintf("grafana-v%s", GrafanaVersion)
+	// The official Grafana release tarball extracts to grafana-<version>
+	// (no leading "v"), e.g. grafana-11.6.6.
+	dir := fmt.Sprintf("grafana-%s", GrafanaVersion)
 	url := fmt.Sprintf("https://dl.grafana.com/oss/release/grafana-%s.linux-%s.tar.gz",
 		GrafanaVersion, goArch)
 

--- a/pkg/cluster/observability/install.go
+++ b/pkg/cluster/observability/install.go
@@ -277,6 +277,10 @@ func remoteGoArch(op operator.CommandOperator) (string, error) {
 	switch strings.TrimSpace(string(arch)) {
 	case "aarch64", "arm64":
 		return "arm64", nil
+	case "armv7l", "armv6l":
+		// node_exporter, Prometheus and Grafana all publish linux-armv7
+		// tarballs; map 32-bit ARM there rather than mislabelling amd64.
+		return "armv7", nil
 	default:
 		return "amd64", nil
 	}

--- a/pkg/cluster/observability/install_test.go
+++ b/pkg/cluster/observability/install_test.go
@@ -96,12 +96,18 @@ func TestGrafanaInstallScript(t *testing.T) {
 	})
 	for _, want := range []string{
 		"grafana-" + GrafanaVersion + ".linux-amd64",
+		// The tarball extracts to grafana-<version> (no leading "v"); the mv
+		// must target that exact dir or the install fails.
+		"mv grafana-" + GrafanaVersion + " /opt/grafana",
 		"/var/lib/grafana/dashboards/seaweedfs.json",
 		"systemctl restart grafana.service",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("grafana script missing %q", want)
 		}
+	}
+	if strings.Contains(s, "grafana-v") {
+		t.Errorf("grafana script must not reference a v-prefixed dir: %s", s)
 	}
 	files := decodedFiles(s)
 	for _, want := range []string{

--- a/pkg/cluster/observability/install_test.go
+++ b/pkg/cluster/observability/install_test.go
@@ -25,10 +25,20 @@ func decodedFiles(script string) string {
 }
 
 // recordOp records executed commands without opening any SSH session.
-type recordOp struct{ executed []string }
+type recordOp struct {
+	executed []string
+	// archOut overrides the `uname -m` reply; defaults to x86_64 when empty.
+	archOut string
+}
 
-func (r *recordOp) Execute(cmd string) error               { r.executed = append(r.executed, cmd); return nil }
-func (r *recordOp) Output(cmd string) ([]byte, error)      { r.executed = append(r.executed, cmd); return []byte("x86_64\n"), nil }
+func (r *recordOp) Execute(cmd string) error { r.executed = append(r.executed, cmd); return nil }
+func (r *recordOp) Output(cmd string) ([]byte, error) {
+	r.executed = append(r.executed, cmd)
+	if r.archOut != "" {
+		return []byte(r.archOut), nil
+	}
+	return []byte("x86_64\n"), nil
+}
 func (r *recordOp) Upload(io.Reader, string, string) error { return nil }
 func (r *recordOp) UploadFile(string, string, string) error {
 	return nil
@@ -120,6 +130,27 @@ func TestGrafanaInstallScript(t *testing.T) {
 	} {
 		if !strings.Contains(files, want) {
 			t.Errorf("grafana embedded files missing %q", want)
+		}
+	}
+}
+
+func TestRemoteGoArch(t *testing.T) {
+	cases := map[string]string{
+		"x86_64\n":  "amd64",
+		"aarch64\n": "arm64",
+		"arm64\n":   "arm64",
+		"armv7l\n":  "armv7",
+		"armv6l\n":  "armv7",
+		"i686\n":    "amd64", // unknown -> amd64 fallback
+	}
+	for in, want := range cases {
+		op := &recordOp{archOut: in}
+		got, err := remoteGoArch(op)
+		if err != nil {
+			t.Fatalf("remoteGoArch(%q): %v", in, err)
+		}
+		if got != want {
+			t.Errorf("remoteGoArch(%q) = %q, want %q", strings.TrimSpace(in), got, want)
 		}
 	}
 }

--- a/pkg/cluster/observability/install_test.go
+++ b/pkg/cluster/observability/install_test.go
@@ -1,0 +1,130 @@
+package observability
+
+import (
+	"encoding/base64"
+	"io"
+	"strings"
+	"testing"
+)
+
+// decodedFiles returns the concatenated decoded content of every
+// `echo <b64> | base64 -d > path` snippet in a script, so tests can assert
+// on the config files the script writes (their content is base64-embedded).
+func decodedFiles(script string) string {
+	var out strings.Builder
+	for _, line := range strings.Split(script, "\n") {
+		if strings.HasPrefix(line, "echo ") && strings.Contains(line, "| base64 -d > ") {
+			b64 := strings.TrimSpace(strings.TrimPrefix(strings.SplitN(line, "|", 2)[0], "echo "))
+			if dec, err := base64.StdEncoding.DecodeString(b64); err == nil {
+				out.Write(dec)
+				out.WriteByte('\n')
+			}
+		}
+	}
+	return out.String()
+}
+
+// recordOp records executed commands without opening any SSH session.
+type recordOp struct{ executed []string }
+
+func (r *recordOp) Execute(cmd string) error               { r.executed = append(r.executed, cmd); return nil }
+func (r *recordOp) Output(cmd string) ([]byte, error)      { r.executed = append(r.executed, cmd); return []byte("x86_64\n"), nil }
+func (r *recordOp) Upload(io.Reader, string, string) error { return nil }
+func (r *recordOp) UploadFile(string, string, string) error {
+	return nil
+}
+
+func TestRunScriptSudoVariants(t *testing.T) {
+	cases := []struct {
+		name, user, pass string
+		wantContains     string
+		wantNotContains  string
+	}{
+		{"root runs bare", "root", "", "| base64 -d | sh", "sudo"},
+		{"non-root passwordless uses sudo -n", "chris", "", "| base64 -d | sudo -n sh", "sudo -S"},
+		{"non-root with password uses sudo -S", "chris", "pw", "sudo -S -p '' sh", "sudo -n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := &recordOp{}
+			if err := runScript(op, tc.user, tc.pass, "echo hi"); err != nil {
+				t.Fatal(err)
+			}
+			got := strings.Join(op.executed, "\n")
+			if !strings.Contains(got, tc.wantContains) {
+				t.Errorf("want %q in %q", tc.wantContains, got)
+			}
+			if tc.wantNotContains != "" && strings.Contains(got, tc.wantNotContains) {
+				t.Errorf("did not want %q in %q", tc.wantNotContains, got)
+			}
+		})
+	}
+}
+
+func TestPrometheusInstallScript(t *testing.T) {
+	s := PrometheusInstallScript("amd64", PrometheusOptions{
+		ConfigYAML: "scrape_configs: []\n", Bind: "127.0.0.1", Port: 9090, Retention: "30d",
+	})
+	// structural parts are literal in the script
+	for _, want := range []string{
+		"prometheus-" + PrometheusVersion + ".linux-amd64",
+		"/usr/local/bin/prometheus",
+		"promtool check config",
+		"systemctl restart prometheus.service",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("prometheus script missing %q", want)
+		}
+	}
+	// config/unit content is base64-embedded; decode to assert
+	files := decodedFiles(s)
+	for _, want := range []string{
+		"--web.listen-address=127.0.0.1:9090",
+		"--storage.tsdb.retention.time=30d",
+		"scrape_configs: []",
+	} {
+		if !strings.Contains(files, want) {
+			t.Errorf("prometheus embedded files missing %q", want)
+		}
+	}
+}
+
+func TestGrafanaInstallScript(t *testing.T) {
+	s := GrafanaInstallScript("amd64", []byte(`{"title":"SeaweedFS"}`), GrafanaOptions{
+		Bind: "0.0.0.0", Port: 3000, AdminUser: "admin", AdminPassword: "secret",
+		PrometheusURL: "http://127.0.0.1:9090", ClusterName: "prod",
+	})
+	for _, want := range []string{
+		"grafana-" + GrafanaVersion + ".linux-amd64",
+		"/var/lib/grafana/dashboards/seaweedfs.json",
+		"systemctl restart grafana.service",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("grafana script missing %q", want)
+		}
+	}
+	files := decodedFiles(s)
+	for _, want := range []string{
+		"/opt/grafana/bin/grafana server",
+		"http_addr = 0.0.0.0",
+		"admin_password = secret",
+		"uid: seaweedprom",
+		"http://127.0.0.1:9090",
+		"SeaweedFS - prod",
+	} {
+		if !strings.Contains(files, want) {
+			t.Errorf("grafana embedded files missing %q", want)
+		}
+	}
+}
+
+func TestPrepareDashboardSuffixesTitleAndDropsID(t *testing.T) {
+	out := prepareDashboard([]byte(`{"id":7,"title":"SeaweedFS"}`), "prod")
+	got := string(out)
+	if strings.Contains(got, `"id"`) {
+		t.Errorf("expected id removed: %s", got)
+	}
+	if !strings.Contains(got, "SeaweedFS - prod") {
+		t.Errorf("expected title suffix: %s", got)
+	}
+}

--- a/pkg/cluster/observability/observability.go
+++ b/pkg/cluster/observability/observability.go
@@ -45,53 +45,40 @@ func DashboardJSON() []byte {
 	return out
 }
 
-// InstallNodeExporter installs a pinned node_exporter release on the
-// host reachable through op and registers it as a systemd service
-// listening on :9100.
-func InstallNodeExporter(op operator.CommandOperator) error {
+// NodeExporterInstallScript renders the shell script that installs and
+// starts node_exporter. Pure, for unit tests.
+func NodeExporterInstallScript(goArch string) string {
+	tarball := fmt.Sprintf("node_exporter-%s.linux-%s.tar.gz", NodeExporterVersion, goArch)
+	dir := fmt.Sprintf("node_exporter-%s.linux-%s", NodeExporterVersion, goArch)
+	url := fmt.Sprintf("https://github.com/prometheus/node_exporter/releases/download/v%s/%s",
+		NodeExporterVersion, tarball)
+	return strings.Join([]string{
+		"set -e",
+		"cd /tmp",
+		fmt.Sprintf("if [ ! -x /usr/local/bin/node_exporter ]; then curl -fsSL -o %s %q && tar -xzf %s && install -m0755 %s/node_exporter /usr/local/bin/node_exporter && rm -rf %s %s; fi",
+			tarball, url, tarball, dir, tarball, dir),
+		"id node_exporter >/dev/null 2>&1 || useradd --system --no-create-home --shell /usr/sbin/nologin node_exporter",
+		writeFileCmd("/etc/systemd/system/node_exporter.service", nodeExporterUnit(), "0644"),
+		"systemctl daemon-reload",
+		"systemctl enable node_exporter.service >/dev/null 2>&1",
+		"systemctl restart node_exporter.service",
+	}, "\n")
+}
+
+// InstallNodeExporter installs a pinned node_exporter release on the host
+// reachable through op and registers it as a systemd service listening on
+// :9100. It elevates via sudo for non-root SSH users (previously it ran
+// the privileged steps bare, which failed for a normal login user).
+func InstallNodeExporter(op operator.CommandOperator, sshUser, sudoPass string) error {
 	if op == nil {
 		return fmt.Errorf("observability: nil CommandOperator")
 	}
-
-	arch, err := op.Output("uname -m")
+	goArch, err := remoteGoArch(op)
 	if err != nil {
-		return fmt.Errorf("detect arch: %w", err)
+		return err
 	}
-	goArch := "amd64"
-	switch strings.TrimSpace(string(arch)) {
-	case "aarch64", "arm64":
-		goArch = "arm64"
-	case "armv7l", "armv6l":
-		goArch = "armv7"
-	}
-
-	tarball := fmt.Sprintf("node_exporter-%s.linux-%s.tar.gz", NodeExporterVersion, goArch)
-	url := fmt.Sprintf("https://github.com/prometheus/node_exporter/releases/download/v%s/%s",
-		NodeExporterVersion, tarball)
-
-	script := strings.Join([]string{
-		"set -e",
-		"cd /tmp",
-		fmt.Sprintf("curl -fsSL -o %s %q", tarball, url),
-		fmt.Sprintf("tar -xzf %s", tarball),
-		fmt.Sprintf("install -m 0755 node_exporter-%s.linux-%s/node_exporter /usr/local/bin/node_exporter",
-			NodeExporterVersion, goArch),
-		fmt.Sprintf("rm -rf %s node_exporter-%s.linux-%s", tarball, NodeExporterVersion, goArch),
-		"id node_exporter >/dev/null 2>&1 || useradd --system --no-create-home --shell /usr/sbin/nologin node_exporter",
-	}, " && ")
-
-	if err := op.Execute(script); err != nil {
-		return fmt.Errorf("install node_exporter binary: %w", err)
-	}
-
-	unit := nodeExporterUnit()
-	if err := op.Upload(strings.NewReader(unit),
-		"/etc/systemd/system/node_exporter.service", "0644"); err != nil {
-		return fmt.Errorf("upload systemd unit: %w", err)
-	}
-
-	if err := op.Execute("systemctl daemon-reload && systemctl enable node_exporter.service && systemctl restart node_exporter.service"); err != nil {
-		return fmt.Errorf("enable node_exporter service: %w", err)
+	if err := runScript(op, sshUser, sudoPass, NodeExporterInstallScript(goArch)); err != nil {
+		return fmt.Errorf("install node_exporter: %w", err)
 	}
 	return nil
 }

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -64,8 +64,87 @@ type (
 		AdminServers  []*AdminServerSpec  `yaml:"admin_servers,omitempty"`
 		EnvoyServers  []*EnvoyServerSpec  `yaml:"envoy_servers,omitempty"`
 		WorkerServers []*WorkerServerSpec `yaml:"worker_servers,omitempty"`
+		// Monitoring, when set, makes seaweed-up deploy a Prometheus +
+		// Grafana stack (and node_exporter on every host) as part of the
+		// cluster, with the bundled SeaweedFS dashboard pre-loaded.
+		Monitoring *MonitoringSpec `yaml:"monitoring,omitempty"`
+	}
+
+	// MonitoringSpec configures the bundled observability stack. Only Host
+	// is required; everything else has a sensible default (see the
+	// Effective* helpers). By default Prometheus and Grafana bind to
+	// 127.0.0.1 on the monitoring host, so reach Grafana over an SSH
+	// tunnel; set bind: 0.0.0.0 to expose them (mind the same cleartext /
+	// firewall caveats as any public service).
+	MonitoringSpec struct {
+		Host                 string `yaml:"host"`
+		PortSsh              int    `yaml:"port.ssh,omitempty"`
+		Bind                 string `yaml:"bind,omitempty"`
+		PrometheusPort       int    `yaml:"prometheus_port,omitempty"`
+		GrafanaPort          int    `yaml:"grafana_port,omitempty"`
+		GrafanaAdminUser     string `yaml:"grafana_admin_user,omitempty"`
+		GrafanaAdminPassword string `yaml:"grafana_admin_password,omitempty"`
+		Retention            string `yaml:"retention,omitempty"`
+		// NodeExporter controls whether node_exporter is installed on
+		// every cluster host. Pointer so an unset value defaults to true.
+		NodeExporter *bool `yaml:"node_exporter,omitempty"`
 	}
 )
+
+// Default ports / values for the monitoring stack.
+const (
+	DefaultPrometheusPort   = 9090
+	DefaultGrafanaPort      = 3000
+	DefaultMonitoringBind   = "127.0.0.1"
+	DefaultGrafanaAdminUser = "admin"
+	DefaultPromRetention    = "15d"
+)
+
+// EffectiveBind returns the configured bind address or the default.
+func (m *MonitoringSpec) EffectiveBind() string {
+	if strings.TrimSpace(m.Bind) == "" {
+		return DefaultMonitoringBind
+	}
+	return m.Bind
+}
+
+// EffectivePrometheusPort returns the configured Prometheus port or the default.
+func (m *MonitoringSpec) EffectivePrometheusPort() int {
+	if m.PrometheusPort == 0 {
+		return DefaultPrometheusPort
+	}
+	return m.PrometheusPort
+}
+
+// EffectiveGrafanaPort returns the configured Grafana port or the default.
+func (m *MonitoringSpec) EffectiveGrafanaPort() int {
+	if m.GrafanaPort == 0 {
+		return DefaultGrafanaPort
+	}
+	return m.GrafanaPort
+}
+
+// EffectiveGrafanaAdminUser returns the configured admin user or the default.
+func (m *MonitoringSpec) EffectiveGrafanaAdminUser() string {
+	if strings.TrimSpace(m.GrafanaAdminUser) == "" {
+		return DefaultGrafanaAdminUser
+	}
+	return m.GrafanaAdminUser
+}
+
+// EffectiveRetention returns the configured Prometheus retention or the default.
+func (m *MonitoringSpec) EffectiveRetention() string {
+	if strings.TrimSpace(m.Retention) == "" {
+		return DefaultPromRetention
+	}
+	return m.Retention
+}
+
+// InstallNodeExporter reports whether node_exporter should be installed
+// on every host (default true when unset).
+func (m *MonitoringSpec) InstallNodeExporter() bool {
+	return m.NodeExporter == nil || *m.NodeExporter
+}
 
 // Validate validates the Specification and returns an error if invalid
 func (s *Specification) Validate() error {
@@ -96,6 +175,21 @@ func (s *Specification) Validate() error {
 	default:
 		return fmt.Errorf("global.ssh_host_key_check %q is invalid (want ignore, accept-new, or strict)",
 			s.GlobalOptions.SSHHostKeyCheck)
+	}
+
+	if mon := s.Monitoring; mon != nil {
+		if strings.TrimSpace(mon.Host) == "" {
+			return fmt.Errorf("monitoring.host is required when monitoring is configured")
+		}
+		for label, p := range map[string]int{
+			"monitoring.port.ssh":        mon.PortSsh,
+			"monitoring.prometheus_port": mon.PrometheusPort,
+			"monitoring.grafana_port":    mon.GrafanaPort,
+		} {
+			if p < 0 || p > 65535 {
+				return fmt.Errorf("%s %d is out of range (0-65535)", label, p)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/cluster/spec/spec_test.go
+++ b/pkg/cluster/spec/spec_test.go
@@ -61,3 +61,51 @@ func TestValidate_SSHHostKeyCheck(t *testing.T) {
 		})
 	}
 }
+
+func TestValidate_Monitoring(t *testing.T) {
+	cases := []struct {
+		name    string
+		mon     *MonitoringSpec
+		wantErr bool
+	}{
+		{"nil ok", nil, false},
+		{"host only ok", &MonitoringSpec{Host: "10.0.0.1"}, false},
+		{"blank host", &MonitoringSpec{Host: "  "}, true},
+		{"bad grafana port", &MonitoringSpec{Host: "h", GrafanaPort: 70000}, true},
+		{"bad prometheus port", &MonitoringSpec{Host: "h", PrometheusPort: -1}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Specification{MasterServers: masterOnly()}
+			s.Monitoring = tc.mon
+			err := s.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestMonitoringDefaults(t *testing.T) {
+	m := &MonitoringSpec{Host: "10.0.0.1"}
+	if m.EffectiveBind() != "127.0.0.1" {
+		t.Errorf("bind default = %q", m.EffectiveBind())
+	}
+	if m.EffectivePrometheusPort() != 9090 || m.EffectiveGrafanaPort() != 3000 {
+		t.Errorf("port defaults wrong: %d %d", m.EffectivePrometheusPort(), m.EffectiveGrafanaPort())
+	}
+	if m.EffectiveGrafanaAdminUser() != "admin" || m.EffectiveRetention() != "15d" {
+		t.Errorf("defaults wrong: %q %q", m.EffectiveGrafanaAdminUser(), m.EffectiveRetention())
+	}
+	if !m.InstallNodeExporter() {
+		t.Errorf("node_exporter should default true")
+	}
+	no := false
+	m.NodeExporter = &no
+	if m.InstallNodeExporter() {
+		t.Errorf("node_exporter explicit false not honored")
+	}
+}


### PR DESCRIPTION
## What

Makes observability a **first-class deployed component**: declare a `monitoring:` block and `cluster deploy` stands up the whole stack — node_exporter on every host, Prometheus + Grafana on the monitoring host, the bundled SeaweedFS dashboard pre-loaded, and the SeaweedFS metrics ports auto-enabled. This replaces the ~8 manual steps (`node-exporter install` → `prometheus-config` → run Prometheus/Grafana → `dashboard install`).

```yaml
monitoring:
  host: 10.0.0.1
  bind: 127.0.0.1            # localhost by default — reach Grafana via SSH tunnel
  grafana_admin_password: CHANGE_ME
```

```bash
seaweed-up cluster deploy -f cluster.yaml                        # cluster + monitoring
seaweed-up cluster deploy -f cluster.yaml --component=monitoring # just the stack
seaweed-up cluster restart -f cluster.yaml --component=monitoring
```

## How

- **spec**: `MonitoringSpec` (host, bind, ports, grafana creds, retention, node_exporter toggle) with `Effective*` defaults + validation.
- **observability**: `InstallPrometheus` / `InstallGrafana` install via official binary tarballs + systemd, with the Prometheus datasource and bundled dashboard **file-provisioned** (no API token). `InstallNodeExporter` is now **sudo-aware** — it previously ran `useradd`/`install`/`systemctl` bare, which fails for a non-root NOPASSWD login. A shared `runScript` helper elevates via `sudo -n` / `sudo -S` exactly like the TLS bootstrap.
- **manager**: `DeployMonitoring` fans node_exporter across all hosts and installs Prometheus+Grafana on the monitoring host, rendering the scrape config from the spec. `assignMetricsPorts` gives master/volume/filer **per-host-unique** metrics ports (so two volume servers on one host don't collide) when not set. Wired into `DeployCluster` and the start/stop/restart lifecycle.

## Reuses
`dashboard.json`, `RenderPromConfig`, the existing `node-exporter`/`prometheus-config`/`dashboard install` commands.

## Test plan
- `go build ./...`, `go vet ./...`, full `go test ./...` — pass.
- New tests: per-host metrics-port assignment (uniqueness + preserves explicit), spec validation/defaults, Prometheus/Grafana/node_exporter install-script rendering (incl. decoding the base64-embedded config files), and `runScript` sudo variants (root / passwordless / password).
- Validated live: the same stack (node_exporter ×6, Prometheus, Grafana + datasource + dashboard) is running against a real 6-host cluster; this PR automates exactly that.

## Stacking
Targets **`emit-metrics-port`** (#88) since the auto-metricsPort feature relies on it; also depends on the passwordless-sudo fix (#86) for the broader non-root deploy path. Retarget to `main` once those merge.