### PR TITLE
docs: reflect the monitoring layer in the README topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ go install
 
 ## Cluster topology
 
-A typical SeaweedFS deployment has three layers. `seaweed-up` knows how to
-deploy and operate all of them from a single YAML file.
+A typical SeaweedFS deployment has three layers, plus an optional monitoring
+stack. `seaweed-up` knows how to deploy and operate all of them from a single
+YAML file.
 
 | Layer           | Components                | Role                                       |
 |-----------------|---------------------------|--------------------------------------------|
@@ -24,9 +25,11 @@ deploy and operate all of them from a single YAML file.
 |                 | `sftp_servers`, `envoy_servers` | Optional additional frontends        |
 | Backend ops     | `admin_servers`           | Coordinate balancing, EC, vacuum (run 1)   |
 |                 | `worker_servers`          | Execute admin-scheduled tasks (run a few)  |
+| Observability   | `monitoring`              | node_exporter + Prometheus + Grafana       |
 
-The admin server and workers are **not on the data path** — restarting them
-does not interrupt reads or writes.
+The admin server, workers, and monitoring stack are **not on the data path** —
+restarting them does not interrupt reads or writes. Monitoring is optional; see
+[Monitoring](#monitoring-prometheus--grafana) below.
 
 ## Configuration examples
 


### PR DESCRIPTION
The cluster-topology table in the README predated the bundled monitoring stack (merged in #90). It listed Storage / File access / Backend ops but not observability.

This adds an **Observability** row — `monitoring` → node_exporter + Prometheus + Grafana — and:
- notes the optional monitoring stack in the section intro,
- includes the monitoring stack in the "not on the data path" callout,
- links to the existing [Monitoring](#monitoring-prometheus--grafana) section.

Docs-only; no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cluster topology documentation to include the optional monitoring stack and explicit Observability layer in component tables.
  * Expanded notes on components outside the data path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->