### PR TITLE
Support upgrading to the rolling "dev" build

### DIFF
--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -565,7 +565,17 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 	// Probe the currently-running cluster version so that rollback has a target
 	// to restore to. If probing fails we proceed with previousVersion="" and
 	// rollback will be disabled for this run.
-	if current, err := probeCurrentClusterVersion(clusterSpec, opts.InsecureSkipTLSVerify); err != nil {
+	//
+	// Behind a bastion the master's address is usually unreachable from the
+	// control machine, so probe over SSH (curl on the node itself) which rides
+	// the jump-host tunnel; otherwise issue a direct HTTP request.
+	probeVersion := func() (string, error) {
+		if b := clusterSpec.GlobalOptions.Bastion; b != nil && b.Host != "" {
+			return probeCurrentClusterVersionViaSSH(clusterSpec, mgr.User, mgr.IdentityFile, "", opts.InsecureSkipTLSVerify)
+		}
+		return probeCurrentClusterVersion(clusterSpec, opts.InsecureSkipTLSVerify)
+	}
+	if current, err := probeVersion(); err != nil {
 		color.Yellow("WARN: Could not determine current cluster version (%v); rollback will be disabled.", err)
 		mgr.Version = ""
 	} else if current == "" {
@@ -633,22 +643,47 @@ type dirStatusPayload struct {
 	Version string `json:"Version"`
 }
 
-// probeCurrentClusterVersion asks the master hosts for their running version.
-// It tries /dir/status first and falls back to /cluster/status, preferring a
-// typed JSON Version field and then falling back to the Server response header.
-//
-// The parser is strict: it only accepts tokens that match a Seaweed-specific
-// version pattern. An IP-like substring ("172.28.0.10") will never be returned.
-// If a master responds 2xx but no version could be extracted, probing
-// continues with the remaining masters; "" + nil is returned only when all
-// masters responded successfully without a recognizable version.
-//
-// When the cluster is TLS-enabled, the default http.Client uses the system
-// cert pool. Pass insecureSkipTLSVerify=true to disable certificate
-// verification (for self-signed dev clusters).
-//
-// TODO: use cluster CA once tls bootstrap PR lands.
-func probeCurrentClusterVersion(clusterSpec *spec.Specification, insecureSkipTLSVerify bool) (string, error) {
+// versionFetcher returns the response body and Server header for one master
+// endpoint (scheme://.../path). Implementations differ only in transport: the
+// HTTP fetcher issues a direct request from the control machine, while the SSH
+// fetcher runs curl on the master node so the probe tunnels through the bastion.
+// A non-2xx response or transport failure is reported as an error.
+type versionFetcher func(ms *spec.MasterServerSpec, scheme, path string) (body []byte, serverHeader string, err error)
+
+// parseClusterVersion extracts a SeaweedFS version from a master's status
+// response, preferring the typed JSON Version field, then a generic lowercase
+// "version" key, then the Server response header. Returns "" when nothing
+// recognizable is present. The extractor is strict: an IP-like substring
+// ("172.28.0.10") will never be returned.
+func parseClusterVersion(body []byte, serverHeader string) string {
+	// Prefer the typed JSON Version field.
+	var typed dirStatusPayload
+	if jsonErr := json.Unmarshal(body, &typed); jsonErr == nil && typed.Version != "" {
+		if v := extractSeaweedVersion(typed.Version); v != "" {
+			return v
+		}
+	}
+	// Generic map lookup covers responses that use lowercase "version".
+	var payload map[string]interface{}
+	if jsonErr := json.Unmarshal(body, &payload); jsonErr == nil {
+		for _, key := range []string{"Version", "version"} {
+			if raw, ok := payload[key].(string); ok && raw != "" {
+				if v := extractSeaweedVersion(raw); v != "" {
+					return v
+				}
+			}
+		}
+	}
+	// Fall back to the Server response header.
+	return extractSeaweedVersion(serverHeader)
+}
+
+// probeClusterVersionWith asks the master hosts for their running version using
+// the supplied fetcher. It tries /dir/status first and falls back to
+// /cluster/status. If a master responds but no version could be extracted,
+// probing continues with the remaining masters; "" + nil is returned only when
+// all masters responded successfully without a recognizable version.
+func probeClusterVersionWith(clusterSpec *spec.Specification, fetch versionFetcher) (string, error) {
 	if len(clusterSpec.MasterServers) == 0 {
 		return "", fmt.Errorf("no master servers in spec")
 	}
@@ -656,62 +691,19 @@ func probeCurrentClusterVersion(clusterSpec *spec.Specification, insecureSkipTLS
 	if clusterSpec.GlobalOptions.TLSEnabled {
 		scheme = "https"
 	}
-	client := &http.Client{
-		Timeout:   5 * time.Second,
-		Transport: newUpgradeHTTPTransport(insecureSkipTLSVerify, clusterSpec.Name),
-	}
 	var lastErr error
 	sawHealthyMasterWithoutVersion := false
 	for _, ms := range clusterSpec.MasterServers {
 		for _, path := range []string{"/dir/status", "/cluster/status"} {
-			addr := net.JoinHostPort(ms.Ip, strconv.Itoa(ms.Port))
-			url := fmt.Sprintf("%s://%s%s", scheme, addr, path)
-			req, err := http.NewRequest(http.MethodGet, url, nil)
+			body, serverHeader, err := fetch(ms, scheme, path)
 			if err != nil {
 				lastErr = err
 				continue
 			}
-			resp, err := client.Do(req)
-			if err != nil {
-				lastErr = err
-				continue
-			}
-			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-				lastErr = fmt.Errorf("status %d from %s", resp.StatusCode, url)
-				_ = resp.Body.Close()
-				continue
-			}
-			body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-			serverHeader := resp.Header.Get("Server")
-			_ = resp.Body.Close()
-			if readErr != nil {
-				lastErr = fmt.Errorf("read body from %s: %w", url, readErr)
-				continue
-			}
-			// Prefer the typed JSON Version field.
-			var typed dirStatusPayload
-			if jsonErr := json.Unmarshal(body, &typed); jsonErr == nil && typed.Version != "" {
-				if v := extractSeaweedVersion(typed.Version); v != "" {
-					return v, nil
-				}
-			}
-			// Generic map lookup covers responses that use lowercase "version".
-			var payload map[string]interface{}
-			if jsonErr := json.Unmarshal(body, &payload); jsonErr == nil {
-				for _, key := range []string{"Version", "version"} {
-					if raw, ok := payload[key].(string); ok && raw != "" {
-						if v := extractSeaweedVersion(raw); v != "" {
-							return v, nil
-						}
-					}
-				}
-			}
-			// Fall back to the Server response header.
-			if v := extractSeaweedVersion(serverHeader); v != "" {
+			if v := parseClusterVersion(body, serverHeader); v != "" {
 				return v, nil
 			}
-			// Nothing matched on this endpoint. Remember that this master
-			// responded 2xx but didn't yield a recognizable version, and
+			// The master responded but didn't yield a recognizable version;
 			// keep probing other masters/endpoints.
 			sawHealthyMasterWithoutVersion = true
 		}
@@ -726,6 +718,114 @@ func probeCurrentClusterVersion(clusterSpec *spec.Specification, insecureSkipTLS
 		lastErr = fmt.Errorf("no master responded")
 	}
 	return "", lastErr
+}
+
+// probeCurrentClusterVersion asks the master hosts for their running version
+// over a direct HTTP(S) request from the control machine.
+//
+// When the cluster is TLS-enabled, the default http.Client uses the system
+// cert pool. Pass insecureSkipTLSVerify=true to disable certificate
+// verification (for self-signed dev clusters).
+//
+// TODO: use cluster CA once tls bootstrap PR lands.
+func probeCurrentClusterVersion(clusterSpec *spec.Specification, insecureSkipTLSVerify bool) (string, error) {
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: newUpgradeHTTPTransport(insecureSkipTLSVerify, clusterSpec.Name),
+	}
+	return probeClusterVersionWith(clusterSpec, func(ms *spec.MasterServerSpec, scheme, path string) ([]byte, string, error) {
+		addr := net.JoinHostPort(ms.Ip, strconv.Itoa(ms.Port))
+		url := fmt.Sprintf("%s://%s%s", scheme, addr, path)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, "", err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, "", err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, "", fmt.Errorf("status %d from %s", resp.StatusCode, url)
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if readErr != nil {
+			return nil, "", fmt.Errorf("read body from %s: %w", url, readErr)
+		}
+		return body, resp.Header.Get("Server"), nil
+	})
+}
+
+// probeCurrentClusterVersionViaSSH is the bastion-friendly counterpart of
+// probeCurrentClusterVersion: instead of reaching the master's (often private)
+// address directly, it SSHes to each master and runs curl against
+// localhost:<master port>, so the probe rides the same jump-host tunnel as the
+// rest of the upgrade. Used whenever a bastion is configured.
+func probeCurrentClusterVersionViaSSH(clusterSpec *spec.Specification, user, identityFile, sudoPass string, insecureSkipTLSVerify bool) (string, error) {
+	kFlag := ""
+	if insecureSkipTLSVerify {
+		kFlag = "-k "
+	}
+	return probeClusterVersionWith(clusterSpec, func(ms *spec.MasterServerSpec, scheme, path string) ([]byte, string, error) {
+		sshAddr := net.JoinHostPort(ms.Ip, strconv.Itoa(nonZero(ms.PortSsh, 22)))
+		localURL := fmt.Sprintf("%s://localhost:%d%s", scheme, ms.Port, path)
+		// -i includes response headers so parseClusterVersion can fall back
+		// to the Server header; -w writes the HTTP status on its own trailer
+		// line so a non-2xx response is reported as an error.
+		cmd := fmt.Sprintf("curl -sS %s-i -m 5 -w '\\n__STATUS__:%%{http_code}' %s 2>/dev/null", kFlag, shellSingleQuote(localURL))
+		var out []byte
+		err := operator.ExecuteRemote(sshAddr, user, identityFile, sudoPass, func(op operator.CommandOperator) error {
+			b, e := op.Output(cmd)
+			out = b
+			return e
+		})
+		if err != nil {
+			return nil, "", fmt.Errorf("probe %s on %s: %w", localURL, sshAddr, err)
+		}
+		status, serverHeader, body := parseCurlResponse(out)
+		if status < 200 || status >= 300 {
+			return nil, "", fmt.Errorf("status %d from %s", status, localURL)
+		}
+		return body, serverHeader, nil
+	})
+}
+
+// parseCurlResponse splits `curl -i` output into the final response's status
+// code, Server header, and body. curl may print preface header blocks (a
+// 100-Continue or a redirect), so each leading "HTTP/..." block is consumed in
+// turn and the last one wins. The trailing "__STATUS__:<code>" sentinel written
+// by curl's -w is the authoritative status (curl's -i status line may be the
+// 100-Continue preface) and is stripped from the returned body.
+func parseCurlResponse(raw []byte) (status int, serverHeader string, body []byte) {
+	text := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	if i := strings.LastIndex(text, "\n__STATUS__:"); i >= 0 {
+		status, _ = strconv.Atoi(strings.TrimSpace(text[i+len("\n__STATUS__:"):]))
+		text = text[:i]
+	}
+	for strings.HasPrefix(text, "HTTP/") {
+		idx := strings.Index(text, "\n\n")
+		if idx < 0 {
+			if sv := serverHeaderFrom(text); sv != "" {
+				serverHeader = sv
+			}
+			return status, serverHeader, nil
+		}
+		if sv := serverHeaderFrom(text[:idx]); sv != "" {
+			serverHeader = sv
+		}
+		text = text[idx+2:]
+	}
+	return status, serverHeader, []byte(text)
+}
+
+// serverHeaderFrom returns the Server header value from a header block, or "".
+func serverHeaderFrom(block string) string {
+	for _, line := range strings.Split(block, "\n") {
+		if i := strings.Index(line, ":"); i > 0 && strings.EqualFold(strings.TrimSpace(line[:i]), "Server") {
+			return strings.TrimSpace(line[i+1:])
+		}
+	}
+	return ""
 }
 
 // newUpgradeHTTPTransport builds an http.Transport for upgrade probes.

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -553,6 +553,7 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 		fmt.Printf("  Masters: %d\n", len(clusterSpec.MasterServers))
 		fmt.Printf("  Volumes: %d\n", len(clusterSpec.VolumeServers))
 		fmt.Printf("  Filers:  %d\n", len(clusterSpec.FilerServers))
+		fmt.Printf("  S3:      %d\n", len(clusterSpec.S3Servers))
 		fmt.Printf("  Admins:  %d\n", len(clusterSpec.AdminServers))
 		fmt.Printf("  Workers: %d\n", len(clusterSpec.WorkerServers))
 		fmt.Printf("  Rollback on failure: %v\n", opts.RollbackOnFailure)

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -768,11 +768,13 @@ func probeCurrentClusterVersionViaSSH(clusterSpec *spec.Specification, user, ide
 	}
 	return probeClusterVersionWith(clusterSpec, func(ms *spec.MasterServerSpec, scheme, path string) ([]byte, string, error) {
 		sshAddr := net.JoinHostPort(ms.Ip, strconv.Itoa(nonZero(ms.PortSsh, 22)))
-		localURL := fmt.Sprintf("%s://localhost:%d%s", scheme, ms.Port, path)
+		// weed binds to the advertised -ip, so curl the node's own address
+		// (not loopback, which is refused unless it binds 0.0.0.0).
+		probeURL := fmt.Sprintf("%s://%s%s", scheme, net.JoinHostPort(ms.Ip, strconv.Itoa(ms.Port)), path)
 		// -i includes response headers so parseClusterVersion can fall back
 		// to the Server header; -w writes the HTTP status on its own trailer
 		// line so a non-2xx response is reported as an error.
-		cmd := fmt.Sprintf("curl -sS %s-i -m 5 -w '\\n__STATUS__:%%{http_code}' %s 2>/dev/null", kFlag, shellSingleQuote(localURL))
+		cmd := fmt.Sprintf("curl -sS %s-i -m 5 -w '\\n__STATUS__:%%{http_code}' %s 2>/dev/null", kFlag, shellSingleQuote(probeURL))
 		var out []byte
 		err := operator.ExecuteRemote(sshAddr, user, identityFile, sudoPass, func(op operator.CommandOperator) error {
 			b, e := op.Output(cmd)
@@ -780,11 +782,11 @@ func probeCurrentClusterVersionViaSSH(clusterSpec *spec.Specification, user, ide
 			return e
 		})
 		if err != nil {
-			return nil, "", fmt.Errorf("probe %s on %s: %w", localURL, sshAddr, err)
+			return nil, "", fmt.Errorf("probe %s on %s: %w", probeURL, sshAddr, err)
 		}
 		status, serverHeader, body := parseCurlResponse(out)
 		if status < 200 || status >= 300 {
-			return nil, "", fmt.Errorf("status %d from %s", status, localURL)
+			return nil, "", fmt.Errorf("status %d from %s", status, probeURL)
 		}
 		return body, serverHeader, nil
 	})

--- a/cmd/cluster_impl_test.go
+++ b/cmd/cluster_impl_test.go
@@ -66,6 +66,52 @@ func newTestMasterSpec(t *testing.T, servers ...*httptest.Server) *spec.Specific
 	return s
 }
 
+func TestParseCurlResponse(t *testing.T) {
+	cases := []struct {
+		name       string
+		raw        string
+		wantStatus int
+		wantServer string
+		wantBody   string
+	}{
+		{
+			name:       "simple 200 with server header",
+			raw:        "HTTP/1.1 200 OK\r\nServer: SeaweedFS/3.85\r\nContent-Type: application/json\r\n\r\n{\"Version\":\"30GB 3.85 abc\"}\n__STATUS__:200",
+			wantStatus: 200,
+			wantServer: "SeaweedFS/3.85",
+			wantBody:   "{\"Version\":\"30GB 3.85 abc\"}",
+		},
+		{
+			name:       "100-continue preface then 200",
+			raw:        "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nServer: SeaweedFS/3.85\r\n\r\n{}\n__STATUS__:200",
+			wantStatus: 200,
+			wantServer: "SeaweedFS/3.85",
+			wantBody:   "{}",
+		},
+		{
+			name:       "non-2xx status from trailer",
+			raw:        "HTTP/1.1 404 Not Found\r\nServer: SeaweedFS/3.85\r\n\r\nnot found\n__STATUS__:404",
+			wantStatus: 404,
+			wantServer: "SeaweedFS/3.85",
+			wantBody:   "not found",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, server, body := parseCurlResponse([]byte(tc.raw))
+			if status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", status, tc.wantStatus)
+			}
+			if server != tc.wantServer {
+				t.Errorf("server = %q, want %q", server, tc.wantServer)
+			}
+			if strings.TrimSpace(string(body)) != tc.wantBody {
+				t.Errorf("body = %q, want %q", strings.TrimSpace(string(body)), tc.wantBody)
+			}
+		})
+	}
+}
+
 func TestProbeCurrentClusterVersion_CanonicalDirStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/dir/status" {

--- a/pkg/cluster/manager/deploy_dev.go
+++ b/pkg/cluster/manager/deploy_dev.go
@@ -1,0 +1,36 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/seaweedfs/seaweed-up/pkg/config"
+)
+
+// devArch is the architecture seaweed-up resolves rolling "dev" builds
+// for. The dev release datestamps each os/arch independently, so a single
+// controller-side resolution targets one arch; amd64 is the SeaweedFS CI
+// and the overwhelmingly common deploy target. Multi-arch dev clusters
+// would need per-host resolution (follow-up).
+const devArch = "amd64"
+
+// resolveDevAsset resolves the newest rolling "dev" build into m.devAsset
+// when the target version is "dev". It is a no-op for normal versions and
+// is safe to call more than once (re-resolves so a moving dev tag is
+// picked up on the next deploy/upgrade). largeDisk is always true:
+// install.sh builds the *_large_disk asset, so dev tracks the matching
+// weed-large-disk-* build.
+func (m *Manager) resolveDevAsset(version string) error {
+	if version != config.DevTag {
+		m.devAsset = nil
+		return nil
+	}
+	owner, repo := m.ReleaseOwnerRepo()
+	asset, err := config.ResolveDevAsset(context.Background(), owner, repo, true, devArch)
+	if err != nil {
+		return err
+	}
+	info(fmt.Sprintf("Resolved dev build %s -> %s", asset.BuildID, asset.DownloadURL))
+	m.devAsset = &asset
+	return nil
+}

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/seaweedfs/seaweed-up/pkg/config"
 	"github.com/seaweedfs/seaweed-up/pkg/operator"
 )
 
@@ -111,8 +112,8 @@ type Manager struct {
 	// Without this we'd have to back-derive from the aggregated mount
 	// count, which overstates the count for per-host shape.
 	volumeServerCountByTarget map[string]int
-	HostPrep         bool
-	ForceRestart     bool
+	HostPrep                  bool
+	ForceRestart              bool
 	// Enterprise, when true, pulls SeaweedFS release binaries from the
 	// public enterprise release repo (github.com/seaweedfs/artifactory)
 	// instead of the standard OSS repo (github.com/seaweedfs/seaweedfs).
@@ -130,6 +131,9 @@ type Manager struct {
 	sudoPass   string
 	confDir    string
 	dataDir    string
+	// devAsset holds the resolved rolling "dev" build (set by
+	// resolveDevAsset when Version == "dev"); nil for normal versions.
+	devAsset *config.DevAsset
 
 	// prepareHostAddressFn overrides PrepareHostAddress for tests. When nil,
 	// PrepareAllHosts calls PrepareHostAddress directly.

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -182,6 +182,11 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	}
 	m.prepare(specification)
 
+	// Resolve the rolling "dev" build to a concrete dated asset, if asked.
+	if err := m.resolveDevAsset(m.Version); err != nil {
+		return fmt.Errorf("resolve dev build: %w", err)
+	}
+
 	if m.HostPrep {
 		if err := m.PrepareAllHosts(specification); err != nil {
 			return err
@@ -553,6 +558,17 @@ func (m *Manager) deployComponentInstance(op operator.CommandOperator, component
 		"ReleaseRepo":       releaseRepo,
 		"AssetPrefix":       assetPrefix,
 		"FullSuffix":        fullSuffix,
+		// Rolling "dev" build fields. Empty unless m.Version == "dev" and
+		// the asset was resolved; install.sh takes its dev code path only
+		// when DevAssetURL is non-empty.
+		"DevAssetURL": "",
+		"DevMd5URL":   "",
+		"DevBuildID":  "",
+	}
+	if m.devAsset != nil {
+		data["DevAssetURL"] = m.devAsset.DownloadURL
+		data["DevMd5URL"] = m.devAsset.Md5URL
+		data["DevBuildID"] = m.devAsset.BuildID
 	}
 
 	// Configure proxy if specified

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -79,6 +79,14 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 
 	m.prepare(specification)
 
+	// When upgrading to the rolling "dev" tag, resolve it to the newest
+	// concrete dated build now (keyed on targetVersion, not m.Version which
+	// still holds the probed current version for rollback). The resolved
+	// asset + its build id drive the download and content-based skip check.
+	if err := m.resolveDevAsset(targetVersion); err != nil {
+		return fmt.Errorf("resolve dev build: %w", err)
+	}
+
 	// Snapshot the currently-deployed version. runClusterUpgrade is expected to
 	// populate m.Version with the cluster's current (pre-upgrade) version by
 	// probing a master host. If it could not probe, m.Version will be empty and

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net"
 	"strconv"
@@ -35,7 +36,12 @@ type upgradeTarget struct {
 	ip        string
 	portSsh   int
 	// healthURL is the HTTP endpoint used for the post-upgrade health probe.
+	// When empty, the post-upgrade gate falls back to a `systemctl is-active`
+	// check on the unit (for components with no HTTP listener, e.g. workers).
 	healthURL string
+	// healthCodes is the shell case-glob of HTTP status codes accepted as
+	// healthy (e.g. "2??", "2??|3??"). Empty means the default "2??".
+	healthCodes string
 	// describe is a human-readable identifier for logs/errors.
 	describe string
 }
@@ -56,6 +62,11 @@ type componentHooks struct {
 	// (e.g. creating volume -dir paths) before deployComponentInstance runs.
 	// May be nil.
 	prepareRemote func(op operator.CommandOperator) error
+	// extras, when non-nil, returns the component-specific extra config files
+	// (e.g. s3.json) to upload alongside the rendered options. It is called
+	// fresh on every deploy attempt because each extra carries a single-use
+	// Reader the retry loop would otherwise exhaust. May be nil.
+	extras func() ([]extraConfigFile, error)
 }
 
 // UpgradeCluster performs a rolling upgrade of the cluster to targetVersion.
@@ -97,52 +108,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 		scheme = "https"
 	}
 
-	var targets []upgradeTarget
-
-	// healthURL targets the node's own configured address (Ip:port). The
-	// probe runs on the host itself over SSH (see waitForHealthyViaSSH), so
-	// it tunnels through the bastion like every other operation instead of
-	// needing direct HTTP reachability to the node's (often private) address
-	// from the control machine. We use the configured Ip rather than
-	// localhost because weed binds its HTTP listener to the advertised -ip
-	// (e.g. 10.0.0.1), so loopback is refused on hosts that don't bind 0.0.0.0.
-	//
-	// Volume servers first.
-	for i, v := range specification.VolumeServers {
-		hostPort := net.JoinHostPort(v.Ip, strconv.Itoa(v.Port))
-		targets = append(targets, upgradeTarget{
-			component: "volume",
-			index:     i,
-			ip:        v.Ip,
-			portSsh:   v.PortSsh,
-			healthURL: fmt.Sprintf("%s://%s/status", scheme, hostPort),
-			describe:  fmt.Sprintf("volume%d %s", i, hostPort),
-		})
-	}
-	// Filer servers next.
-	for i, f := range specification.FilerServers {
-		hostPort := net.JoinHostPort(f.Ip, strconv.Itoa(f.Port))
-		targets = append(targets, upgradeTarget{
-			component: "filer",
-			index:     i,
-			ip:        f.Ip,
-			portSsh:   f.PortSsh,
-			healthURL: fmt.Sprintf("%s://%s/", scheme, hostPort),
-			describe:  fmt.Sprintf("filer%d %s", i, hostPort),
-		})
-	}
-	// Masters last so quorum isn't disturbed early.
-	for i, ms := range specification.MasterServers {
-		hostPort := net.JoinHostPort(ms.Ip, strconv.Itoa(ms.Port))
-		targets = append(targets, upgradeTarget{
-			component: "master",
-			index:     i,
-			ip:        ms.Ip,
-			portSsh:   ms.PortSsh,
-			healthURL: fmt.Sprintf("%s://%s/cluster/status", scheme, hostPort),
-			describe:  fmt.Sprintf("master%d %s", i, hostPort),
-		})
-	}
+	targets := buildUpgradeTargets(specification, scheme)
 
 	if opts.DryRun {
 		info(fmt.Sprintf("Dry-run: rolling upgrade plan to version %q (previous=%q)", targetVersion, previousVersion))
@@ -155,6 +121,18 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 	var masters []string
 	for _, masterSpec := range specification.MasterServers {
 		masters = append(masters, net.JoinHostPort(masterSpec.Ip, strconv.Itoa(masterSpec.Port)))
+	}
+
+	// Resolve the default admin endpoint workers fall back to when they carry
+	// no explicit admin of their own (same precedence as DeployCluster). Only
+	// needed when the cluster actually has workers.
+	var workerAdmins []string
+	if len(specification.WorkerServers) > 0 {
+		resolved, err := resolveWorkerDefaultAdmins(specification)
+		if err != nil {
+			return err
+		}
+		workerAdmins = resolved
 	}
 
 	info(fmt.Sprintf("Starting rolling upgrade to version %q (previous=%q)", targetVersion, previousVersion))
@@ -175,7 +153,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 		if err := m.resolveDevAsset(prev); err != nil {
 			return fmt.Errorf("%s failed (%v); resolving rollback target %q: %w", t.describe, cause, prev, err)
 		}
-		if rbErr := m.upgradeOneHost(specification, masters, t); rbErr != nil {
+		if rbErr := m.upgradeOneHost(specification, masters, workerAdmins, t); rbErr != nil {
 			return fmt.Errorf("%s failed (%v); rollback to %q also failed: %w", t.describe, cause, prev, rbErr)
 		}
 		return fmt.Errorf("%s failed; rolled back to %q: %w", t.describe, prev, cause)
@@ -192,14 +170,22 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 		hostPrev := previousVersion
 
 		m.Version = targetVersion
-		if err := m.upgradeOneHost(specification, masters, t); err != nil {
+		if err := m.upgradeOneHost(specification, masters, workerAdmins, t); err != nil {
 			return rollbackHost(t, hostPrev, fmt.Errorf("upgrade %s: %w", t.describe, err))
 		}
 
 		sshAddr := net.JoinHostPort(t.ip, strconv.Itoa(t.portSsh))
-		if err := m.waitForHealthyViaSSH(sshAddr, t.healthURL, opts.HealthTimeout, opts.HealthInterval, opts.InsecureSkipTLSVerify); err != nil {
-			info(fmt.Sprintf("Health check failed for %s: %v", t.describe, err))
-			return rollbackHost(t, hostPrev, fmt.Errorf("health check failed for %s: %w", t.describe, err))
+		var healthErr error
+		if t.healthURL != "" {
+			healthErr = m.waitForHealthyViaSSH(sshAddr, t.healthURL, t.healthCodes, opts.HealthTimeout, opts.HealthInterval, opts.InsecureSkipTLSVerify)
+		} else {
+			// No HTTP listener (workers): fall back to a systemd liveness gate.
+			unit := fmt.Sprintf("seaweed_%s%d.service", t.component, t.index)
+			healthErr = m.waitForServiceActiveViaSSH(sshAddr, unit, opts.HealthTimeout, opts.HealthInterval)
+		}
+		if healthErr != nil {
+			info(fmt.Sprintf("Health check failed for %s: %v", t.describe, healthErr))
+			return rollbackHost(t, hostPrev, fmt.Errorf("health check failed for %s: %w", t.describe, healthErr))
 		}
 
 		info(fmt.Sprintf("%s upgraded and healthy", t.describe))
@@ -210,8 +196,76 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 	return nil
 }
 
+// buildUpgradeTargets returns the ordered list of instances a rolling upgrade
+// touches: volume -> filer -> master (storage core, masters next-to-last to
+// preserve quorum) -> s3 -> admin -> worker (clients/gateways, after the core
+// they depend on; workers last since they connect to the admin).
+//
+// Every health probe runs on the node itself over SSH (see
+// waitForHealthyViaSSH), so healthURL targets the node's own advertised Ip:port
+// — weed binds its HTTP listener to the advertised -ip (e.g. 10.0.0.1), so
+// loopback would be refused on hosts that don't bind 0.0.0.0. Per-component
+// liveness differs: volume/filer/master answer 2xx on their status endpoints;
+// the admin root 307-redirects to /login (accept 2xx|3xx); the S3 API answers
+// 403 unauthenticated but /status is 2xx; workers expose no HTTP listener, so
+// healthURL is left empty and the caller falls back to `systemctl is-active`.
+func buildUpgradeTargets(specification *spec.Specification, scheme string) []upgradeTarget {
+	var targets []upgradeTarget
+	for i, v := range specification.VolumeServers {
+		hostPort := net.JoinHostPort(v.Ip, strconv.Itoa(v.Port))
+		targets = append(targets, upgradeTarget{
+			component: "volume", index: i, ip: v.Ip, portSsh: v.PortSsh,
+			healthURL: fmt.Sprintf("%s://%s/status", scheme, hostPort),
+			describe:  fmt.Sprintf("volume%d %s", i, hostPort),
+		})
+	}
+	for i, f := range specification.FilerServers {
+		hostPort := net.JoinHostPort(f.Ip, strconv.Itoa(f.Port))
+		targets = append(targets, upgradeTarget{
+			component: "filer", index: i, ip: f.Ip, portSsh: f.PortSsh,
+			healthURL: fmt.Sprintf("%s://%s/", scheme, hostPort),
+			describe:  fmt.Sprintf("filer%d %s", i, hostPort),
+		})
+	}
+	for i, ms := range specification.MasterServers {
+		hostPort := net.JoinHostPort(ms.Ip, strconv.Itoa(ms.Port))
+		targets = append(targets, upgradeTarget{
+			component: "master", index: i, ip: ms.Ip, portSsh: ms.PortSsh,
+			healthURL: fmt.Sprintf("%s://%s/cluster/status", scheme, hostPort),
+			describe:  fmt.Sprintf("master%d %s", i, hostPort),
+		})
+	}
+	for i, s3 := range specification.S3Servers {
+		hostPort := net.JoinHostPort(s3.Ip, strconv.Itoa(s3.Port))
+		targets = append(targets, upgradeTarget{
+			component: "s3", index: i, ip: s3.Ip, portSsh: s3.PortSsh,
+			healthURL: fmt.Sprintf("%s://%s/status", scheme, hostPort),
+			describe:  fmt.Sprintf("s3%d %s", i, hostPort),
+		})
+	}
+	for i, a := range specification.AdminServers {
+		hostPort := net.JoinHostPort(a.Ip, strconv.Itoa(a.Port))
+		targets = append(targets, upgradeTarget{
+			component: "admin", index: i, ip: a.Ip, portSsh: a.PortSsh,
+			healthURL: fmt.Sprintf("%s://%s/", scheme, hostPort), healthCodes: "2??|3??",
+			describe: fmt.Sprintf("admin%d %s", i, hostPort),
+		})
+	}
+	for i, w := range specification.WorkerServers {
+		hostPort := net.JoinHostPort(w.Ip, strconv.Itoa(w.PortSsh))
+		targets = append(targets, upgradeTarget{
+			component: "worker", index: i, ip: w.Ip, portSsh: w.PortSsh,
+			describe: fmt.Sprintf("worker%d %s", i, hostPort),
+		})
+	}
+	return targets
+}
+
 // upgradeOneHost stops, reinstalls (at m.Version), and starts a single host instance.
-func (m *Manager) upgradeOneHost(specification *spec.Specification, masters []string, t upgradeTarget) error {
+// workerAdmins is the resolved default admin endpoint list used when a worker
+// spec carries no explicit admin (mirrors DeployCluster); it is unused for
+// non-worker components.
+func (m *Manager) upgradeOneHost(specification *spec.Specification, masters, workerAdmins []string, t upgradeTarget) error {
 	var hooks componentHooks
 	switch t.component {
 	case "volume":
@@ -239,6 +293,48 @@ func (m *Manager) upgradeOneHost(specification *spec.Specification, masters []st
 			stop:        func() error { return m.StopMasterServer(ms, t.index) },
 			writeConfig: func(buf *bytes.Buffer) { ms.WriteToBuffer(masters, buf) },
 		}
+	case "s3":
+		s3 := specification.S3Servers[t.index]
+		// The s3 gateway's options reference an s3.json (IAM creds) by its
+		// on-host path; re-render both so a credential change in the spec is
+		// picked up by the upgrade. The path mirrors DeployS3Server.
+		s3ConfigPath := ""
+		if len(s3.S3Config) > 0 {
+			s3ConfigPath = fmt.Sprintf("%s/s3%d.d/s3.json", m.confDir, t.index)
+		}
+		hooks = componentHooks{
+			serviceName: "s3",
+			sshAddr:     net.JoinHostPort(s3.Ip, strconv.Itoa(s3.PortSsh)),
+			stop:        func() error { return m.StopS3Server(s3, t.index) },
+			writeConfig: func(buf *bytes.Buffer) { s3.WriteToBuffer(buf, s3ConfigPath) },
+			extras: func() ([]extraConfigFile, error) {
+				if len(s3.S3Config) == 0 {
+					return nil, nil
+				}
+				b, err := json.MarshalIndent(s3.S3Config, "", "  ")
+				if err != nil {
+					return nil, fmt.Errorf("marshal s3.json: %w", err)
+				}
+				// s3.json holds IAM credentials; restrict to owner-only.
+				return []extraConfigFile{{Name: "s3.json", Content: bytes.NewBuffer(b), Mode: "0600"}}, nil
+			},
+		}
+	case "admin":
+		a := specification.AdminServers[t.index]
+		hooks = componentHooks{
+			serviceName: "admin",
+			sshAddr:     net.JoinHostPort(a.Ip, strconv.Itoa(a.PortSsh)),
+			stop:        func() error { return m.StopAdminServer(a, t.index) },
+			writeConfig: func(buf *bytes.Buffer) { a.WriteToBuffer(masters, buf) },
+		}
+	case "worker":
+		w := specification.WorkerServers[t.index]
+		hooks = componentHooks{
+			serviceName: "worker",
+			sshAddr:     net.JoinHostPort(w.Ip, strconv.Itoa(w.PortSsh)),
+			stop:        func() error { return m.StopWorkerServer(w, t.index) },
+			writeConfig: func(buf *bytes.Buffer) { w.WriteToBuffer(workerAdmins, buf) },
+		}
 	default:
 		return fmt.Errorf("unknown component: %s", t.component)
 	}
@@ -258,12 +354,20 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 		return operator.ExecuteRemote(hooks.sshAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
 			var buf bytes.Buffer
 			hooks.writeConfig(&buf)
+			var extras []extraConfigFile
+			if hooks.extras != nil {
+				e, err := hooks.extras()
+				if err != nil {
+					return err
+				}
+				extras = e
+			}
 			if hooks.prepareRemote != nil {
 				if err := hooks.prepareRemote(op); err != nil {
 					return err
 				}
 			}
-			if err := m.deployComponentInstance(op, hooks.serviceName, componentInstance, &buf); err != nil {
+			if err := m.deployComponentInstance(op, hooks.serviceName, componentInstance, &buf, extras...); err != nil {
 				return err
 			}
 			return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
@@ -290,11 +394,11 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 }
 
 // waitForHealthyViaSSH polls probeURL from the node itself (over SSH) until it
-// returns 2xx or the timeout elapses. Running the probe on the node — rather
-// than issuing an HTTP request from the control machine — means it tunnels
-// through the bastion exactly like every other operation, so it works even
-// when the node's (often private) service address is unreachable from the
-// laptop running the upgrade.
+// returns an accepted status (codes, e.g. "2??" or "2??|3??") or the timeout
+// elapses. Running the probe on the node — rather than issuing an HTTP request
+// from the control machine — means it tunnels through the bastion exactly like
+// every other operation, so it works even when the node's (often private)
+// service address is unreachable from the laptop running the upgrade.
 //
 // The poll loop runs inside a single SSH session (one shell loop) rather than
 // one SSH round-trip per attempt, so a slow-starting service doesn't cost a
@@ -304,9 +408,12 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 // clusters; callers must opt in explicitly via --insecure-skip-tls-verify.
 //
 // TODO: use cluster CA once tls bootstrap PR lands.
-func (m *Manager) waitForHealthyViaSSH(sshAddr, probeURL string, timeout, interval time.Duration, insecureSkipTLSVerify bool) error {
+func (m *Manager) waitForHealthyViaSSH(sshAddr, probeURL, codes string, timeout, interval time.Duration, insecureSkipTLSVerify bool) error {
 	if probeURL == "" {
 		return nil
+	}
+	if codes == "" {
+		codes = "2??"
 	}
 	secs := int(timeout.Seconds())
 	if secs < 1 {
@@ -320,15 +427,15 @@ func (m *Manager) waitForHealthyViaSSH(sshAddr, probeURL string, timeout, interv
 	if insecureSkipTLSVerify {
 		kFlag = "-k "
 	}
-	// POSIX-sh poll loop: curl the endpoint until it answers 2xx or the
-	// deadline passes. `2??` matches any 2xx status; curl errors (e.g.
-	// connection refused while the unit is still starting) are swallowed to
-	// "000" so the loop keeps trying.
+	// POSIX-sh poll loop: curl the endpoint until it answers an accepted
+	// status or the deadline passes. `codes` is a case-glob alternation (e.g.
+	// "2??" or "2??|3??"); curl errors (e.g. connection refused while the unit
+	// is still starting) are swallowed to "000" so the loop keeps trying.
 	script := `end=$(( $(date +%s) + __SECS__ ))
 last=000
 while [ "$(date +%s)" -lt "$end" ]; do
   code=$(curl -sS __K__-o /dev/null -m 5 -w '%{http_code}' __URL__ 2>/dev/null || echo 000)
-  case "$code" in 2??) echo HEALTHY; exit 0;; esac
+  case "$code" in __CODES__) echo HEALTHY; exit 0;; esac
   last=$code
   sleep __IV__
 done
@@ -337,6 +444,7 @@ exit 1`
 	script = strings.ReplaceAll(script, "__SECS__", strconv.Itoa(secs))
 	script = strings.ReplaceAll(script, "__IV__", strconv.Itoa(iv))
 	script = strings.ReplaceAll(script, "__K__", kFlag)
+	script = strings.ReplaceAll(script, "__CODES__", codes)
 	script = strings.ReplaceAll(script, "__URL__", shellSingleQuote(probeURL))
 
 	var out []byte
@@ -347,6 +455,46 @@ exit 1`
 	})
 	if err != nil {
 		return fmt.Errorf("probe %s on %s: %w (%s)", probeURL, sshAddr, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// waitForServiceActiveViaSSH polls `systemctl is-active <unit>` on the node
+// until it reports "active" or the timeout elapses. It is the post-upgrade gate
+// for components that expose no HTTP listener (workers): there's nothing to
+// curl, so the best available liveness signal is that systemd kept the unit up
+// (a crash-looping unit reports activating/failed and never settles on active).
+func (m *Manager) waitForServiceActiveViaSSH(sshAddr, unit string, timeout, interval time.Duration) error {
+	secs := int(timeout.Seconds())
+	if secs < 1 {
+		secs = 1
+	}
+	iv := int(interval.Seconds())
+	if iv < 1 {
+		iv = 1
+	}
+	script := `end=$(( $(date +%s) + __SECS__ ))
+last=unknown
+while [ "$(date +%s)" -lt "$end" ]; do
+  st=$(systemctl is-active __UNIT__ 2>/dev/null || true)
+  if [ "$st" = active ]; then echo ACTIVE; exit 0; fi
+  last=$st
+  sleep __IV__
+done
+echo "INACTIVE last=$last"
+exit 1`
+	script = strings.ReplaceAll(script, "__SECS__", strconv.Itoa(secs))
+	script = strings.ReplaceAll(script, "__IV__", strconv.Itoa(iv))
+	script = strings.ReplaceAll(script, "__UNIT__", shellSingleQuote(unit))
+
+	var out []byte
+	err := operator.ExecuteRemote(sshAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+		b, e := op.Output(script)
+		out = b
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("service %s on %s not active: %w (%s)", unit, sshAddr, err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -166,6 +166,15 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 		}
 		info(fmt.Sprintf("Rolling back %s to version %q", t.describe, prev))
 		m.Version = prev
+		// Clear any resolved dev asset so the rollback installs the concrete
+		// previous version through the versioned path. Without this, m.devAsset
+		// (set when we resolved the dev build at the top of UpgradeCluster)
+		// would still drive install.sh down the dev path and "roll back" to the
+		// very build we're backing out of. prev is the probed pre-upgrade
+		// release and never "dev", so this is effectively a clear.
+		if err := m.resolveDevAsset(prev); err != nil {
+			return fmt.Errorf("%s failed (%v); resolving rollback target %q: %w", t.describe, cause, prev, err)
+		}
 		if rbErr := m.upgradeOneHost(specification, masters, t); rbErr != nil {
 			return fmt.Errorf("%s failed (%v); rollback to %q also failed: %w", t.describe, cause, prev, rbErr)
 		}

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -2,12 +2,10 @@ package manager
 
 import (
 	"bytes"
-	"crypto/tls"
 	"fmt"
-	"io"
 	"net"
-	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
@@ -101,6 +99,12 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 
 	var targets []upgradeTarget
 
+	// healthURL targets localhost on the node: the probe runs on the host
+	// itself over SSH (see waitForHealthyViaSSH), so it tunnels through the
+	// bastion like every other operation instead of needing direct HTTP
+	// reachability to the node's (often private) address from the control
+	// machine.
+	//
 	// Volume servers first.
 	for i, v := range specification.VolumeServers {
 		hostPort := net.JoinHostPort(v.Ip, strconv.Itoa(v.Port))
@@ -109,7 +113,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			index:     i,
 			ip:        v.Ip,
 			portSsh:   v.PortSsh,
-			healthURL: fmt.Sprintf("%s://%s/status", scheme, hostPort),
+			healthURL: fmt.Sprintf("%s://localhost:%d/status", scheme, v.Port),
 			describe:  fmt.Sprintf("volume%d %s", i, hostPort),
 		})
 	}
@@ -121,7 +125,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			index:     i,
 			ip:        f.Ip,
 			portSsh:   f.PortSsh,
-			healthURL: fmt.Sprintf("%s://%s/", scheme, hostPort),
+			healthURL: fmt.Sprintf("%s://localhost:%d/", scheme, f.Port),
 			describe:  fmt.Sprintf("filer%d %s", i, hostPort),
 		})
 	}
@@ -133,7 +137,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			index:     i,
 			ip:        ms.Ip,
 			portSsh:   ms.PortSsh,
-			healthURL: fmt.Sprintf("%s://%s/cluster/status", scheme, hostPort),
+			healthURL: fmt.Sprintf("%s://localhost:%d/cluster/status", scheme, ms.Port),
 			describe:  fmt.Sprintf("master%d %s", i, hostPort),
 		})
 	}
@@ -181,7 +185,8 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			return rollbackHost(t, hostPrev, fmt.Errorf("upgrade %s: %w", t.describe, err))
 		}
 
-		if err := waitForHealthy(t.healthURL, opts.HealthTimeout, opts.HealthInterval, opts.InsecureSkipTLSVerify); err != nil {
+		sshAddr := net.JoinHostPort(t.ip, strconv.Itoa(t.portSsh))
+		if err := m.waitForHealthyViaSSH(sshAddr, t.healthURL, opts.HealthTimeout, opts.HealthInterval, opts.InsecureSkipTLSVerify); err != nil {
 			info(fmt.Sprintf("Health check failed for %s: %v", t.describe, err))
 			return rollbackHost(t, hostPrev, fmt.Errorf("health check failed for %s: %w", t.describe, err))
 		}
@@ -253,44 +258,64 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 	})
 }
 
-// waitForHealthy polls an HTTP(S) URL until it returns 2xx or the timeout
-// elapses. This is intentionally minimal — a more thorough probe would parse
-// the body.
+// waitForHealthyViaSSH polls localURL from the node itself (over SSH) until it
+// returns 2xx or the timeout elapses. Running the probe on the node — rather
+// than issuing an HTTP request from the control machine — means it tunnels
+// through the bastion exactly like every other operation, so it works even
+// when the node's (often private) service address is unreachable from the
+// laptop running the upgrade.
 //
-// By default TLS connections verify against the system cert pool. Pass
-// insecureSkipTLSVerify=true to disable verification (for self-signed dev
-// clusters); callers must opt in explicitly via --insecure-skip-tls-verify.
+// The poll loop runs inside a single SSH session (one shell loop) rather than
+// one SSH round-trip per attempt, so a slow-starting service doesn't cost a
+// handshake per second.
+//
+// Pass insecureSkipTLSVerify=true to add curl's -k for self-signed dev
+// clusters; callers must opt in explicitly via --insecure-skip-tls-verify.
 //
 // TODO: use cluster CA once tls bootstrap PR lands.
-func waitForHealthy(url string, timeout, interval time.Duration, insecureSkipTLSVerify bool) error {
-	if url == "" {
+func (m *Manager) waitForHealthyViaSSH(sshAddr, localURL string, timeout, interval time.Duration, insecureSkipTLSVerify bool) error {
+	if localURL == "" {
 		return nil
 	}
-	tlsConfig := &tls.Config{}
+	secs := int(timeout.Seconds())
+	if secs < 1 {
+		secs = 1
+	}
+	iv := int(interval.Seconds())
+	if iv < 1 {
+		iv = 1
+	}
+	kFlag := ""
 	if insecureSkipTLSVerify {
-		tlsConfig.InsecureSkipVerify = true //nolint:gosec // explicitly requested via --insecure-skip-tls-verify
+		kFlag = "-k "
 	}
-	transport := &http.Transport{TLSClientConfig: tlsConfig}
-	client := &http.Client{Timeout: 5 * time.Second, Transport: transport}
-	deadline := time.Now().Add(timeout)
-	var lastErr error
-	for time.Now().Before(deadline) {
-		resp, err := client.Get(url)
-		if err == nil {
-			// Drain and close so the connection can be reused.
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-				return nil
-			}
-			lastErr = fmt.Errorf("status %d from %s", resp.StatusCode, url)
-		} else {
-			lastErr = err
-		}
-		time.Sleep(interval)
+	// POSIX-sh poll loop: curl the endpoint until it answers 2xx or the
+	// deadline passes. `2??` matches any 2xx status; curl errors (e.g.
+	// connection refused while the unit is still starting) are swallowed to
+	// "000" so the loop keeps trying.
+	script := `end=$(( $(date +%s) + __SECS__ ))
+last=000
+while [ "$(date +%s)" -lt "$end" ]; do
+  code=$(curl -sS __K__-o /dev/null -m 5 -w '%{http_code}' __URL__ 2>/dev/null || echo 000)
+  case "$code" in 2??) echo HEALTHY; exit 0;; esac
+  last=$code
+  sleep __IV__
+done
+echo "UNHEALTHY last=$last"
+exit 1`
+	script = strings.ReplaceAll(script, "__SECS__", strconv.Itoa(secs))
+	script = strings.ReplaceAll(script, "__IV__", strconv.Itoa(iv))
+	script = strings.ReplaceAll(script, "__K__", kFlag)
+	script = strings.ReplaceAll(script, "__URL__", shellSingleQuote(localURL))
+
+	var out []byte
+	err := operator.ExecuteRemote(sshAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+		b, e := op.Output(script)
+		out = b
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("probe %s on %s: %w (%s)", localURL, sshAddr, err, strings.TrimSpace(string(out)))
 	}
-	if lastErr == nil {
-		lastErr = fmt.Errorf("timed out waiting for %s", url)
-	}
-	return lastErr
+	return nil
 }

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -254,19 +254,39 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 		info(fmt.Sprintf("stop %s returned: %v (continuing)", t.describe, err))
 	}
 	componentInstance := fmt.Sprintf("%s%d", hooks.serviceName, t.index)
-	return operator.ExecuteRemote(hooks.sshAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
-		var buf bytes.Buffer
-		hooks.writeConfig(&buf)
-		if hooks.prepareRemote != nil {
-			if err := hooks.prepareRemote(op); err != nil {
+	deploy := func() error {
+		return operator.ExecuteRemote(hooks.sshAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+			var buf bytes.Buffer
+			hooks.writeConfig(&buf)
+			if hooks.prepareRemote != nil {
+				if err := hooks.prepareRemote(op); err != nil {
+					return err
+				}
+			}
+			if err := m.deployComponentInstance(op, hooks.serviceName, componentInstance, &buf); err != nil {
 				return err
 			}
+			return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
+		})
+	}
+	// Retry the whole on-node sequence a few times. SCP/SSH multiplexed
+	// through a bastion can drop a channel mid-transfer and surface a
+	// transient EOF (observed once mid-rollout). Every step here is
+	// idempotent — config rewrite, mkdir -p, content-skipping install,
+	// restart — so a fresh attempt (ExecuteRemote re-dials the target, and
+	// the bastion too if its shared connection died) is safe and almost
+	// always clears a transient blip.
+	const attempts = 3
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if lastErr = deploy(); lastErr == nil {
+			return nil
 		}
-		if err := m.deployComponentInstance(op, hooks.serviceName, componentInstance, &buf); err != nil {
-			return err
+		if i < attempts-1 {
+			info(fmt.Sprintf("deploy %s attempt %d/%d failed: %v (retrying)", t.describe, i+1, attempts, lastErr))
 		}
-		return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
-	})
+	}
+	return lastErr
 }
 
 // waitForHealthyViaSSH polls probeURL from the node itself (over SSH) until it

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -99,11 +99,13 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 
 	var targets []upgradeTarget
 
-	// healthURL targets localhost on the node: the probe runs on the host
-	// itself over SSH (see waitForHealthyViaSSH), so it tunnels through the
-	// bastion like every other operation instead of needing direct HTTP
-	// reachability to the node's (often private) address from the control
-	// machine.
+	// healthURL targets the node's own configured address (Ip:port). The
+	// probe runs on the host itself over SSH (see waitForHealthyViaSSH), so
+	// it tunnels through the bastion like every other operation instead of
+	// needing direct HTTP reachability to the node's (often private) address
+	// from the control machine. We use the configured Ip rather than
+	// localhost because weed binds its HTTP listener to the advertised -ip
+	// (e.g. 10.0.0.1), so loopback is refused on hosts that don't bind 0.0.0.0.
 	//
 	// Volume servers first.
 	for i, v := range specification.VolumeServers {
@@ -113,7 +115,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			index:     i,
 			ip:        v.Ip,
 			portSsh:   v.PortSsh,
-			healthURL: fmt.Sprintf("%s://localhost:%d/status", scheme, v.Port),
+			healthURL: fmt.Sprintf("%s://%s/status", scheme, hostPort),
 			describe:  fmt.Sprintf("volume%d %s", i, hostPort),
 		})
 	}
@@ -125,7 +127,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			index:     i,
 			ip:        f.Ip,
 			portSsh:   f.PortSsh,
-			healthURL: fmt.Sprintf("%s://localhost:%d/", scheme, f.Port),
+			healthURL: fmt.Sprintf("%s://%s/", scheme, hostPort),
 			describe:  fmt.Sprintf("filer%d %s", i, hostPort),
 		})
 	}
@@ -137,7 +139,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			index:     i,
 			ip:        ms.Ip,
 			portSsh:   ms.PortSsh,
-			healthURL: fmt.Sprintf("%s://localhost:%d/cluster/status", scheme, ms.Port),
+			healthURL: fmt.Sprintf("%s://%s/cluster/status", scheme, hostPort),
 			describe:  fmt.Sprintf("master%d %s", i, hostPort),
 		})
 	}
@@ -258,7 +260,7 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 	})
 }
 
-// waitForHealthyViaSSH polls localURL from the node itself (over SSH) until it
+// waitForHealthyViaSSH polls probeURL from the node itself (over SSH) until it
 // returns 2xx or the timeout elapses. Running the probe on the node — rather
 // than issuing an HTTP request from the control machine — means it tunnels
 // through the bastion exactly like every other operation, so it works even
@@ -273,8 +275,8 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 // clusters; callers must opt in explicitly via --insecure-skip-tls-verify.
 //
 // TODO: use cluster CA once tls bootstrap PR lands.
-func (m *Manager) waitForHealthyViaSSH(sshAddr, localURL string, timeout, interval time.Duration, insecureSkipTLSVerify bool) error {
-	if localURL == "" {
+func (m *Manager) waitForHealthyViaSSH(sshAddr, probeURL string, timeout, interval time.Duration, insecureSkipTLSVerify bool) error {
+	if probeURL == "" {
 		return nil
 	}
 	secs := int(timeout.Seconds())
@@ -306,7 +308,7 @@ exit 1`
 	script = strings.ReplaceAll(script, "__SECS__", strconv.Itoa(secs))
 	script = strings.ReplaceAll(script, "__IV__", strconv.Itoa(iv))
 	script = strings.ReplaceAll(script, "__K__", kFlag)
-	script = strings.ReplaceAll(script, "__URL__", shellSingleQuote(localURL))
+	script = strings.ReplaceAll(script, "__URL__", shellSingleQuote(probeURL))
 
 	var out []byte
 	err := operator.ExecuteRemote(sshAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
@@ -315,7 +317,7 @@ exit 1`
 		return e
 	})
 	if err != nil {
-		return fmt.Errorf("probe %s on %s: %w (%s)", localURL, sshAddr, err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("probe %s on %s: %w (%s)", probeURL, sshAddr, err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/pkg/cluster/manager/manager_upgrade_test.go
+++ b/pkg/cluster/manager/manager_upgrade_test.go
@@ -1,0 +1,82 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+)
+
+// TestBuildUpgradeTargets verifies the rolling upgrade covers every restartable
+// component (not just volume/filer/master), in dependency order, with the right
+// per-component health probe.
+func TestBuildUpgradeTargets(t *testing.T) {
+	s := &spec.Specification{
+		MasterServers: []*spec.MasterServerSpec{{Ip: "10.0.0.1", Port: 9333, PortSsh: 22}},
+		VolumeServers: []*spec.VolumeServerSpec{{Ip: "10.0.0.1", Port: 8080, PortSsh: 22}},
+		FilerServers:  []*spec.FilerServerSpec{{Ip: "10.0.0.1", Port: 8888, PortSsh: 22}},
+		S3Servers:     []*spec.S3ServerSpec{{Ip: "10.0.0.1", Port: 8333, PortSsh: 22}},
+		AdminServers:  []*spec.AdminServerSpec{{Ip: "10.0.0.1", Port: 23646, PortSsh: 22}},
+		WorkerServers: []*spec.WorkerServerSpec{{Ip: "10.0.0.1", PortSsh: 22, Admin: "10.0.0.1:23646"}},
+	}
+
+	targets := buildUpgradeTargets(s, "http")
+
+	// Order: volume -> filer -> master -> s3 -> admin -> worker.
+	wantOrder := []string{"volume", "filer", "master", "s3", "admin", "worker"}
+	if len(targets) != len(wantOrder) {
+		t.Fatalf("got %d targets, want %d (%v)", len(targets), len(wantOrder), wantOrder)
+	}
+	for i, want := range wantOrder {
+		if targets[i].component != want {
+			t.Errorf("target[%d] component = %q, want %q", i, targets[i].component, want)
+		}
+	}
+
+	byComponent := map[string]upgradeTarget{}
+	for _, tg := range targets {
+		byComponent[tg.component] = tg
+	}
+
+	// Health probes hit the node's advertised Ip:port (never localhost).
+	cases := []struct {
+		component string
+		url       string
+		codes     string // "" => default 2xx
+	}{
+		{"volume", "http://10.0.0.1:8080/status", ""},
+		{"filer", "http://10.0.0.1:8888/", ""},
+		{"master", "http://10.0.0.1:9333/cluster/status", ""},
+		{"s3", "http://10.0.0.1:8333/status", ""},
+		{"admin", "http://10.0.0.1:23646/", "2??|3??"},
+	}
+	for _, c := range cases {
+		tg := byComponent[c.component]
+		if tg.healthURL != c.url {
+			t.Errorf("%s healthURL = %q, want %q", c.component, tg.healthURL, c.url)
+		}
+		if tg.healthCodes != c.codes {
+			t.Errorf("%s healthCodes = %q, want %q", c.component, tg.healthCodes, c.codes)
+		}
+	}
+
+	// Workers expose no HTTP listener: empty healthURL signals the
+	// systemctl is-active fallback gate.
+	if w := byComponent["worker"]; w.healthURL != "" {
+		t.Errorf("worker healthURL = %q, want empty (systemd is-active gate)", w.healthURL)
+	}
+}
+
+// TestBuildUpgradeTargets_TLSScheme confirms the probe scheme follows the
+// cluster TLS flag.
+func TestBuildUpgradeTargets_TLSScheme(t *testing.T) {
+	s := &spec.Specification{
+		MasterServers: []*spec.MasterServerSpec{{Ip: "10.0.0.1", Port: 9333, PortSsh: 22}},
+	}
+	targets := buildUpgradeTargets(s, "https")
+	if len(targets) != 1 {
+		t.Fatalf("got %d targets, want 1", len(targets))
+	}
+	if got, want := targets[0].healthURL, "https://10.0.0.1:9333/cluster/status"; got != want {
+		t.Errorf("healthURL = %q, want %q", got, want)
+	}
+}

--- a/pkg/config/dev.go
+++ b/pkg/config/dev.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"golang.org/x/net/context/ctxhttp"
+)
+
+// DevTag is the rolling pre-release tag SeaweedFS publishes continuous
+// builds under.
+const DevTag = "dev"
+
+// DevAsset is a resolved rolling-"dev" build artifact for one os/arch.
+type DevAsset struct {
+	// DownloadURL is the browser download URL of the tarball.
+	DownloadURL string
+	// Md5URL is DownloadURL + ".md5".
+	Md5URL string
+	// BuildID is the build datestamp embedded in the asset name
+	// (e.g. "20260607-1918"). It changes on every dev build, so it is the
+	// identity used to decide whether a re-upgrade is needed.
+	BuildID string
+}
+
+// devAssetRe matches a dev asset name and captures its build datestamp.
+// largeDisk builds are named weed-large-disk-<stamp>-linux-<arch>.tar.gz;
+// regular builds weed-<stamp>-linux-<arch>.tar.gz. The \d right after the
+// "weed-" prefix in the regular pattern keeps it from also matching the
+// "weed-large-disk-" ones.
+func devAssetRe(largeDisk bool, goArch string) *regexp.Regexp {
+	if largeDisk {
+		return regexp.MustCompile(`^weed-large-disk-(\d{8}-\d{4})-linux-` + regexp.QuoteMeta(goArch) + `\.tar\.gz$`)
+	}
+	return regexp.MustCompile(`^weed-(\d{8}-\d{4})-linux-` + regexp.QuoteMeta(goArch) + `\.tar\.gz$`)
+}
+
+// pickDevAsset returns the name and build datestamp of the newest dev
+// asset for the given variant/arch. Datestamps are YYYYMMDD-HHMM, so a
+// plain string comparison orders them chronologically.
+func pickDevAsset(assets []Asset, largeDisk bool, goArch string) (name, buildID string, ok bool) {
+	re := devAssetRe(largeDisk, goArch)
+	for _, a := range assets {
+		m := re.FindStringSubmatch(a.Name)
+		if m == nil {
+			continue
+		}
+		if buildID == "" || m[1] > buildID {
+			buildID = m[1]
+			name = a.Name
+			ok = true
+		}
+	}
+	return name, buildID, ok
+}
+
+// GitHubReleaseByTag fetches a single release by tag name.
+func GitHubReleaseByTag(ctx context.Context, owner, repo, tag string) (Release, error) {
+	ctx, cancel := context.WithTimeout(ctx, githubAPITimeout)
+	defer cancel()
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/tags/%s", owner, repo, tag)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return Release{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	setGithubAuthHeaders(req)
+
+	res, err := ctxhttp.Do(ctx, http.DefaultClient, req)
+	if err != nil {
+		return Release{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return Release{}, fmt.Errorf("github: GET %s returned %d", url, res.StatusCode)
+	}
+
+	var rel Release
+	if err := json.NewDecoder(res.Body).Decode(&rel); err != nil {
+		return Release{}, err
+	}
+	return rel, nil
+}
+
+// ResolveDevAsset resolves the newest rolling "dev" build for the given
+// repo / variant / architecture into a concrete download.
+func ResolveDevAsset(ctx context.Context, owner, repo string, largeDisk bool, goArch string) (DevAsset, error) {
+	rel, err := GitHubReleaseByTag(ctx, owner, repo, DevTag)
+	if err != nil {
+		return DevAsset{}, fmt.Errorf("resolve dev release: %w", err)
+	}
+	name, buildID, ok := pickDevAsset(rel.Assets, largeDisk, goArch)
+	if !ok {
+		variant := "weed"
+		if largeDisk {
+			variant = "weed-large-disk"
+		}
+		return DevAsset{}, fmt.Errorf("no %s-*-linux-%s.tar.gz asset in the %q release", variant, goArch, DevTag)
+	}
+	dl := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s", owner, repo, DevTag, name)
+	return DevAsset{DownloadURL: dl, Md5URL: dl + ".md5", BuildID: buildID}, nil
+}

--- a/pkg/config/dev_test.go
+++ b/pkg/config/dev_test.go
@@ -1,0 +1,53 @@
+package config
+
+import "testing"
+
+func TestPickDevAsset(t *testing.T) {
+	assets := []Asset{
+		{Name: "weed-large-disk-20260607-1918-linux-amd64.tar.gz"},
+		{Name: "weed-large-disk-20260607-1918-linux-amd64.tar.gz.md5"},
+		{Name: "weed-large-disk-20260606-1200-linux-amd64.tar.gz"}, // older
+		{Name: "weed-large-disk-20260607-1918-linux-arm64.tar.gz"}, // wrong arch
+		{Name: "weed-20260607-1918-linux-amd64.tar.gz"},            // regular variant
+		{Name: "weed-large-disk-20260607-1922-windows-amd64.zip"},  // wrong os
+	}
+
+	t.Run("large-disk picks newest amd64", func(t *testing.T) {
+		name, id, ok := pickDevAsset(assets, true, "amd64")
+		if !ok || id != "20260607-1918" || name != "weed-large-disk-20260607-1918-linux-amd64.tar.gz" {
+			t.Fatalf("got name=%q id=%q ok=%v", name, id, ok)
+		}
+	})
+
+	t.Run("regular variant excludes large-disk", func(t *testing.T) {
+		name, id, ok := pickDevAsset(assets, false, "amd64")
+		if !ok || name != "weed-20260607-1918-linux-amd64.tar.gz" || id != "20260607-1918" {
+			t.Fatalf("got name=%q id=%q ok=%v", name, id, ok)
+		}
+	})
+
+	t.Run("arch respected", func(t *testing.T) {
+		name, _, ok := pickDevAsset(assets, true, "arm64")
+		if !ok || name != "weed-large-disk-20260607-1918-linux-arm64.tar.gz" {
+			t.Fatalf("got name=%q ok=%v", name, ok)
+		}
+	})
+
+	t.Run("none matches", func(t *testing.T) {
+		if _, _, ok := pickDevAsset(assets, true, "ppc64le"); ok {
+			t.Fatalf("expected no match for ppc64le")
+		}
+	})
+
+	t.Run("newest wins regardless of order", func(t *testing.T) {
+		shuffled := []Asset{
+			{Name: "weed-large-disk-20260101-0000-linux-amd64.tar.gz"},
+			{Name: "weed-large-disk-20271231-2359-linux-amd64.tar.gz"},
+			{Name: "weed-large-disk-20260607-1918-linux-amd64.tar.gz"},
+		}
+		_, id, ok := pickDevAsset(shuffled, true, "amd64")
+		if !ok || id != "20271231-2359" {
+			t.Fatalf("got id=%q ok=%v", id, ok)
+		}
+	})
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -111,6 +111,31 @@ install_dependencies() {
 }
 
 download_and_install() {
+{{if .DevAssetURL}}
+  # Rolling "dev" build path. The version string ("dev") never changes, so
+  # idempotency keys on the build datestamp ({{.DevBuildID}}) recorded in a
+  # marker file: a moving dev tag yields a new datestamp and re-installs.
+  WANT_ID="{{.DevBuildID}}"
+  MARKER="${BIN_DIR}/.weed-dev-buildid"
+  curID=""
+  [ -f "$MARKER" ] && curID=$(cat "$MARKER" 2>/dev/null)
+  if [ -x "${BIN_DIR}/${BINARY}" ] && [ "$curID" = "$WANT_ID" ]; then
+    info "Seaweed dev build ${WANT_ID} already installed, skipping"
+  else
+    info "Downloading dev build ${WANT_ID}"
+    curl {{.ProxyConfig}} -o "$TMP_DIR/devbuild.tar.gz" -sfL "{{.DevAssetURL}}"
+    curl {{.ProxyConfig}} -o "$TMP_DIR/devbuild.tar.gz.md5" -sfL "{{.DevMd5URL}}"
+    info "Verifying dev build ${WANT_ID}"
+    md5Value=`cat "$TMP_DIR/devbuild.tar.gz.md5" | awk '{print $1}'`
+    ( cd "$TMP_DIR" && echo "${md5Value}  devbuild.tar.gz" | md5sum -c )
+    # The dev tarball holds a single binary (weed for the regular build,
+    # weed-large-disk for the large-disk build); install it as ${BINARY}.
+    devBin=`tar tzf "$TMP_DIR/devbuild.tar.gz" | head -1`
+    $SUDO tar xzf "$TMP_DIR/devbuild.tar.gz" -C "$TMP_DIR"
+    $SUDO install -m 0755 "$TMP_DIR/${devBin}" "${BIN_DIR}/${BINARY}"
+    echo "${WANT_ID}" | $SUDO tee "$MARKER" >/dev/null
+  fi
+{{else}}
   # Enterprise weed builds self-report as "<tag>-enterprise" while the
   # release is tagged as plain "<tag>", so strip any "-enterprise" suffix
   # before comparing against the target version — otherwise every deploy
@@ -162,6 +187,7 @@ download_and_install() {
     info "Unpacking ${SEAWEED_VERSION} ${assetFileName}"
     $SUDO tar xvf "$TMP_DIR/seaweed_${SEAWEED_VERSION}_${assetFileName}" --directory $BIN_DIR
   fi
+{{end}}
 }
 
 create_user_and_config() {

--- a/scripts/install_render_test.go
+++ b/scripts/install_render_test.go
@@ -1,0 +1,63 @@
+package scripts
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func renderInstall(t *testing.T, data map[string]interface{}) string {
+	t.Helper()
+	// Fields install.sh always references; tests override as needed.
+	base := map[string]interface{}{
+		"Component": "master", "ComponentInstance": "master0",
+		"ConfigDir": "/etc/seaweed", "DataDir": "/opt/seaweed", "TmpDir": "/tmp/x",
+		"SkipEnable": false, "SkipStart": false, "ForceRestart": false,
+		"Version": "4.31", "ProxyConfig": "", "ReleaseOwner": "seaweedfs",
+		"ReleaseRepo": "seaweedfs", "AssetPrefix": "", "FullSuffix": "_full",
+		"DevAssetURL": "", "DevMd5URL": "", "DevBuildID": "",
+	}
+	for k, v := range data {
+		base[k] = v
+	}
+	r, err := RenderScript("install.sh", base)
+	if err != nil {
+		t.Fatalf("RenderScript: %v", err)
+	}
+	b, _ := io.ReadAll(r)
+	return string(b)
+}
+
+func TestInstallScript_DevPath(t *testing.T) {
+	out := renderInstall(t, map[string]interface{}{
+		"Version":     "dev",
+		"DevAssetURL": "https://github.com/seaweedfs/seaweedfs/releases/download/dev/weed-large-disk-20260607-1918-linux-amd64.tar.gz",
+		"DevMd5URL":   "https://github.com/seaweedfs/seaweedfs/releases/download/dev/weed-large-disk-20260607-1918-linux-amd64.tar.gz.md5",
+		"DevBuildID":  "20260607-1918",
+	})
+	for _, want := range []string{
+		`WANT_ID="20260607-1918"`,
+		".weed-dev-buildid",
+		"weed-large-disk-20260607-1918-linux-amd64.tar.gz",
+		`[ "$curID" = "$WANT_ID" ]`, // content-based skip on the build id
+		"md5sum -c",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dev install script missing %q", want)
+		}
+	}
+	// must not fall into the versioned download path
+	if strings.Contains(out, "Downloading ${SEAWEED_VERSION} ${assetFileName}") {
+		t.Errorf("dev path should bypass the versioned download branch")
+	}
+}
+
+func TestInstallScript_VersionedPath(t *testing.T) {
+	out := renderInstall(t, map[string]interface{}{"Version": "4.31"})
+	if !strings.Contains(out, `[ "$installedVersion" = "${SEAWEED_VERSION}" ]`) {
+		t.Errorf("versioned path missing the version-compare skip check")
+	}
+	if strings.Contains(out, ".weed-dev-buildid") {
+		t.Errorf("versioned path should not contain dev marker logic")
+	}
+}


### PR DESCRIPTION
## What

Lets `cluster upgrade --version=dev` (and `deploy --version=dev`) track SeaweedFS's rolling **dev** pre-release, **re-upgrade when dev moves**, and run the rolling upgrade's health/version probes **on-node over SSH** so they work behind a bastion.

## Why it didn't work before

The dev release's assets are **datestamped** — `weed-large-disk-<YYYYMMDD-HHMM>-linux-<arch>.tar.gz` — not the fixed `linux_amd64_full_large_disk.tar.gz` the installer builds, so `--version=dev` 404'd. And the installer's skip check compares `weed version | cut -d' ' -f3` to the target; for a moving `dev` that never changes, so it would never re-upgrade even after the dev binary changed.

Separately, the rolling upgrade's post-restart **health check** and the pre-upgrade **version probe** issued HTTP requests from the control machine straight to each node's service address. Behind a bastion those private addresses are unreachable from the machine running the upgrade, so every probe timed out — health checks failed the upgrade outright, and version detection silently disabled rollback.

## How

- **`pkg/config`** — `ResolveDevAsset` fetches the `dev` release and picks the newest dated asset for the variant/arch via the pure, unit-tested `pickDevAsset`. Returns the download URL, its `.md5`, and the **build datestamp** as the build identity.
- **`pkg/cluster/manager`** — `resolveDevAsset` (called from `DeployCluster`/`UpgradeCluster`, keyed on the *target* version so rollback's `previousVersion` is preserved) stores the resolved asset and threads `DevAssetURL`/`DevMd5URL`/`DevBuildID` into the install template.
- **`scripts/install.sh`** — a dev code path: download the resolved tarball, verify the hash-only `.md5`, install the contained binary (the large-disk tarball ships `weed-large-disk` → installed as `weed`), and record the datestamp in `.weed-dev-buildid`. The **skip check compares that marker to the resolved build id**, so a stable dev is a no-op and a moved dev re-upgrades.

### Bastion-friendly upgrade probes

- **Health check** — `waitForHealthyViaSSH` replaces the HTTP `waitForHealthy`: it runs a single POSIX-sh `curl` poll loop on the node (one SSH session for the whole wait, not a handshake per attempt), so it rides the same jump-host tunnel as the rest of the upgrade.
- **Version probe** — `probeCurrentClusterVersionViaSSH` curls each master over SSH and parses `curl -i` output. The shared `probeClusterVersionWith` core and `parseClusterVersion` keep the existing HTTP path (and its tests) unchanged; `runClusterUpgrade` selects the SSH probe only when `global.bastion` is set.
- **Probe the advertised IP, not loopback** — weed binds its HTTP listener to the advertised `-ip`, so the on-node probes curl the node's own `Ip:port` (loopback is refused on hosts that don't bind `0.0.0.0`).
- **Rollback restores the real prior version** — re-resolve the dev asset against the rollback target (never `dev`) before reinstalling, which clears `m.devAsset` so a rollback routes through the versioned path instead of re-installing the dev build it was backing out of.

## Test plan

- `go build ./...`, `go vet ./...`, full `go test ./...` — pass.
- `pickDevAsset`: large-disk vs regular variant, arch filtering, `.md5` exclusion, newest-datestamp-wins regardless of order.
- install.sh render tests: dev path emits the datestamp marker + content-based skip and bypasses the versioned branch; versioned path keeps the version-compare check and has no dev marker logic.
- `parseCurlResponse`: header/body/status split, 100-continue preface, non-2xx via the `-w` trailer.
- Verified end-to-end against a live 6-node cluster behind a bastion: resolves `weed-large-disk-<stamp>-linux-amd64.tar.gz`, version probe detects the running release over SSH, and all 18 components (12 volume + 3 filer + 3 master) roll to the dev build with the on-node health gate passing.

## Notes

- Resolves the **amd64** dev build (SeaweedFS CI / the common target). Multi-arch dev clusters need per-host resolution — a follow-up.
