### PR TITLE
admin: default dataDir so maintenance task state persists across restarts

### DIFF
--- a/pkg/cluster/spec/admin_server_spec.go
+++ b/pkg/cluster/spec/admin_server_spec.go
@@ -65,14 +65,9 @@ func (a *AdminServerSpec) WriteToBuffer(masters []string, buf *bytes.Buffer) {
 	}
 	addToBuffer(buf, "master", strings.Join(mastersToUse, ","))
 
-	// dataDir backs the admin's maintenance task store. Without it the admin
-	// logs "no data directory specified, cannot save task state" and its
-	// scheduler cannot persist EC balance/rebuild task state — the tasks then
-	// repeat every cycle without ever converging, churning EC shards (this
-	// corrupted shard placement on a live cluster: shards moved to a
-	// destination without their .ecx index, leaving them unloadable). Default
-	// to "." which resolves to the systemd WorkingDirectory (the instance data
-	// dir), mirroring how the master defaults mdir to ".".
+	// Default to "." (the systemd WorkingDirectory) when unset, like the
+	// master's mdir. Without a dataDir the admin can't persist maintenance
+	// task state and its EC balance/rebuild tasks churn shards.
 	dataDir := a.DataDir
 	if dataDir == "" {
 		dataDir = "."

--- a/pkg/cluster/spec/admin_server_spec.go
+++ b/pkg/cluster/spec/admin_server_spec.go
@@ -65,7 +65,19 @@ func (a *AdminServerSpec) WriteToBuffer(masters []string, buf *bytes.Buffer) {
 	}
 	addToBuffer(buf, "master", strings.Join(mastersToUse, ","))
 
-	addToBuffer(buf, "dataDir", a.DataDir)
+	// dataDir backs the admin's maintenance task store. Without it the admin
+	// logs "no data directory specified, cannot save task state" and its
+	// scheduler cannot persist EC balance/rebuild task state — the tasks then
+	// repeat every cycle without ever converging, churning EC shards (this
+	// corrupted shard placement on a live cluster: shards moved to a
+	// destination without their .ecx index, leaving them unloadable). Default
+	// to "." which resolves to the systemd WorkingDirectory (the instance data
+	// dir), mirroring how the master defaults mdir to ".".
+	dataDir := a.DataDir
+	if dataDir == "" {
+		dataDir = "."
+	}
+	addToBuffer(buf, "dataDir", dataDir)
 	addToBuffer(buf, "adminUser", a.AdminUser)
 	addToBuffer(buf, "adminPassword", a.AdminPassword)
 

--- a/pkg/cluster/spec/admin_server_spec_test.go
+++ b/pkg/cluster/spec/admin_server_spec_test.go
@@ -32,8 +32,8 @@ func TestAdminServerSpec_WriteToBuffer_DataDirDefault(t *testing.T) {
 	a := &AdminServerSpec{Ip: "10.0.0.5", Port: 23646}
 	var buf bytes.Buffer
 	a.WriteToBuffer([]string{"10.0.0.1:9333"}, &buf)
-	if got := buf.String(); !bytes.Contains([]byte(got), []byte("dataDir=.\n")) {
-		t.Fatalf("expected dataDir=. default, got: %q", got)
+	if !bytes.Contains(buf.Bytes(), []byte("dataDir=.\n")) {
+		t.Fatalf("expected dataDir=. default, got: %q", buf.String())
 	}
 }
 

--- a/pkg/cluster/spec/admin_server_spec_test.go
+++ b/pkg/cluster/spec/admin_server_spec_test.go
@@ -16,10 +16,24 @@ func TestAdminServerSpec_WriteToBuffer_Defaults(t *testing.T) {
 	a.WriteToBuffer(masters, &buf)
 
 	// At the default port the `port=` line should be suppressed (matches
-	// how other specs emit options).
-	want := "ip=10.0.0.5\nmaster=10.0.0.1:9333,10.0.0.2:9333\n"
+	// how other specs emit options). dataDir defaults to "." so the admin's
+	// maintenance scheduler can persist task state in its WorkingDirectory.
+	want := "ip=10.0.0.5\nmaster=10.0.0.1:9333,10.0.0.2:9333\ndataDir=.\n"
 	if got := buf.String(); got != want {
 		t.Fatalf("unexpected options output\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestAdminServerSpec_WriteToBuffer_DataDirDefault is a regression guard: an
+// admin deployed without an explicit dataDir must still get one ("."), or its
+// maintenance scheduler can't persist task state and the EC balance/rebuild
+// loop churns shards endlessly.
+func TestAdminServerSpec_WriteToBuffer_DataDirDefault(t *testing.T) {
+	a := &AdminServerSpec{Ip: "10.0.0.5", Port: 23646}
+	var buf bytes.Buffer
+	a.WriteToBuffer([]string{"10.0.0.1:9333"}, &buf)
+	if got := buf.String(); !bytes.Contains([]byte(got), []byte("dataDir=.\n")) {
+		t.Fatalf("expected dataDir=. default, got: %q", got)
 	}
 }
 
@@ -60,7 +74,7 @@ func TestAdminServerSpec_WriteToBuffer_MastersOverride(t *testing.T) {
 	var buf bytes.Buffer
 	a.WriteToBuffer(masters, &buf)
 
-	want := "ip=10.0.0.5\nmaster=override1:9333,override2:9333\n"
+	want := "ip=10.0.0.5\nmaster=override1:9333,override2:9333\ndataDir=.\n"
 	if got := buf.String(); got != want {
 		t.Fatalf("unexpected options output\n got: %q\nwant: %q", got, want)
 	}
@@ -119,9 +133,11 @@ func TestAdminServerSpec_WriteToBuffer_ConfigPassthrough(t *testing.T) {
 	var buf bytes.Buffer
 	a.WriteToBuffer(masters, &buf)
 
-	// Config entries are emitted last in sorted key order.
+	// Config entries are emitted last in sorted key order. dataDir defaults
+	// to "." (after master, before the Config pass-through).
 	want := "ip=10.0.0.5\n" +
 		"master=10.0.0.1:9333\n" +
+		"dataDir=.\n" +
 		"port.grpc=33646\n" +
 		"urlPrefix=/seaweedfs\n"
 	if got := buf.String(); got != want {


### PR DESCRIPTION
## What

Default the admin server's `dataDir` to `.` when the operator doesn't set one explicitly.

## Why

Without a `dataDir` the admin's maintenance scheduler can't persist task state — it logs, on every maintenance cycle:

```
maintenance_queue.go:54 Failed to save task state for … : no data directory specified, cannot save task state
```

Defaulting `dataDir` to `.` (which resolves to the systemd `WorkingDirectory` — the per-instance data dir `install.sh` already creates, mirroring how the master defaults `mdir` to `.`) stops the log flood and gives the scheduler durable task storage. An explicit `dataDir` in `cluster.yaml` still takes precedence.

## Scope note

The admin scheduler operates on **in-memory** task state, so this is a **durability + log-cleanliness** fix — not a correctness fix for EC scheduling. (Separately diagnosed on a live cluster: EC shards were churned/degraded by an EC move/encode **verification gap** in SeaweedFS, not by the missing `dataDir`. That's a SeaweedFS-side fix.)

## Verification

- `go build ./...`, `go test ./...` pass; added a regression test and updated existing ones to expect `dataDir=.`.
- Confirmed live: after redeploy, `admin.options` gains `dataDir=.`, the admin logs `Data Directory: .`, the `no data directory` errors stop, and a `plugin/` state dir is written under the instance data dir.