### PR TITLE
spec: shared global.s3_config inherited by s3_servers (DRY up duplicated identities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,38 @@ Two example specs live under `examples/`:
   2 S3 gateways, 1 admin, 2 workers, and a co-located Prometheus + Grafana
   monitoring stack.
 
+## Shared config defaults
+
+Cluster-wide values are written once and inherited by each entry, so you
+don't repeat them per server:
+
+- **`global.s3_config`** — the s3.json (IAM identities) every `s3_servers`
+  entry uses. Define it once under `global`; the secret lives in one place.
+- **`s3_servers[].filer`** — defaults to the first `filer_servers` entry.
+- **`worker_servers[].admin`** — defaults to the first `admin_servers` entry.
+
+So a multi-gateway / multi-worker spec is just a list of IPs:
+
+```yaml
+global:
+  s3_config:
+    identities:
+      - name: app
+        credentials: [{ accessKey: APP_KEY, secretKey: CHANGE_ME }]
+        actions: [Read, Write, List, Tagging]
+
+s3_servers:        # filer + s3_config inherited
+  - { ip: 10.0.0.51 }
+  - { ip: 10.0.0.52 }
+
+worker_servers:    # admin inherited from admin_servers[0]
+  - { ip: 10.0.0.71 }
+  - { ip: 10.0.0.72 }
+```
+
+Set any of these per entry to override the default (e.g. point a gateway at
+a co-located filer, or a worker at a different admin).
+
 ## Deploy
 
 ```bash

--- a/examples/typical.yaml
+++ b/examples/typical.yaml
@@ -14,6 +14,19 @@ global:
   dir.data: "/opt/seaweed"
   volumeSizeLimitMB: 30000
   replication: "010"
+  # Shared s3.json (IAM identities) for every s3_servers entry — defined once
+  # here, not per gateway. A per-entry s3_config overrides it.
+  s3_config:
+    identities:
+      - name: app
+        credentials:
+          - accessKey: APP_ACCESS_KEY
+            secretKey: CHANGE_ME
+        actions:
+          - Read
+          - Write
+          - List
+          - Tagging
 
 # Storage layer -------------------------------------------------------------
 
@@ -85,13 +98,11 @@ filer_servers:
       database: seaweedfs
       sslmode: disable
 
+# filer defaults to the first filer_servers entry; s3_config is inherited
+# from global.s3_config. Set either per-entry to override.
 s3_servers:
   - ip: 10.0.0.51
-    port: 8333
-    filer: 10.0.0.31:8888
   - ip: 10.0.0.52
-    port: 8333
-    filer: 10.0.0.32:8888
 
 # Backend operations --------------------------------------------------------
 #
@@ -105,11 +116,11 @@ admin_servers:
     admin_user: admin
     admin_password: CHANGE_ME
 
+# admin defaults to the first admin_servers entry; set `admin:` per-entry
+# only to point a worker at a different admin.
 worker_servers:
   - ip: 10.0.0.71
-    admin: 10.0.0.61:23646
   - ip: 10.0.0.72
-    admin: 10.0.0.61:23646
 
 # Observability -------------------------------------------------------------
 #

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -500,6 +500,10 @@ func (m *Manager) prepare(specification *spec.Specification) {
 		if s3Spec.Filer == "" {
 			s3Spec.Filer = defaultFiler
 		}
+		// Inherit the shared global.s3_config when this gateway has none.
+		if len(s3Spec.S3Config) == 0 {
+			s3Spec.S3Config = specification.GlobalOptions.S3Config
+		}
 		if s3Spec.Port == 0 {
 			s3Spec.Port = 8333
 		}

--- a/pkg/cluster/manager/prepare_s3config_test.go
+++ b/pkg/cluster/manager/prepare_s3config_test.go
@@ -1,0 +1,36 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+)
+
+// TestPrepare_S3ConfigInheritsGlobal verifies an s3_servers entry without its
+// own s3_config inherits global.s3_config, while an entry with its own keeps it.
+// Filer is likewise defaulted from the first filer.
+func TestPrepare_S3ConfigInheritsGlobal(t *testing.T) {
+	global := map[string]interface{}{"identities": "shared"}
+	own := map[string]interface{}{"identities": "own"}
+	s := &spec.Specification{
+		GlobalOptions: spec.GlobalOptions{S3Config: global},
+		FilerServers:  []*spec.FilerServerSpec{{Ip: "10.0.0.1", Port: 8888}},
+		S3Servers: []*spec.S3ServerSpec{
+			{Ip: "10.0.0.1"},                // inherits global s3_config + default filer
+			{Ip: "10.0.0.2", S3Config: own}, // keeps its own
+		},
+	}
+
+	m := &Manager{User: "root"} // root skips the sudo-password prompt in prepare
+	m.prepare(s)
+
+	if got := s.S3Servers[0].S3Config["identities"]; got != "shared" {
+		t.Errorf("s3[0] should inherit global s3_config, got %v", got)
+	}
+	if got := s.S3Servers[1].S3Config["identities"]; got != "own" {
+		t.Errorf("s3[1] should keep its own s3_config, got %v", got)
+	}
+	if got := s.S3Servers[0].Filer; got != "10.0.0.1:8888" {
+		t.Errorf("s3[0] filer should default to first filer, got %q", got)
+	}
+}

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -23,6 +23,10 @@ type (
 		//   "accept-new" - learn unknown hosts (TOFU), reject changed keys
 		//   "strict"     - host must already be in ~/.ssh/known_hosts
 		SSHHostKeyCheck string `yaml:"ssh_host_key_check,omitempty"`
+		// S3Config is a shared s3.json (IAM identities) inherited by every
+		// s3_servers entry that doesn't set its own — so the secret-bearing
+		// identity block lives in one place instead of being repeated per gateway.
+		S3Config map[string]interface{} `yaml:"s3_config,omitempty"`
 	}
 
 	// BastionSpec configures an SSH jump host that seaweed-up tunnels


### PR DESCRIPTION
## What

Add a cluster-wide `global.s3_config` that every `s3_servers` entry inherits when it doesn't define its own.

## Why

With multiple S3 gateways, each `s3_servers` entry had to repeat the **entire** `s3_config` block — the IAM identities including the **secret key** — once per gateway. That's verbose and a footgun (rotate a key → edit it N times). Example before, ×6:

```yaml
s3_servers:
  - ip: 10.0.0.1
    filer: 10.0.0.1:8888
    s3_config: { identities: [ { name: warp, credentials: [ { accessKey: ..., secretKey: ... } ], ... } ] }
  - ip: 10.0.0.2
    filer: 10.0.0.1:8888
    s3_config: { identities: [ ... same ... ] }
  # ...
```

After:

```yaml
global:
  s3_config: { identities: [ { name: warp, credentials: [ ... ] } ] }
s3_servers:
  - { ip: 10.0.0.1 }
  - { ip: 10.0.0.2 }
  # filer + s3_config inherited
```

## How

`m.prepare` (shared by deploy and upgrade) copies `global.s3_config` into any `s3_servers` entry whose own `s3_config` is empty. A per-entry `s3_config` still fully overrides. This mirrors the two defaults that already exist: `filer` defaults to the first `filer_servers` entry, and a worker's `admin` defaults to the first `admin_servers` entry — so `filer:` and worker `admin:` can likewise be omitted per entry.

## Test

`TestPrepare_S3ConfigInheritsGlobal` — an entry without `s3_config` inherits the global one (and gets the default filer); an entry with its own keeps it. `go build/vet/test ./...` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 gateway configurations now inherit shared settings from global options when not explicitly configured individually. This streamlines topology specifications and reduces redundancy, allowing administrators to define common S3 identity and configuration settings once at the global level instead of repeating them for each gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->