### PR TITLE
volume: support the Rust weed-volume engine (engine: rust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ volume_servers:
 `engine` accepts `go`/`weed` (default) or `rust`/`weed-volume`. For the `rust`
 engine, seaweed-up downloads `weed-volume_large_disk_linux_<arch>.tar.gz` (plus
 `.md5`) from the release for `--version` — the asset published by SeaweedFS's
-`rust_binaries_release.yml`.
+`rust_binaries_release.yml`. With `--enterprise` it pulls
+`weed-volume-enterprise_large_disk_linux_<arch>.tar.gz` from the artifactory
+release instead, so the rust engine works for both editions.
 
 - `ignore` (default) — no verification; preserves historical behavior.
 - `accept-new` — trust-on-first-use: unknown hosts are learned and

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ volume_servers:
 ```
 
 `engine` accepts `go`/`weed` (default) or `rust`/`weed-volume`. For the `rust`
-engine, seaweed-up downloads `weed-volume-linux-<arch>.tar.gz` (plus `.md5`)
-from the release for `--version`, so publish that asset alongside the `weed`
-tarballs.
+engine, seaweed-up downloads `weed-volume_large_disk_linux_<arch>.tar.gz` (plus
+`.md5`) from the release for `--version` — the asset published by SeaweedFS's
+`rust_binaries_release.yml`.
 
 - `ignore` (default) — no verification; preserves historical behavior.
 - `accept-new` — trust-on-first-use: unknown hosts are learned and

--- a/README.md
+++ b/README.md
@@ -123,6 +123,25 @@ global:
   ssh_host_key_check: accept-new   # ignore (default) | accept-new | strict
 ```
 
+## Rust volume server
+
+A volume server can run the standalone Rust `weed-volume` binary instead of
+the Go `weed volume`. Both register with the same masters, read the same
+options file, and share the on-disk format, so they coexist in one cluster —
+set `engine` per volume server:
+
+```yaml
+volume_servers:
+  - ip: 10.0.0.21          # Go weed volume (default)
+  - ip: 10.0.0.22
+    engine: rust           # standalone weed-volume binary
+```
+
+`engine` accepts `go`/`weed` (default) or `rust`/`weed-volume`. For the `rust`
+engine, seaweed-up downloads `weed-volume-linux-<arch>.tar.gz` (plus `.md5`)
+from the release for `--version`, so publish that asset alongside the `weed`
+tarballs.
+
 - `ignore` (default) — no verification; preserves historical behavior.
 - `accept-new` — trust-on-first-use: unknown hosts are learned and
   appended to `~/.ssh/known_hosts`, but a host whose key has *changed* is

--- a/examples/typical.yaml
+++ b/examples/typical.yaml
@@ -38,6 +38,8 @@ master_servers:
   - ip: 10.0.0.13
     port: 9333
 
+# Set `engine: rust` on a volume server to run the standalone weed-volume
+# (Rust) binary instead of the Go `weed volume`; both share one cluster.
 volume_servers:
   - ip: 10.0.0.21
     port: 8382

--- a/pkg/cluster/manager/deploy_volume_server.go
+++ b/pkg/cluster/manager/deploy_volume_server.go
@@ -92,7 +92,7 @@ func (m *Manager) DeployVolumeServer(masters []string, volumeServerSpec *spec.Vo
 			return err
 		}
 
-		return m.deployComponentInstance(op, component, componentInstance, &buf)
+		return m.deployComponentBinary(op, component, componentInstance, volumeServerSpec.Engine, &buf)
 
 	})
 }

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -535,6 +535,14 @@ func (m *Manager) prepare(specification *spec.Specification) {
 }
 
 func (m *Manager) deployComponentInstance(op operator.CommandOperator, component string, componentInstance string, cliOptions *bytes.Buffer, extras ...extraConfigFile) error {
+	return m.deployComponentBinary(op, component, componentInstance, "", cliOptions, extras...)
+}
+
+// deployComponentBinary is deployComponentInstance with an explicit volume
+// engine ("" / "go" / "weed" → Go weed; "rust" / "weed-volume" → the Rust
+// weed-volume binary). Only the volume deploy/upgrade paths pass a non-empty
+// engine; every other component installs the Go weed binary as before.
+func (m *Manager) deployComponentBinary(op operator.CommandOperator, component string, componentInstance string, engine string, cliOptions *bytes.Buffer, extras ...extraConfigFile) error {
 	info("Deploying " + componentInstance + "...")
 
 	dir := "/tmp/seaweed-up." + randstr.String(6)
@@ -566,9 +574,19 @@ func (m *Manager) deployComponentInstance(op operator.CommandOperator, component
 		fullSuffix = ""
 	}
 
+	// Rust volume servers install the standalone weed-volume binary; every
+	// other component (and Go volume servers) install weed.
+	rustVolume := engine == "rust" || engine == "weed-volume"
+	binary := "weed"
+	if rustVolume {
+		binary = "weed-volume"
+	}
+
 	data := map[string]interface{}{
 		"Component":         component,
 		"ComponentInstance": componentInstance,
+		"Binary":            binary,
+		"RustVolume":        rustVolume,
 		"ConfigDir":         m.confDir,
 		"DataDir":           m.dataDir,
 		"TmpDir":            dir,

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -599,6 +599,7 @@ func (m *Manager) deployComponentBinary(op operator.CommandOperator, component s
 		"ReleaseRepo":       releaseRepo,
 		"AssetPrefix":       assetPrefix,
 		"FullSuffix":        fullSuffix,
+		"Enterprise":        m.Enterprise,
 		// Rolling "dev" build fields. Empty unless m.Version == "dev" and
 		// the asset was resolved; install.sh takes its dev code path only
 		// when DevAssetURL is non-empty.

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -67,6 +67,9 @@ type componentHooks struct {
 	// fresh on every deploy attempt because each extra carries a single-use
 	// Reader the retry loop would otherwise exhaust. May be nil.
 	extras func() ([]extraConfigFile, error)
+	// engine selects the volume binary ("" Go weed, "rust" weed-volume);
+	// empty for non-volume components.
+	engine string
 }
 
 // UpgradeCluster performs a rolling upgrade of the cluster to targetVersion.
@@ -276,6 +279,7 @@ func (m *Manager) upgradeOneHost(specification *spec.Specification, masters, wor
 			stop:          func() error { return m.StopVolumeServer(vs, t.index) },
 			writeConfig:   func(buf *bytes.Buffer) { vs.WriteToBuffer(masters, buf) },
 			prepareRemote: func(op operator.CommandOperator) error { return m.ensureVolumeFolders(op, vs) },
+			engine:        vs.Engine,
 		}
 	case "filer":
 		fs := specification.FilerServers[t.index]
@@ -367,7 +371,7 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 					return err
 				}
 			}
-			if err := m.deployComponentInstance(op, hooks.serviceName, componentInstance, &buf, extras...); err != nil {
+			if err := m.deployComponentBinary(op, hooks.serviceName, componentInstance, hooks.engine, &buf, extras...); err != nil {
 				return err
 			}
 			return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -189,6 +189,9 @@ func (s *Specification) Validate() error {
 	}
 
 	for i, v := range s.VolumeServers {
+		if v == nil {
+			return fmt.Errorf("volume_servers[%d] is null (yaml null list item?)", i)
+		}
 		if !ValidVolumeEngine(v.Engine) {
 			return fmt.Errorf("volume_servers[%d].engine %q is invalid (want go or rust)", i, v.Engine)
 		}

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -188,6 +188,12 @@ func (s *Specification) Validate() error {
 			s.GlobalOptions.SSHHostKeyCheck)
 	}
 
+	for i, v := range s.VolumeServers {
+		if !ValidVolumeEngine(v.Engine) {
+			return fmt.Errorf("volume_servers[%d].engine %q is invalid (want go or rust)", i, v.Engine)
+		}
+	}
+
 	if mon := s.Monitoring; mon != nil {
 		if strings.TrimSpace(mon.Host) == "" {
 			return fmt.Errorf("monitoring.host is required when monitoring is configured")

--- a/pkg/cluster/spec/volume_engine_test.go
+++ b/pkg/cluster/spec/volume_engine_test.go
@@ -26,4 +26,13 @@ func TestSpecification_Validate_VolumeEngine(t *testing.T) {
 	if err := base("rusty").Validate(); err == nil {
 		t.Error("engine \"rusty\" should be rejected")
 	}
+
+	// A null volume_servers list item must be rejected, not panic.
+	nullEntry := &Specification{
+		MasterServers: []*MasterServerSpec{{Ip: "10.0.0.1"}},
+		VolumeServers: []*VolumeServerSpec{nil},
+	}
+	if err := nullEntry.Validate(); err == nil {
+		t.Error("a null volume_servers entry should be rejected")
+	}
 }

--- a/pkg/cluster/spec/volume_engine_test.go
+++ b/pkg/cluster/spec/volume_engine_test.go
@@ -1,0 +1,29 @@
+package spec
+
+import "testing"
+
+func TestVolumeServerSpec_IsRust(t *testing.T) {
+	cases := map[string]bool{"": false, "go": false, "weed": false, "rust": true, "weed-volume": true}
+	for engine, want := range cases {
+		if got := (&VolumeServerSpec{Engine: engine}).IsRust(); got != want {
+			t.Errorf("IsRust(%q) = %v, want %v", engine, got, want)
+		}
+	}
+}
+
+func TestSpecification_Validate_VolumeEngine(t *testing.T) {
+	base := func(engine string) *Specification {
+		return &Specification{
+			MasterServers: []*MasterServerSpec{{Ip: "10.0.0.1"}},
+			VolumeServers: []*VolumeServerSpec{{Ip: "10.0.0.1", Engine: engine}},
+		}
+	}
+	for _, ok := range []string{"", "go", "weed", "rust", "weed-volume"} {
+		if err := base(ok).Validate(); err != nil {
+			t.Errorf("engine %q should be valid, got %v", ok, err)
+		}
+	}
+	if err := base("rusty").Validate(); err == nil {
+		t.Error("engine \"rusty\" should be rejected")
+	}
+}

--- a/pkg/cluster/spec/volume_server_spec.go
+++ b/pkg/cluster/spec/volume_server_spec.go
@@ -31,7 +31,27 @@ type VolumeServerSpec struct {
 	Config             map[string]interface{} `yaml:"config,omitempty"`
 	Arch               string                 `yaml:"arch,omitempty"`
 	OS                 string                 `yaml:"os,omitempty"`
+	// Engine selects the volume implementation: "" / "go" / "weed" run the Go
+	// `weed volume`; "rust" / "weed-volume" run the standalone Rust
+	// `weed-volume` binary. Both register with the same masters and read the
+	// same options file, so they can coexist in one cluster.
+	Engine string `yaml:"engine,omitempty"`
 }
+
+// IsRust reports whether this volume server runs the Rust weed-volume binary.
+func (vs *VolumeServerSpec) IsRust() bool {
+	return vs.Engine == "rust" || vs.Engine == "weed-volume"
+}
+
+// ValidVolumeEngine reports whether engine is an accepted value.
+func ValidVolumeEngine(engine string) bool {
+	switch engine {
+	case "", "go", "weed", "rust", "weed-volume":
+		return true
+	}
+	return false
+}
+
 type FolderSpec struct {
 	Folder   string `yaml:"folder"`
 	DiskType string `yaml:"disk" default:"hdd"`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -122,7 +122,9 @@ download_and_install() {
     info "weed-volume ${SEAWEED_VERSION} already installed, skipping"
   else
     OS="linux"
-    RUST_ASSET="weed-volume-${OS}-${SUFFIX}.tar.gz"
+    # Matches the rust release asset (rust_binaries_release.yml): the
+    # large-disk variant tarball holds a binary named weed-volume-large-disk.
+    RUST_ASSET="weed-volume_large_disk_${OS}_${SUFFIX}.tar.gz"
     RUST_URL="https://github.com/{{.ReleaseOwner}}/{{.ReleaseRepo}}/releases/download/${SEAWEED_VERSION}/${RUST_ASSET}"
     info "Downloading weed-volume ${SEAWEED_VERSION} (${RUST_ASSET})"
     curl {{.ProxyConfig}} -o "$TMP_DIR/${RUST_ASSET}" -sfL "${RUST_URL}"
@@ -130,7 +132,7 @@ download_and_install() {
     info "Verifying weed-volume ${SEAWEED_VERSION}"
     md5Value=`cat "$TMP_DIR/${RUST_ASSET}.md5" | awk '{print $1}'`
     ( cd "$TMP_DIR" && echo "${md5Value}  ${RUST_ASSET}" | md5sum -c )
-    rustBin=`tar tzf "$TMP_DIR/${RUST_ASSET}" | grep -E '(^|/)weed-volume$' | head -1`
+    rustBin=`tar tzf "$TMP_DIR/${RUST_ASSET}" | grep -E '(^|/)weed-volume(-large-disk)?$' | head -1`
     if [ -z "$rustBin" ]; then fatal "no weed-volume binary in ${RUST_ASSET}"; fi
     $SUDO tar xzf "$TMP_DIR/${RUST_ASSET}" -C "$TMP_DIR"
     $SUDO install -m 0755 "$TMP_DIR/${rustBin}" "${BIN_DIR}/${BINARY}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -122,9 +122,11 @@ download_and_install() {
     info "weed-volume ${SEAWEED_VERSION} already installed, skipping"
   else
     OS="linux"
-    # Matches the rust release asset (rust_binaries_release.yml): the
-    # large-disk variant tarball holds a binary named weed-volume-large-disk.
-    RUST_ASSET="weed-volume_large_disk_${OS}_${SUFFIX}.tar.gz"
+    # Matches the rust release asset: the large-disk variant tarball holds a
+    # binary named weed-volume-large-disk. OSS publishes weed-volume_... from
+    # seaweedfs/seaweedfs; enterprise publishes weed-volume-enterprise_... from
+    # seaweedfs/artifactory (ReleaseOwner/ReleaseRepo already select the repo).
+    RUST_ASSET="weed-volume{{if .Enterprise}}-enterprise{{end}}_large_disk_${OS}_${SUFFIX}.tar.gz"
     RUST_URL="https://github.com/{{.ReleaseOwner}}/{{.ReleaseRepo}}/releases/download/${SEAWEED_VERSION}/${RUST_ASSET}"
     info "Downloading weed-volume ${SEAWEED_VERSION} (${RUST_ASSET})"
     curl {{.ProxyConfig}} -o "$TMP_DIR/${RUST_ASSET}" -sfL "${RUST_URL}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,7 +41,7 @@ setup_env() {
   SEAWEED_COMPONENT_INSTANCE_SERVICE_FILE=/etc/systemd/system/seaweed_${COMPONENT_INSTANCE}.service
 
   BIN_DIR=/usr/local/bin
-  BINARY=weed
+  BINARY={{.Binary}}
 
   PRE_INSTALL_HASHES=$(get_installed_hashes)
 
@@ -111,7 +111,32 @@ install_dependencies() {
 }
 
 download_and_install() {
-{{if .DevAssetURL}}
+{{if .RustVolume}}
+  # Rust volume server: install the standalone weed-volume binary from the
+  # release. Idempotency keys on a marker storing the installed version, since
+  # weed-volume's --version scheme differs from the SeaweedFS release tag.
+  MARKER="${BIN_DIR}/.weed-volume-version"
+  curID=""
+  [ -f "$MARKER" ] && curID=$(cat "$MARKER" 2>/dev/null)
+  if [ -x "${BIN_DIR}/${BINARY}" ] && [ "$curID" = "${SEAWEED_VERSION}" ]; then
+    info "weed-volume ${SEAWEED_VERSION} already installed, skipping"
+  else
+    OS="linux"
+    RUST_ASSET="weed-volume-${OS}-${SUFFIX}.tar.gz"
+    RUST_URL="https://github.com/{{.ReleaseOwner}}/{{.ReleaseRepo}}/releases/download/${SEAWEED_VERSION}/${RUST_ASSET}"
+    info "Downloading weed-volume ${SEAWEED_VERSION} (${RUST_ASSET})"
+    curl {{.ProxyConfig}} -o "$TMP_DIR/${RUST_ASSET}" -sfL "${RUST_URL}"
+    curl {{.ProxyConfig}} -o "$TMP_DIR/${RUST_ASSET}.md5" -sfL "${RUST_URL}.md5"
+    info "Verifying weed-volume ${SEAWEED_VERSION}"
+    md5Value=`cat "$TMP_DIR/${RUST_ASSET}.md5" | awk '{print $1}'`
+    ( cd "$TMP_DIR" && echo "${md5Value}  ${RUST_ASSET}" | md5sum -c )
+    rustBin=`tar tzf "$TMP_DIR/${RUST_ASSET}" | grep -E '(^|/)weed-volume$' | head -1`
+    if [ -z "$rustBin" ]; then fatal "no weed-volume binary in ${RUST_ASSET}"; fi
+    $SUDO tar xzf "$TMP_DIR/${RUST_ASSET}" -C "$TMP_DIR"
+    $SUDO install -m 0755 "$TMP_DIR/${rustBin}" "${BIN_DIR}/${BINARY}"
+    echo "${SEAWEED_VERSION}" | $SUDO tee "$MARKER" >/dev/null
+  fi
+{{else}}{{if .DevAssetURL}}
   # Rolling "dev" build path. The version string ("dev") never changes, so
   # idempotency keys on the build datestamp ({{.DevBuildID}}) recorded in a
   # marker file: a moving dev tag yields a new datestamp and re-installs.
@@ -187,7 +212,7 @@ download_and_install() {
     info "Unpacking ${SEAWEED_VERSION} ${assetFileName}"
     $SUDO tar xvf "$TMP_DIR/seaweed_${SEAWEED_VERSION}_${assetFileName}" --directory $BIN_DIR
   fi
-{{end}}
+{{end}}{{end}}
 }
 
 create_user_and_config() {
@@ -214,7 +239,7 @@ StartLimitIntervalSec=10
 
 [Service]
 WorkingDirectory=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR}
-ExecStart=${BIN_DIR}/${BINARY} -logdir=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR} -alsologtostderr=false -config_dir=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR} ${COMPONENT} -options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options
+{{if .RustVolume}}ExecStart=${BIN_DIR}/${BINARY} -options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options{{else}}ExecStart=${BIN_DIR}/${BINARY} -logdir=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR} -alsologtostderr=false -config_dir=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR} ${COMPONENT} -options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options{{end}}
 ExecReload=/bin/kill -s HUP \$MAINPID
 KillMode=process
 KillSignal=SIGINT

--- a/scripts/install_render_test.go
+++ b/scripts/install_render_test.go
@@ -16,7 +16,7 @@ func renderInstall(t *testing.T, data map[string]interface{}) string {
 		"Version": "4.31", "ProxyConfig": "", "ReleaseOwner": "seaweedfs",
 		"ReleaseRepo": "seaweedfs", "AssetPrefix": "", "FullSuffix": "_full",
 		"DevAssetURL": "", "DevMd5URL": "", "DevBuildID": "",
-		"Binary": "weed", "RustVolume": false,
+		"Binary": "weed", "RustVolume": false, "Enterprise": false,
 	}
 	for k, v := range data {
 		base[k] = v
@@ -74,6 +74,23 @@ func TestInstallScript_RustVolumePath(t *testing.T) {
 	}
 	if strings.Contains(out, "-logdir=") || strings.Contains(out, "${COMPONENT} -options=") {
 		t.Errorf("rust ExecStart should not use go-style flags / subcommand")
+	}
+}
+
+func TestInstallScript_RustVolumeEnterprisePath(t *testing.T) {
+	out := renderInstall(t, map[string]interface{}{
+		"Component": "volume", "ComponentInstance": "volume0",
+		"Binary": "weed-volume", "RustVolume": true, "Enterprise": true,
+		"ReleaseOwner": "seaweedfs", "ReleaseRepo": "artifactory", "Version": "4.31",
+	})
+	if !strings.Contains(out, "weed-volume-enterprise_large_disk_${OS}_${SUFFIX}.tar.gz") {
+		t.Errorf("enterprise rust path should download the weed-volume-enterprise_ asset")
+	}
+	if !strings.Contains(out, "seaweedfs/artifactory/releases") {
+		t.Errorf("enterprise rust path should pull from the artifactory repo")
+	}
+	if strings.Contains(out, "weed-volume_large_disk_") {
+		t.Errorf("enterprise rust path should not use the OSS asset name")
 	}
 }
 

--- a/scripts/install_render_test.go
+++ b/scripts/install_render_test.go
@@ -60,7 +60,7 @@ func TestInstallScript_RustVolumePath(t *testing.T) {
 	})
 	for _, want := range []string{
 		"BINARY=weed-volume",
-		"weed-volume-${OS}-${SUFFIX}.tar.gz",                         // versioned per-arch asset
+		"weed-volume_large_disk_${OS}_${SUFFIX}.tar.gz",             // versioned per-arch release asset
 		".weed-volume-version",                                       // version marker
 		"ExecStart=${BIN_DIR}/${BINARY} -options=",                   // no `weed volume` subcommand / go globals
 	} {

--- a/scripts/install_render_test.go
+++ b/scripts/install_render_test.go
@@ -16,6 +16,7 @@ func renderInstall(t *testing.T, data map[string]interface{}) string {
 		"Version": "4.31", "ProxyConfig": "", "ReleaseOwner": "seaweedfs",
 		"ReleaseRepo": "seaweedfs", "AssetPrefix": "", "FullSuffix": "_full",
 		"DevAssetURL": "", "DevMd5URL": "", "DevBuildID": "",
+		"Binary": "weed", "RustVolume": false,
 	}
 	for k, v := range data {
 		base[k] = v
@@ -49,6 +50,30 @@ func TestInstallScript_DevPath(t *testing.T) {
 	// must not fall into the versioned download path
 	if strings.Contains(out, "Downloading ${SEAWEED_VERSION} ${assetFileName}") {
 		t.Errorf("dev path should bypass the versioned download branch")
+	}
+}
+
+func TestInstallScript_RustVolumePath(t *testing.T) {
+	out := renderInstall(t, map[string]interface{}{
+		"Component": "volume", "ComponentInstance": "volume0",
+		"Binary": "weed-volume", "RustVolume": true, "Version": "4.31",
+	})
+	for _, want := range []string{
+		"BINARY=weed-volume",
+		"weed-volume-${OS}-${SUFFIX}.tar.gz",                         // versioned per-arch asset
+		".weed-volume-version",                                       // version marker
+		"ExecStart=${BIN_DIR}/${BINARY} -options=",                   // no `weed volume` subcommand / go globals
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rust volume install script missing %q", want)
+		}
+	}
+	// must not take the Go versioned/full-asset path or the go-style ExecStart
+	if strings.Contains(out, "_full_large_disk.tar.gz") {
+		t.Errorf("rust path should not download the Go weed tarball")
+	}
+	if strings.Contains(out, "-logdir=") || strings.Contains(out, "${COMPONENT} -options=") {
+		t.Errorf("rust ExecStart should not use go-style flags / subcommand")
 	}
 }
 


### PR DESCRIPTION
## What

Add a per-`volume_servers` **`engine`** selector so a volume server can run the standalone Rust **`weed-volume`** binary instead of the Go `weed volume`:

```yaml
volume_servers:
  - ip: 10.0.0.21          # Go weed volume (default)
  - ip: 10.0.0.22
    engine: rust           # standalone weed-volume binary
```

`engine` accepts `go`/`weed` (default) or `rust`/`weed-volume`; anything else is rejected by `Validate()`.

## Why it's a small change

The Rust `weed-volume` is designed as a drop-in: it reads the **same `-options=<file>`** (`optionName=optionValue`) format seaweed-up already renders, uses the **same flag names**, speaks the **same gRPC/heartbeat protocol**, and shares the **on-disk format**. So the options renderer (`VolumeServerSpec.WriteToBuffer`) and the entire control plane (masters/admin/EC/balance) are reused unchanged — Go and Rust volume servers coexist in one cluster.

## How

- **spec**: `VolumeServerSpec.Engine` + `IsRust()` + `Validate()` check.
- **threading**: `deployComponentInstance` → `deployComponentBinary(…, engine, …)`; the volume deploy and the upgrade volume hook pass `vs.Engine`. The other 6 components are untouched (they install Go `weed`).
- **install.sh**: a rust branch installs `weed-volume` from the per-arch release asset `weed-volume-linux-<arch>.tar.gz` (+ `.md5`), idempotent via a `.weed-volume-version` marker; systemd `ExecStart=weed-volume -options=<file>` (no Go subcommand or `-logdir`/`-config_dir`).

## Distribution prerequisite

For `engine: rust`, publish `weed-volume-linux-amd64.tar.gz` / `weed-volume-linux-arm64.tar.gz` (each containing the `weed-volume` binary) plus a `.md5` on the release for `--version`, alongside the existing `weed` tarballs. (Asset naming is defined in `install.sh`; adjust there if the release pipeline differs.)

## Test

`TestInstallScript_RustVolumePath` (rust download + ExecStart, no Go path), `TestVolumeServerSpec_IsRust`, `TestSpecification_Validate_VolumeEngine`; `go build/vet/test ./...` pass.