### PR TITLE
fix: resolve rust weed-volume dev asset for rolling dev upgrades

### DIFF
--- a/pkg/cluster/manager/deploy_dev.go
+++ b/pkg/cluster/manager/deploy_dev.go
@@ -4,8 +4,23 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
 	"github.com/seaweedfs/seaweed-up/pkg/config"
 )
+
+// specHasRustVolume reports whether any volume server in the spec runs the
+// standalone Rust weed-volume binary (which ships as a separate dev asset).
+func specHasRustVolume(s *spec.Specification) bool {
+	if s == nil {
+		return false
+	}
+	for _, v := range s.VolumeServers {
+		if v != nil && v.IsRust() {
+			return true
+		}
+	}
+	return false
+}
 
 // devArch is the architecture seaweed-up resolves rolling "dev" builds
 // for. The dev release datestamps each os/arch independently, so a single
@@ -15,22 +30,38 @@ import (
 const devArch = "amd64"
 
 // resolveDevAsset resolves the newest rolling "dev" build into m.devAsset
-// when the target version is "dev". It is a no-op for normal versions and
-// is safe to call more than once (re-resolves so a moving dev tag is
-// picked up on the next deploy/upgrade). largeDisk is always true:
-// install.sh builds the *_large_disk asset, so dev tracks the matching
-// weed-large-disk-* build.
-func (m *Manager) resolveDevAsset(version string) error {
+// (the Go `weed` server) and, when the cluster has any Rust volume server,
+// m.rustDevAsset (the standalone `weed-volume`). It is a no-op for normal
+// versions and is safe to call more than once (re-resolves so a moving dev
+// tag is picked up on the next deploy/upgrade). largeDisk is always true:
+// install.sh builds the *-large-disk asset, so dev tracks the matching
+// large-disk build. The two assets are datestamped independently in the dev
+// release, so each is resolved on its own.
+func (m *Manager) resolveDevAsset(version string, specification *spec.Specification) error {
 	if version != config.DevTag {
 		m.devAsset = nil
+		m.rustDevAsset = nil
 		return nil
 	}
 	owner, repo := m.ReleaseOwnerRepo()
-	asset, err := config.ResolveDevAsset(context.Background(), owner, repo, true, devArch)
+	asset, err := config.ResolveDevAsset(context.Background(), owner, repo, "weed", true, devArch)
 	if err != nil {
 		return err
 	}
 	info(fmt.Sprintf("Resolved dev build %s -> %s", asset.BuildID, asset.DownloadURL))
 	m.devAsset = &asset
+
+	// The Rust volume binary ships as a separate weed-volume-large-disk-*
+	// dev asset; resolve it only when a volume server actually runs Rust.
+	if specHasRustVolume(specification) {
+		rustAsset, err := config.ResolveDevAsset(context.Background(), owner, repo, "weed-volume", true, devArch)
+		if err != nil {
+			return err
+		}
+		info(fmt.Sprintf("Resolved rust dev build %s -> %s", rustAsset.BuildID, rustAsset.DownloadURL))
+		m.rustDevAsset = &rustAsset
+	} else {
+		m.rustDevAsset = nil
+	}
 	return nil
 }

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -131,9 +131,14 @@ type Manager struct {
 	sudoPass   string
 	confDir    string
 	dataDir    string
-	// devAsset holds the resolved rolling "dev" build (set by
-	// resolveDevAsset when Version == "dev"); nil for normal versions.
+	// devAsset holds the resolved rolling "dev" build of the Go `weed`
+	// server (set by resolveDevAsset when Version == "dev"); nil otherwise.
 	devAsset *config.DevAsset
+	// rustDevAsset holds the resolved rolling "dev" build of the standalone
+	// Rust `weed-volume` binary, set only when Version == "dev" and the spec
+	// has a Rust volume server (the dev release datestamps it separately
+	// from the Go asset); nil otherwise.
+	rustDevAsset *config.DevAsset
 
 	// prepareHostAddressFn overrides PrepareHostAddress for tests. When nil,
 	// PrepareAllHosts calls PrepareHostAddress directly.

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -183,7 +183,7 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	m.prepare(specification)
 
 	// Resolve the rolling "dev" build to a concrete dated asset, if asked.
-	if err := m.resolveDevAsset(m.Version); err != nil {
+	if err := m.resolveDevAsset(m.Version, specification); err != nil {
 		return fmt.Errorf("resolve dev build: %w", err)
 	}
 
@@ -602,15 +602,25 @@ func (m *Manager) deployComponentBinary(op operator.CommandOperator, component s
 		"Enterprise":        m.Enterprise,
 		// Rolling "dev" build fields. Empty unless m.Version == "dev" and
 		// the asset was resolved; install.sh takes its dev code path only
-		// when DevAssetURL is non-empty.
-		"DevAssetURL": "",
-		"DevMd5URL":   "",
-		"DevBuildID":  "",
+		// when DevAssetURL is non-empty. The Rust volume binary is a
+		// separate, independently-datestamped dev asset, threaded apart and
+		// used only by the rust install branch.
+		"DevAssetURL":     "",
+		"DevMd5URL":       "",
+		"DevBuildID":      "",
+		"RustDevAssetURL": "",
+		"RustDevMd5URL":   "",
+		"RustDevBuildID":  "",
 	}
 	if m.devAsset != nil {
 		data["DevAssetURL"] = m.devAsset.DownloadURL
 		data["DevMd5URL"] = m.devAsset.Md5URL
 		data["DevBuildID"] = m.devAsset.BuildID
+	}
+	if rustVolume && m.rustDevAsset != nil {
+		data["RustDevAssetURL"] = m.rustDevAsset.DownloadURL
+		data["RustDevMd5URL"] = m.rustDevAsset.Md5URL
+		data["RustDevBuildID"] = m.rustDevAsset.BuildID
 	}
 
 	// Configure proxy if specified

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -91,6 +91,21 @@ func validateSingleAdminServer(specification *spec.Specification) error {
 		len(ips), strings.Join(ips, ", "))
 }
 
+// validateVolumeServers rejects nil entries in the volume_servers list.
+// A YAML null list item (a stray bullet on its own line, or `volume_servers:
+// [null]`) decodes to a nil *VolumeServerSpec; later passes that iterate the
+// list (disk-demand accounting, the per-server deploy fan-out, the Rust-asset
+// scan) would then dereference it and panic. Catch it up front with a clear
+// error, mirroring validateSingleAdminServer.
+func validateVolumeServers(specification *spec.Specification) error {
+	for i, v := range specification.VolumeServers {
+		if v == nil {
+			return fmt.Errorf("invalid cluster spec: volume_servers[%d] is null (yaml null list item?)", i)
+		}
+	}
+	return nil
+}
+
 // validateSftpFilerPrerequisite ensures that any SFTP server can reach a
 // filer: either the spec defines at least one FilerServer (which prepare()
 // would wire in as the default), or every SftpServer declares an explicit
@@ -172,6 +187,9 @@ func computeVolumeTargetDemand(volumes []*spec.VolumeServerSpec) (mountpoints, s
 
 func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	if err := validateSingleAdminServer(specification); err != nil {
+		return err
+	}
+	if err := validateVolumeServers(specification); err != nil {
 		return err
 	}
 	if err := validateS3Prerequisites(specification); err != nil {

--- a/pkg/cluster/manager/manager_deploy_test.go
+++ b/pkg/cluster/manager/manager_deploy_test.go
@@ -140,6 +140,30 @@ func TestValidateSingleAdminServer_rejectsTwo(t *testing.T) {
 	}
 }
 
+func TestValidateVolumeServers_rejectsNilEntry(t *testing.T) {
+	// No volume servers, or all real entries: allowed.
+	if err := validateVolumeServers(&spec.Specification{}); err != nil {
+		t.Errorf("empty volume_servers should pass: %v", err)
+	}
+	ok := &spec.Specification{}
+	ok.VolumeServers = append(ok.VolumeServers, &spec.VolumeServerSpec{Ip: "10.0.0.1"})
+	if err := validateVolumeServers(ok); err != nil {
+		t.Errorf("real volume_servers entry should pass: %v", err)
+	}
+
+	// A YAML null list item decodes to a nil *VolumeServerSpec; later passes
+	// iterate the list and would panic. The validator turns that into an error.
+	s := &spec.Specification{}
+	s.VolumeServers = append(s.VolumeServers, &spec.VolumeServerSpec{Ip: "10.0.0.1"}, nil)
+	err := validateVolumeServers(s)
+	if err == nil {
+		t.Fatal("expected error for nil volume_servers entry, got nil")
+	}
+	if !strings.Contains(err.Error(), "null") {
+		t.Errorf("error should mention the null entry, got: %v", err)
+	}
+}
+
 func TestValidateSftpFilerPrerequisite_NoSftp(t *testing.T) {
 	s := &spec.Specification{}
 	if err := validateSftpFilerPrerequisite(s); err != nil {

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -95,7 +95,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 	// concrete dated build now (keyed on targetVersion, not m.Version which
 	// still holds the probed current version for rollback). The resolved
 	// asset + its build id drive the download and content-based skip check.
-	if err := m.resolveDevAsset(targetVersion); err != nil {
+	if err := m.resolveDevAsset(targetVersion, specification); err != nil {
 		return fmt.Errorf("resolve dev build: %w", err)
 	}
 
@@ -153,7 +153,7 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 		// would still drive install.sh down the dev path and "roll back" to the
 		// very build we're backing out of. prev is the probed pre-upgrade
 		// release and never "dev", so this is effectively a clear.
-		if err := m.resolveDevAsset(prev); err != nil {
+		if err := m.resolveDevAsset(prev, specification); err != nil {
 			return fmt.Errorf("%s failed (%v); resolving rollback target %q: %w", t.describe, cause, prev, err)
 		}
 		if rbErr := m.upgradeOneHost(specification, masters, workerAdmins, t); rbErr != nil {

--- a/pkg/config/dev.go
+++ b/pkg/config/dev.go
@@ -27,22 +27,25 @@ type DevAsset struct {
 }
 
 // devAssetRe matches a dev asset name and captures its build datestamp.
-// largeDisk builds are named weed-large-disk-<stamp>-linux-<arch>.tar.gz;
-// regular builds weed-<stamp>-linux-<arch>.tar.gz. The \d right after the
-// "weed-" prefix in the regular pattern keeps it from also matching the
-// "weed-large-disk-" ones.
-func devAssetRe(largeDisk bool, goArch string) *regexp.Regexp {
+// `binary` is the binary prefix ("weed" for the Go server, "weed-volume"
+// for the standalone Rust volume server). largeDisk builds are named
+// <binary>-large-disk-<stamp>-linux-<arch>.tar.gz; regular builds
+// <binary>-<stamp>-linux-<arch>.tar.gz. The \d right after the "<binary>-"
+// prefix in the regular pattern keeps it from also matching the
+// "<binary>-large-disk-" ones (and "weed-" from matching "weed-volume-").
+func devAssetRe(binary string, largeDisk bool, goArch string) *regexp.Regexp {
+	prefix := regexp.QuoteMeta(binary)
 	if largeDisk {
-		return regexp.MustCompile(`^weed-large-disk-(\d{8}-\d{4})-linux-` + regexp.QuoteMeta(goArch) + `\.tar\.gz$`)
+		return regexp.MustCompile(`^` + prefix + `-large-disk-(\d{8}-\d{4})-linux-` + regexp.QuoteMeta(goArch) + `\.tar\.gz$`)
 	}
-	return regexp.MustCompile(`^weed-(\d{8}-\d{4})-linux-` + regexp.QuoteMeta(goArch) + `\.tar\.gz$`)
+	return regexp.MustCompile(`^` + prefix + `-(\d{8}-\d{4})-linux-` + regexp.QuoteMeta(goArch) + `\.tar\.gz$`)
 }
 
 // pickDevAsset returns the name and build datestamp of the newest dev
-// asset for the given variant/arch. Datestamps are YYYYMMDD-HHMM, so a
-// plain string comparison orders them chronologically.
-func pickDevAsset(assets []Asset, largeDisk bool, goArch string) (name, buildID string, ok bool) {
-	re := devAssetRe(largeDisk, goArch)
+// asset for the given binary/variant/arch. Datestamps are YYYYMMDD-HHMM,
+// so a plain string comparison orders them chronologically.
+func pickDevAsset(assets []Asset, binary string, largeDisk bool, goArch string) (name, buildID string, ok bool) {
+	re := devAssetRe(binary, largeDisk, goArch)
 	for _, a := range assets {
 		m := re.FindStringSubmatch(a.Name)
 		if m == nil {
@@ -87,17 +90,18 @@ func GitHubReleaseByTag(ctx context.Context, owner, repo, tag string) (Release, 
 }
 
 // ResolveDevAsset resolves the newest rolling "dev" build for the given
-// repo / variant / architecture into a concrete download.
-func ResolveDevAsset(ctx context.Context, owner, repo string, largeDisk bool, goArch string) (DevAsset, error) {
+// repo / binary / variant / architecture into a concrete download. `binary`
+// is "weed" for the Go server or "weed-volume" for the Rust volume server.
+func ResolveDevAsset(ctx context.Context, owner, repo, binary string, largeDisk bool, goArch string) (DevAsset, error) {
 	rel, err := GitHubReleaseByTag(ctx, owner, repo, DevTag)
 	if err != nil {
 		return DevAsset{}, fmt.Errorf("resolve dev release: %w", err)
 	}
-	name, buildID, ok := pickDevAsset(rel.Assets, largeDisk, goArch)
+	name, buildID, ok := pickDevAsset(rel.Assets, binary, largeDisk, goArch)
 	if !ok {
-		variant := "weed"
+		variant := binary
 		if largeDisk {
-			variant = "weed-large-disk"
+			variant = binary + "-large-disk"
 		}
 		return DevAsset{}, fmt.Errorf("no %s-*-linux-%s.tar.gz asset in the %q release", variant, goArch, DevTag)
 	}

--- a/pkg/config/dev_test.go
+++ b/pkg/config/dev_test.go
@@ -6,35 +6,51 @@ func TestPickDevAsset(t *testing.T) {
 	assets := []Asset{
 		{Name: "weed-large-disk-20260607-1918-linux-amd64.tar.gz"},
 		{Name: "weed-large-disk-20260607-1918-linux-amd64.tar.gz.md5"},
-		{Name: "weed-large-disk-20260606-1200-linux-amd64.tar.gz"}, // older
-		{Name: "weed-large-disk-20260607-1918-linux-arm64.tar.gz"}, // wrong arch
-		{Name: "weed-20260607-1918-linux-amd64.tar.gz"},            // regular variant
-		{Name: "weed-large-disk-20260607-1922-windows-amd64.zip"},  // wrong os
+		{Name: "weed-large-disk-20260606-1200-linux-amd64.tar.gz"},        // older
+		{Name: "weed-large-disk-20260607-1918-linux-arm64.tar.gz"},        // wrong arch
+		{Name: "weed-20260607-1918-linux-amd64.tar.gz"},                   // regular variant
+		{Name: "weed-large-disk-20260607-1922-windows-amd64.zip"},         // wrong os
+		{Name: "weed-volume-large-disk-20260607-1925-linux-amd64.tar.gz"}, // rust large-disk
+		{Name: "weed-volume-20260607-1925-linux-amd64.tar.gz"},            // rust regular
 	}
 
 	t.Run("large-disk picks newest amd64", func(t *testing.T) {
-		name, id, ok := pickDevAsset(assets, true, "amd64")
+		name, id, ok := pickDevAsset(assets, "weed", true, "amd64")
 		if !ok || id != "20260607-1918" || name != "weed-large-disk-20260607-1918-linux-amd64.tar.gz" {
 			t.Fatalf("got name=%q id=%q ok=%v", name, id, ok)
 		}
 	})
 
-	t.Run("regular variant excludes large-disk", func(t *testing.T) {
-		name, id, ok := pickDevAsset(assets, false, "amd64")
+	t.Run("regular variant excludes large-disk and weed-volume", func(t *testing.T) {
+		name, id, ok := pickDevAsset(assets, "weed", false, "amd64")
 		if !ok || name != "weed-20260607-1918-linux-amd64.tar.gz" || id != "20260607-1918" {
 			t.Fatalf("got name=%q id=%q ok=%v", name, id, ok)
 		}
 	})
 
+	t.Run("rust weed-volume large-disk", func(t *testing.T) {
+		name, id, ok := pickDevAsset(assets, "weed-volume", true, "amd64")
+		if !ok || id != "20260607-1925" || name != "weed-volume-large-disk-20260607-1925-linux-amd64.tar.gz" {
+			t.Fatalf("got name=%q id=%q ok=%v", name, id, ok)
+		}
+	})
+
+	t.Run("rust weed-volume regular excludes large-disk", func(t *testing.T) {
+		name, _, ok := pickDevAsset(assets, "weed-volume", false, "amd64")
+		if !ok || name != "weed-volume-20260607-1925-linux-amd64.tar.gz" {
+			t.Fatalf("got name=%q ok=%v", name, ok)
+		}
+	})
+
 	t.Run("arch respected", func(t *testing.T) {
-		name, _, ok := pickDevAsset(assets, true, "arm64")
+		name, _, ok := pickDevAsset(assets, "weed", true, "arm64")
 		if !ok || name != "weed-large-disk-20260607-1918-linux-arm64.tar.gz" {
 			t.Fatalf("got name=%q ok=%v", name, ok)
 		}
 	})
 
 	t.Run("none matches", func(t *testing.T) {
-		if _, _, ok := pickDevAsset(assets, true, "ppc64le"); ok {
+		if _, _, ok := pickDevAsset(assets, "weed", true, "ppc64le"); ok {
 			t.Fatalf("expected no match for ppc64le")
 		}
 	})
@@ -45,7 +61,7 @@ func TestPickDevAsset(t *testing.T) {
 			{Name: "weed-large-disk-20271231-2359-linux-amd64.tar.gz"},
 			{Name: "weed-large-disk-20260607-1918-linux-amd64.tar.gz"},
 		}
-		_, id, ok := pickDevAsset(shuffled, true, "amd64")
+		_, id, ok := pickDevAsset(shuffled, "weed", true, "amd64")
 		if !ok || id != "20271231-2359" {
 			t.Fatalf("got id=%q ok=%v", id, ok)
 		}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -112,33 +112,51 @@ install_dependencies() {
 
 download_and_install() {
 {{if .RustVolume}}
-  # Rust volume server: install the standalone weed-volume binary from the
-  # release. Idempotency keys on a marker storing the installed version, since
-  # weed-volume's --version scheme differs from the SeaweedFS release tag.
+  # Rust volume server: install the standalone weed-volume binary. Idempotency
+  # keys on a marker storing the installed version id, since weed-volume's
+  # --version scheme differs from the SeaweedFS release tag.
   MARKER="${BIN_DIR}/.weed-volume-version"
+{{if .RustDevAssetURL}}
+  # Rolling "dev" build: the release tag ("dev") never changes, so key on the
+  # build datestamp ({{.RustDevBuildID}}) -- a moving dev tag re-installs. The
+  # URL is resolved by the manager (the dev release datestamps each asset).
+  RUST_VERSION_ID="{{.RustDevBuildID}}"
+  RUST_ASSET="weed-volume-dev.tar.gz"
+  RUST_URL="{{.RustDevAssetURL}}"
+  RUST_MD5_URL="{{.RustDevMd5URL}}"
+{{else}}
+  OS="linux"
+  # Matches the rust release asset: the large-disk variant tarball holds a
+  # binary named weed-volume-large-disk. OSS publishes weed-volume_... from
+  # seaweedfs/seaweedfs; enterprise publishes weed-volume-enterprise_... from
+  # seaweedfs/artifactory (ReleaseOwner/ReleaseRepo already select the repo).
+  RUST_VERSION_ID="${SEAWEED_VERSION}"
+  RUST_ASSET="weed-volume{{if .Enterprise}}-enterprise{{end}}_large_disk_${OS}_${SUFFIX}.tar.gz"
+  RUST_URL="https://github.com/{{.ReleaseOwner}}/{{.ReleaseRepo}}/releases/download/${SEAWEED_VERSION}/${RUST_ASSET}"
+  RUST_MD5_URL="${RUST_URL}.md5"
+{{end}}
   curID=""
   [ -f "$MARKER" ] && curID=$(cat "$MARKER" 2>/dev/null)
-  if [ -x "${BIN_DIR}/${BINARY}" ] && [ "$curID" = "${SEAWEED_VERSION}" ]; then
-    info "weed-volume ${SEAWEED_VERSION} already installed, skipping"
+  if [ -x "${BIN_DIR}/${BINARY}" ] && [ "$curID" = "${RUST_VERSION_ID}" ]; then
+    info "weed-volume ${RUST_VERSION_ID} already installed, skipping"
   else
-    OS="linux"
-    # Matches the rust release asset: the large-disk variant tarball holds a
-    # binary named weed-volume-large-disk. OSS publishes weed-volume_... from
-    # seaweedfs/seaweedfs; enterprise publishes weed-volume-enterprise_... from
-    # seaweedfs/artifactory (ReleaseOwner/ReleaseRepo already select the repo).
-    RUST_ASSET="weed-volume{{if .Enterprise}}-enterprise{{end}}_large_disk_${OS}_${SUFFIX}.tar.gz"
-    RUST_URL="https://github.com/{{.ReleaseOwner}}/{{.ReleaseRepo}}/releases/download/${SEAWEED_VERSION}/${RUST_ASSET}"
-    info "Downloading weed-volume ${SEAWEED_VERSION} (${RUST_ASSET})"
-    curl {{.ProxyConfig}} -o "$TMP_DIR/${RUST_ASSET}" -sfL "${RUST_URL}"
-    curl {{.ProxyConfig}} -o "$TMP_DIR/${RUST_ASSET}.md5" -sfL "${RUST_URL}.md5"
-    info "Verifying weed-volume ${SEAWEED_VERSION}"
-    md5Value=`cat "$TMP_DIR/${RUST_ASSET}.md5" | awk '{print $1}'`
-    ( cd "$TMP_DIR" && echo "${md5Value}  ${RUST_ASSET}" | md5sum -c )
+    info "Downloading weed-volume ${RUST_VERSION_ID} (${RUST_URL})"
+    curl {{.ProxyConfig}} --retry 3 --retry-delay 2 -o "$TMP_DIR/${RUST_ASSET}" -sfL "${RUST_URL}"
+    # Verify md5 when published. Stable releases ship a .md5; the rolling dev
+    # build currently does not, so a missing .md5 is best-effort rather than a
+    # hard failure (the download already came over HTTPS from the release).
+    if curl {{.ProxyConfig}} --retry 3 --retry-delay 2 -o "$TMP_DIR/${RUST_ASSET}.md5" -sfL "${RUST_MD5_URL}"; then
+      info "Verifying weed-volume ${RUST_VERSION_ID}"
+      md5Value=`cat "$TMP_DIR/${RUST_ASSET}.md5" | awk '{print $1}'`
+      ( cd "$TMP_DIR" && echo "${md5Value}  ${RUST_ASSET}" | md5sum -c )
+    else
+      info "No .md5 published for weed-volume ${RUST_VERSION_ID}; skipping checksum verification"
+    fi
     rustBin=`tar tzf "$TMP_DIR/${RUST_ASSET}" | grep -E '(^|/)weed-volume(-large-disk)?$' | head -1`
     if [ -z "$rustBin" ]; then fatal "no weed-volume binary in ${RUST_ASSET}"; fi
     $SUDO tar xzf "$TMP_DIR/${RUST_ASSET}" -C "$TMP_DIR"
     $SUDO install -m 0755 "$TMP_DIR/${rustBin}" "${BIN_DIR}/${BINARY}"
-    echo "${SEAWEED_VERSION}" | $SUDO tee "$MARKER" >/dev/null
+    echo "${RUST_VERSION_ID}" | $SUDO tee "$MARKER" >/dev/null
   fi
 {{else}}{{if .DevAssetURL}}
   # Rolling "dev" build path. The version string ("dev") never changes, so

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,8 +130,11 @@ download_and_install() {
   # binary named weed-volume-large-disk. OSS publishes weed-volume_... from
   # seaweedfs/seaweedfs; enterprise publishes weed-volume-enterprise_... from
   # seaweedfs/artifactory (ReleaseOwner/ReleaseRepo already select the repo).
-  RUST_VERSION_ID="${SEAWEED_VERSION}"
   RUST_ASSET="weed-volume{{if .Enterprise}}-enterprise{{end}}_large_disk_${OS}_${SUFFIX}.tar.gz"
+  # Key idempotency on version + asset name: the OSS and enterprise builds
+  # share a version but ship different binaries, so the asset name in the
+  # marker forces a reinstall when the flavor changes at the same version.
+  RUST_VERSION_ID="${SEAWEED_VERSION}:${RUST_ASSET}"
   RUST_URL="https://github.com/{{.ReleaseOwner}}/{{.ReleaseRepo}}/releases/download/${SEAWEED_VERSION}/${RUST_ASSET}"
   RUST_MD5_URL="${RUST_URL}.md5"
 {{end}}
@@ -142,17 +145,31 @@ download_and_install() {
   else
     info "Downloading weed-volume ${RUST_VERSION_ID} (${RUST_URL})"
     curl {{.ProxyConfig}} --retry 3 --retry-delay 2 -o "$TMP_DIR/${RUST_ASSET}" -sfL "${RUST_URL}"
-    # Verify md5 when published. Stable releases ship a .md5; the rolling dev
-    # build currently does not, so a missing .md5 is best-effort rather than a
-    # hard failure (the download already came over HTTPS from the release).
-    if curl {{.ProxyConfig}} --retry 3 --retry-delay 2 -o "$TMP_DIR/${RUST_ASSET}.md5" -sfL "${RUST_MD5_URL}"; then
+{{if .RustDevAssetURL}}
+    # Rolling dev assets currently publish no .md5, so verification here is
+    # best-effort -- but only a genuine 404 (the checksum truly isn't there) is
+    # a soft skip. Capture the HTTP status (no -f, so 404 still returns a code;
+    # keep -L since release URLs redirect to the CDN) and fail loudly on
+    # network/proxy errors rather than silently install an unverified binary.
+    md5Code=$(curl {{.ProxyConfig}} --retry 3 --retry-delay 2 -o "$TMP_DIR/${RUST_ASSET}.md5" -sSL -w "%{http_code}" "${RUST_MD5_URL}" || true)
+    if [ "$md5Code" = "200" ]; then
       info "Verifying weed-volume ${RUST_VERSION_ID}"
-      md5Value=`cat "$TMP_DIR/${RUST_ASSET}.md5" | awk '{print $1}'`
+      md5Value=$(awk '{print $1}' "$TMP_DIR/${RUST_ASSET}.md5")
       ( cd "$TMP_DIR" && echo "${md5Value}  ${RUST_ASSET}" | md5sum -c )
-    else
+    elif [ "$md5Code" = "404" ]; then
       info "No .md5 published for weed-volume ${RUST_VERSION_ID}; skipping checksum verification"
+    else
+      fatal "failed to fetch .md5 for weed-volume ${RUST_VERSION_ID} (HTTP ${md5Code})"
     fi
-    rustBin=`tar tzf "$TMP_DIR/${RUST_ASSET}" | grep -E '(^|/)weed-volume(-large-disk)?$' | head -1`
+{{else}}
+    # Stable releases ship a .md5, so verification is mandatory: a failed
+    # download or missing checksum must abort rather than install unverified.
+    curl {{.ProxyConfig}} --retry 3 --retry-delay 2 -o "$TMP_DIR/${RUST_ASSET}.md5" -sfL "${RUST_MD5_URL}"
+    info "Verifying weed-volume ${RUST_VERSION_ID}"
+    md5Value=$(awk '{print $1}' "$TMP_DIR/${RUST_ASSET}.md5")
+    ( cd "$TMP_DIR" && echo "${md5Value}  ${RUST_ASSET}" | md5sum -c )
+{{end}}
+    rustBin=$(tar tzf "$TMP_DIR/${RUST_ASSET}" | grep -E '(^|/)weed-volume(-large-disk)?$' | head -1)
     if [ -z "$rustBin" ]; then fatal "no weed-volume binary in ${RUST_ASSET}"; fi
     $SUDO tar xzf "$TMP_DIR/${RUST_ASSET}" -C "$TMP_DIR"
     $SUDO install -m 0755 "$TMP_DIR/${rustBin}" "${BIN_DIR}/${BINARY}"

--- a/scripts/install_render_test.go
+++ b/scripts/install_render_test.go
@@ -16,6 +16,7 @@ func renderInstall(t *testing.T, data map[string]interface{}) string {
 		"Version": "4.31", "ProxyConfig": "", "ReleaseOwner": "seaweedfs",
 		"ReleaseRepo": "seaweedfs", "AssetPrefix": "", "FullSuffix": "_full",
 		"DevAssetURL": "", "DevMd5URL": "", "DevBuildID": "",
+		"RustDevAssetURL": "", "RustDevMd5URL": "", "RustDevBuildID": "",
 		"Binary": "weed", "RustVolume": false, "Enterprise": false,
 	}
 	for k, v := range data {
@@ -74,6 +75,31 @@ func TestInstallScript_RustVolumePath(t *testing.T) {
 	}
 	if strings.Contains(out, "-logdir=") || strings.Contains(out, "${COMPONENT} -options=") {
 		t.Errorf("rust ExecStart should not use go-style flags / subcommand")
+	}
+}
+
+func TestInstallScript_RustVolumeDevPath(t *testing.T) {
+	out := renderInstall(t, map[string]interface{}{
+		"Component": "volume", "ComponentInstance": "volume0",
+		"Binary": "weed-volume", "RustVolume": true, "Version": "dev",
+		"RustDevAssetURL": "https://github.com/seaweedfs/seaweedfs/releases/download/dev/weed-volume-large-disk-20260613-0656-linux-amd64.tar.gz",
+		"RustDevMd5URL":   "https://github.com/seaweedfs/seaweedfs/releases/download/dev/weed-volume-large-disk-20260613-0656-linux-amd64.tar.gz.md5",
+		"RustDevBuildID":  "20260613-0656",
+	})
+	for _, want := range []string{
+		"BINARY=weed-volume",
+		"weed-volume-large-disk-20260613-0656-linux-amd64.tar.gz", // resolved dev asset URL
+		`RUST_VERSION_ID="20260613-0656"`,                          // keyed on dev build id, not "dev"
+		".weed-volume-version",
+		"skipping checksum verification", // best-effort md5 (dev lacks .md5)
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rust dev install script missing %q", want)
+		}
+	}
+	// must NOT construct the stable per-arch asset name with version=dev
+	if strings.Contains(out, "weed-volume_large_disk_${OS}_${SUFFIX}.tar.gz") {
+		t.Errorf("rust dev path should use the resolved dev asset, not the stable asset name")
 	}
 }
 

--- a/scripts/install_render_test.go
+++ b/scripts/install_render_test.go
@@ -63,6 +63,7 @@ func TestInstallScript_RustVolumePath(t *testing.T) {
 		"BINARY=weed-volume",
 		"weed-volume_large_disk_${OS}_${SUFFIX}.tar.gz",             // versioned per-arch release asset
 		".weed-volume-version",                                       // version marker
+		`RUST_VERSION_ID="${SEAWEED_VERSION}:${RUST_ASSET}"`,         // composite key: version + flavor
 		"ExecStart=${BIN_DIR}/${BINARY} -options=",                   // no `weed volume` subcommand / go globals
 	} {
 		if !strings.Contains(out, want) {
@@ -75,6 +76,11 @@ func TestInstallScript_RustVolumePath(t *testing.T) {
 	}
 	if strings.Contains(out, "-logdir=") || strings.Contains(out, "${COMPONENT} -options=") {
 		t.Errorf("rust ExecStart should not use go-style flags / subcommand")
+	}
+	// Stable releases ship a .md5, so checksum verification is mandatory:
+	// the best-effort skip notice must not appear on the stable path.
+	if strings.Contains(out, "skipping checksum verification") {
+		t.Errorf("stable rust path must verify md5, not skip it")
 	}
 }
 
@@ -92,6 +98,8 @@ func TestInstallScript_RustVolumeDevPath(t *testing.T) {
 		`RUST_VERSION_ID="20260613-0656"`,                          // keyed on dev build id, not "dev"
 		".weed-volume-version",
 		"skipping checksum verification", // best-effort md5 (dev lacks .md5)
+		`[ "$md5Code" = "404" ]`,         // only a genuine 404 is a soft skip
+		"failed to fetch .md5",           // other md5 errors are fatal, not silent
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("rust dev install script missing %q", want)


### PR DESCRIPTION
## Problem

`cluster upgrade --version=dev` (and `deploy --version=dev`) fails for clusters running the standalone Rust `weed-volume` binary.

The rolling **dev** release datestamps each asset independently — the Go server and the Rust volume server get *different* timestamps:

```
weed-large-disk-20260613-0653-linux-amd64.tar.gz          # Go weed
weed-volume-large-disk-20260613-0656-linux-amd64.tar.gz   # Rust weed-volume
```

`install.sh`'s rust branch only knew the **stable** per-arch asset name (`weed-volume_large_disk_${OS}_${SUFFIX}.tar.gz`). Under the `dev` tag that URL doesn't exist, so rust volume servers 404'd on download while the Go components upgraded fine.

## Fix

- **Generalize dev-asset resolution** (`pkg/config/dev.go`): `devAssetRe`/`pickDevAsset`/`ResolveDevAsset` now take a `binary` prefix (`"weed"` or `"weed-volume"`). The regex anchors on `<binary>-` so `weed-` no longer matches `weed-volume-` and vice-versa.
- **Resolve the rust asset only when needed** (`pkg/cluster/manager/deploy_dev.go`): when `Version == "dev"` and the spec has any Rust volume server, resolve `weed-volume` separately into `m.rustDevAsset`. No extra GitHub call for non-rust clusters.
- **Thread it into the template** (`manager.go`, `manager_deploy.go`, `manager_upgrade.go`): new `RustDevAssetURL` / `RustDevMd5URL` / `RustDevBuildID` template fields, populated only on the rust path.
- **install.sh rust branch** now has a dev sub-path that uses the resolved URL and keys idempotency on the rust build datestamp (the `dev` tag itself never changes). md5 verification is **best-effort**: the dev rust asset publishes no `.md5`, so it's verified when present and skipped with a notice when absent (download is already over HTTPS). Stable releases still verify the checksum as before. Download also gains `--retry 3 --retry-delay 2`.

## Tests

- `pkg/config/dev_test.go`: new `weed-volume` large-disk + regular subtests; the existing `weed` cases now assert `weed-volume` is excluded.
- `scripts/install_render_test.go`: new `TestInstallScript_RustVolumeDevPath` asserts the resolved dev URL, `RUST_VERSION_ID` keyed on the datestamp, the version marker, the best-effort md5 notice, and that the stable asset name is *not* emitted.

`go build`, `go vet`, and `go test ./...` all pass.

## Verified live

Rolling `--version=dev` upgrade of a 12-node Rust volume cluster: each volume server downloaded `weed-volume-large-disk-20260613-0656`, the on-disk binary hash changed on every node, EC shard count returned to baseline, and re-running was a no-op (`already installed, skipping` on the datestamp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Rust volume server binaries in development mode deployments and upgrades.

* **Improvements**
  * Enhanced dev asset resolution to intelligently detect and handle Rust volume server components during cluster operations.
  * Improved installation verification with more robust checksum handling for Rust binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->