### PR TITLE
feat: docker-compose-style live console for deploy/upgrade/status

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -97,6 +97,7 @@ SeaweedFS components across the target hosts using SSH.`,
 	cmd.Flags().BoolVar(&opts.Check, "check", false, "run preflight checks before deploying and abort on failure")
 	cmd.Flags().IntVar(&opts.Concurrency, "concurrency", 0, "max concurrent per-host deploys (0 = unlimited)")
 	cmd.Flags().BoolVar(&opts.Enterprise, "enterprise", false, "pull SeaweedFS binaries from the enterprise release repo (github.com/seaweedfs/artifactory) instead of the OSS repo")
+	cmd.Flags().BoolVar(&opts.Plain, "plain", false, "disable the live per-component console; use line-by-line logging")
 
 	_ = cmd.MarkFlagRequired("file")
 
@@ -147,6 +148,7 @@ Shows real-time information about cluster components including:
 	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "show detailed information")
 	cmd.Flags().StringVar(&opts.Timeout, "timeout", "30s", "timeout for status collection")
 	cmd.Flags().IntVar(&opts.Refresh, "refresh", 0, "auto-refresh interval in seconds")
+	cmd.Flags().BoolVar(&opts.Plain, "plain", false, "use the plain table instead of the compose-style status view")
 
 	return cmd
 }
@@ -197,6 +199,7 @@ This command safely upgrades cluster components with minimal downtime:
 	cmd.Flags().BoolVar(&opts.RollbackOnFailure, "rollback-on-failure", true, "reinstall previous version on a host if its post-upgrade health check fails")
 	cmd.Flags().BoolVar(&opts.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "skip TLS certificate verification for upgrade health probes")
 	cmd.Flags().BoolVar(&opts.Enterprise, "enterprise", false, "pull SeaweedFS binaries from the enterprise release repo (github.com/seaweedfs/artifactory) instead of the OSS repo")
+	cmd.Flags().BoolVar(&opts.Plain, "plain", false, "disable the live per-component console; use line-by-line logging")
 
 	_ = cmd.MarkFlagRequired("version")
 	_ = cmd.MarkFlagRequired("file")

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/health"
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/manager"
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/preflight"
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/progress"
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/scale"
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/state"
@@ -33,6 +34,7 @@ import (
 	"github.com/seaweedfs/seaweed-up/pkg/operator"
 	"github.com/seaweedfs/seaweed-up/pkg/utils"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 )
 
@@ -60,6 +62,9 @@ type ClusterDeployOptions struct {
 	// release metadata lookup to dodge the 60 req/hr anonymous rate
 	// limit on shared CI runners.
 	Enterprise bool
+	// Plain disables the live docker-compose-style console and falls back to
+	// line-by-line logging (also the automatic behavior when stdout isn't a TTY).
+	Plain bool
 }
 
 type ClusterStatusOptions struct {
@@ -68,6 +73,8 @@ type ClusterStatusOptions struct {
 	Verbose    bool
 	Timeout    string
 	Refresh    int
+	// Plain forces the tabwriter table instead of the compose-style status view.
+	Plain bool
 }
 
 type ClusterUpgradeOptions struct {
@@ -83,6 +90,8 @@ type ClusterUpgradeOptions struct {
 	// Enterprise pulls target binaries from the public SeaweedFS
 	// enterprise release repo (github.com/seaweedfs/artifactory).
 	Enterprise bool
+	// Plain disables the live console (see ClusterDeployOptions.Plain).
+	Plain bool
 }
 
 type ClusterScaleOutOptions struct {
@@ -142,6 +151,7 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 	mgr.ProxyUrl = opts.ProxyUrl
 	mgr.Concurrency = opts.Concurrency
 	mgr.Enterprise = opts.Enterprise
+	mgr.Reporter = progress.New(os.Stdout, opts.Plain)
 
 	// If `cluster plan -o` left a deploy-disks.json sidecar alongside
 	// cluster.yaml, feed its allowlist into the manager so
@@ -425,10 +435,75 @@ func displayClusterStatus(ctx context.Context, clusterSpec *spec.Specification, 
 		return ch, nil
 	}
 
-	if err := renderStatusTable(clusterSpec, ch, opts.Verbose); err != nil {
+	// Compose-style one-line-per-component view on a TTY; fall back to the
+	// plain tabwriter table when piped, in CI, or with --plain.
+	if opts.Plain || !stdoutIsTTY() {
+		if err := renderStatusTable(clusterSpec, ch, opts.Verbose); err != nil {
+			return ch, err
+		}
+		return ch, nil
+	}
+	if err := renderStatusCompose(clusterSpec, ch, opts.Verbose, os.Stdout); err != nil {
 		return ch, err
 	}
 	return ch, nil
+}
+
+// stdoutIsTTY reports whether stdout is an interactive terminal.
+func stdoutIsTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// renderStatusCompose prints one colored line per probed component
+// (● green healthy / red unhealthy), aligned into fixed columns. It mirrors
+// renderStatusTable's information but in the docker-compose-style layout.
+func renderStatusCompose(s *spec.Specification, ch *health.ClusterHealth, verbose bool, w io.Writer) error {
+	name := s.Name
+	if name == "" {
+		name = "(unnamed)"
+	}
+	color.Green("Cluster Status: %s", name)
+
+	green := color.New(color.FgGreen).SprintFunc()
+	red := color.New(color.FgRed).SprintFunc()
+
+	fmt.Fprintf(w, "  %-8s %-24s %-5s %-14s %s\n", "KIND", "ADDRESS", "STATE", "VERSION", "DETAIL")
+	row := func(r health.ProbeResult) {
+		dot, stateStr := green("●"), "OK"
+		if !r.Healthy {
+			dot, stateStr = red("●"), "DOWN"
+		}
+		detail := r.Err
+		if verbose && r.Raw != nil {
+			if b, err := json.Marshal(r.Raw); err == nil {
+				if detail != "" {
+					detail += " | " + string(b)
+				} else {
+					detail = string(b)
+				}
+			}
+		}
+		if detail == "" {
+			detail = "-"
+		}
+		fmt.Fprintf(w, "%s %-8s %-24s %-5s %-14s %s\n", dot, r.Kind, r.Address, stateStr, orDash(r.Version), detail)
+	}
+	for _, r := range ch.Masters {
+		row(r)
+	}
+	for _, r := range ch.Volumes {
+		row(r)
+	}
+	for _, r := range ch.Filers {
+		row(r)
+	}
+
+	if !ch.AllHealthy() {
+		color.Red("Cluster is UNHEALTHY")
+	} else {
+		color.Green("Cluster is healthy")
+	}
+	return nil
 }
 
 func renderStatusTable(s *spec.Specification, ch *health.ClusterHealth, verbose bool) error {
@@ -523,6 +598,7 @@ func runClusterUpgrade(clusterName string, opts *ClusterUpgradeOptions) error {
 		mgr.SshPort = 22
 	}
 	mgr.Enterprise = opts.Enterprise
+	mgr.Reporter = progress.New(os.Stdout, opts.Plain)
 
 	if opts.User == "" {
 		currentUser, err := utils.CurrentUser()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/seaweedfs/seaweed-up
 go 1.26.0
 
 require (
-	github.com/alexellis/go-execute v0.6.0
 	github.com/bramvdbogaerde/go-scp v1.6.0
 	github.com/fatih/color v1.19.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/alexellis/go-execute v0.6.0 h1:FVGoudJnWSObwf9qmehbvVuvhK6g1UpKOCBjS+OUXEA=
-github.com/alexellis/go-execute v0.6.0/go.mod h1:nlg2F6XdYydUm1xXQMMiuibQCV1mveybBkNWfdNznjk=
 github.com/bramvdbogaerde/go-scp v1.6.0 h1:lDh0lUuz1dbIhJqlKLwWT7tzIRONCp1Mtx3pgQVaLQo=
 github.com/bramvdbogaerde/go-scp v1.6.0/go.mod h1:on2aH5AxaFb2G0N5Vsdy6B0Ml7k9HuHSwfo1y0QzAbQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/pkg/cluster/manager/deploy_dev.go
+++ b/pkg/cluster/manager/deploy_dev.go
@@ -48,7 +48,7 @@ func (m *Manager) resolveDevAsset(version string, specification *spec.Specificat
 	if err != nil {
 		return err
 	}
-	info(fmt.Sprintf("Resolved dev build %s -> %s", asset.BuildID, asset.DownloadURL))
+	m.info(fmt.Sprintf("Resolved dev build %s -> %s", asset.BuildID, asset.DownloadURL))
 	m.devAsset = &asset
 
 	// The Rust volume binary ships as a separate weed-volume-large-disk-*
@@ -58,7 +58,7 @@ func (m *Manager) resolveDevAsset(version string, specification *spec.Specificat
 		if err != nil {
 			return err
 		}
-		info(fmt.Sprintf("Resolved rust dev build %s -> %s", rustAsset.BuildID, rustAsset.DownloadURL))
+		m.info(fmt.Sprintf("Resolved rust dev build %s -> %s", rustAsset.BuildID, rustAsset.DownloadURL))
 		m.rustDevAsset = &rustAsset
 	} else {
 		m.rustDevAsset = nil

--- a/pkg/cluster/manager/deploy_envoy_server.go
+++ b/pkg/cluster/manager/deploy_envoy_server.go
@@ -61,7 +61,7 @@ func (m *Manager) DeployEnvoyServer(filerSpecs []*spec.FilerServerSpec, envoySpe
 }
 
 func (m *Manager) deployEnvoyInstance(op operator.CommandOperator, component string, componentInstance string, envoySpec *spec.EnvoyServerSpec, buf *bytes.Buffer) error {
-	info("Deploying " + componentInstance + "...")
+	m.info("Deploying " + componentInstance + "...")
 
 	dir := "/tmp/seaweed-up." + randstr.String(6)
 
@@ -107,12 +107,12 @@ func (m *Manager) deployEnvoyInstance(op operator.CommandOperator, component str
 		return fmt.Errorf("error received during upload %s.yaml: %s", component, err)
 	}
 
-	info("Installing " + componentInstance + "...")
+	m.info("Installing " + componentInstance + "...")
 	err = op.Execute(fmt.Sprintf("cat %s/install_%s.sh | SUDO_PASS=\"%s\" sh -\n", dir, componentInstance, m.sudoPass))
 	if err != nil {
 		return fmt.Errorf("error received during installation: %s", err)
 	}
 
-	info("Done.")
+	m.info("Done.")
 	return nil
 }

--- a/pkg/cluster/manager/deploy_monitoring.go
+++ b/pkg/cluster/manager/deploy_monitoring.go
@@ -71,7 +71,7 @@ func (m *Manager) DeployMonitoring(s *spec.Specification) error {
 		for _, h := range hosts {
 			h := h
 			eg.Go(func() error {
-				info(fmt.Sprintf("Installing node_exporter on %s...", h.ip))
+				m.info(fmt.Sprintf("Installing node_exporter on %s...", h.ip))
 				addr := fmt.Sprintf("%s:%d", h.ip, h.port)
 				if err := operator.ExecuteRemote(addr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
 					return observability.InstallNodeExporter(op, m.User, m.sudoPass)
@@ -84,7 +84,7 @@ func (m *Manager) DeployMonitoring(s *spec.Specification) error {
 		if err := eg.Wait(); err != nil {
 			return err
 		}
-		info(fmt.Sprintf("node_exporter installed on %d host(s)", len(hosts)))
+		m.info(fmt.Sprintf("node_exporter installed on %d host(s)", len(hosts)))
 	}
 
 	monAddr := fmt.Sprintf("%s:%d", mon.Host, utils.NvlInt(mon.PortSsh, m.SshPort, 22))
@@ -93,7 +93,7 @@ func (m *Manager) DeployMonitoring(s *spec.Specification) error {
 	promCfg.WriteString("global:\n  scrape_interval: 15s\n  evaluation_interval: 15s\n\n")
 	promCfg.WriteString(observability.RenderPromConfig(s))
 
-	info("Installing Prometheus on " + mon.Host)
+	m.info("Installing Prometheus on " + mon.Host)
 	if err := operator.ExecuteRemote(monAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
 		return observability.InstallPrometheus(op, m.User, m.sudoPass, observability.PrometheusOptions{
 			ConfigYAML: promCfg.String(),
@@ -105,7 +105,7 @@ func (m *Manager) DeployMonitoring(s *spec.Specification) error {
 		return fmt.Errorf("install prometheus on %s: %w", mon.Host, err)
 	}
 
-	info("Installing Grafana on " + mon.Host)
+	m.info("Installing Grafana on " + mon.Host)
 	if err := operator.ExecuteRemote(monAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
 		return observability.InstallGrafana(op, m.User, m.sudoPass, observability.GrafanaOptions{
 			Bind:          mon.EffectiveBind(),
@@ -119,7 +119,7 @@ func (m *Manager) DeployMonitoring(s *spec.Specification) error {
 		return fmt.Errorf("install grafana on %s: %w", mon.Host, err)
 	}
 
-	info(fmt.Sprintf("Monitoring deployed: Grafana on %s:%d (bind %s), Prometheus :%d",
+	m.info(fmt.Sprintf("Monitoring deployed: Grafana on %s:%d (bind %s), Prometheus :%d",
 		mon.Host, mon.EffectiveGrafanaPort(), mon.EffectiveBind(), mon.EffectivePrometheusPort()))
 	return nil
 }

--- a/pkg/cluster/manager/deploy_volume_server.go
+++ b/pkg/cluster/manager/deploy_volume_server.go
@@ -349,7 +349,7 @@ func (m *Manager) prepareUnmountedDisks(op operator.CommandOperator, target stri
 	for _, k := range orderedPaths {
 		dev := disks[k]
 		if dev.FilesystemType == "" {
-			info("mkfs " + dev.Path)
+			m.info("mkfs " + dev.Path)
 			if err := m.sudo(op, fmt.Sprintf("mkfs.ext4 %s", dev.Path)); err != nil {
 				return fmt.Errorf("create file system on %s: %v", dev.Path, err)
 			}
@@ -390,13 +390,13 @@ func (m *Manager) prepareUnmountedDisks(op operator.CommandOperator, target stri
 			if err != nil {
 				return err
 			}
-			info("Installing mount_" + dev.DeviceName + ".sh")
+			m.info("Installing mount_" + dev.DeviceName + ".sh")
 			err = op.Upload(prepareScript, fmt.Sprintf("/tmp/mount_%s.sh", dev.DeviceName), "0755")
 			if err != nil {
 				return fmt.Errorf("error received during upload mount script: %s", err)
 			}
 
-			info(fmt.Sprintf("mount %s (UUID=%s) at %s", dev.DeviceName, dev.UUID, targetMountPoint))
+			m.info(fmt.Sprintf("mount %s (UUID=%s) at %s", dev.DeviceName, dev.UUID, targetMountPoint))
 			err = op.Execute(fmt.Sprintf("cat /tmp/mount_%s.sh | SUDO_PASS=%s sh -\n", dev.DeviceName, shellSingleQuote(m.sudoPass)))
 			if err != nil {
 				return fmt.Errorf("error received during mount: %s", err)

--- a/pkg/cluster/manager/host_prep.go
+++ b/pkg/cluster/manager/host_prep.go
@@ -23,7 +23,7 @@ func PrepareHostsForSpec(m *Manager, specification *spec.Specification) error {
 // sysctls, firewall rules, and time sync. It is idempotent and safe to run
 // multiple times.
 func (m *Manager) PrepareHost(op operator.CommandOperator) error {
-	info("Running host preparation (ulimits, sysctls, firewall, time sync)...")
+	m.info("Running host preparation (ulimits, sysctls, firewall, time sync)...")
 
 	dir := "/tmp/seaweed-up." + randstr.String(6)
 	defer func() { _ = op.Execute("rm -rf " + dir) }()
@@ -42,7 +42,7 @@ func (m *Manager) PrepareHost(op operator.CommandOperator) error {
 		return fmt.Errorf("run host_prep.sh: %w", err)
 	}
 
-	info("Host preparation complete.")
+	m.info("Host preparation complete.")
 	return nil
 }
 
@@ -95,7 +95,7 @@ func (m *Manager) PrepareAllHosts(specification *spec.Specification) error {
 		prepare = m.PrepareHostAddress
 	}
 	for _, h := range order {
-		info(fmt.Sprintf("Preparing host %s:%d", h.ip, h.sshPort))
+		m.info(fmt.Sprintf("Preparing host %s:%d", h.ip, h.sshPort))
 		if err := prepare(h.ip, h.sshPort); err != nil {
 			return fmt.Errorf("prepare host %s: %w", h.ip, err)
 		}

--- a/pkg/cluster/manager/manager.go
+++ b/pkg/cluster/manager/manager.go
@@ -2,9 +2,11 @@ package manager
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/progress"
 	"github.com/seaweedfs/seaweed-up/pkg/config"
 	"github.com/seaweedfs/seaweed-up/pkg/operator"
 )
@@ -49,7 +51,7 @@ func (m *Manager) ReleaseOwnerRepo() (owner, repo string) {
 
 // shellSingleQuote wraps s in single quotes so it is safe to embed in a POSIX
 // shell command. Any single quote inside s is escaped by closing the quoted
-// string, inserting an escaped quote, and reopening: ' -> '\''.
+// string, inserting an escaped quote, and reopening: ' -> '\”.
 func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
@@ -143,6 +145,17 @@ type Manager struct {
 	// prepareHostAddressFn overrides PrepareHostAddress for tests. When nil,
 	// PrepareAllHosts calls PrepareHostAddress directly.
 	prepareHostAddressFn func(ip string, sshPort int) error
+
+	// Reporter renders the per-component console. Defaults to a plain
+	// (line-by-line) reporter via NewManager so non-TTY runs and tests keep
+	// their historical output; the cmd layer swaps in a live reporter on a
+	// TTY. All component logging routes through it (see info/taskFor).
+	Reporter progress.Reporter
+	// tasks maps a component instance id ("volume3") to its progress line.
+	// DeployCluster/UpgradeCluster populate it before fanning work out, then
+	// only read it concurrently, so a plain RWMutex suffices.
+	tasksMu sync.RWMutex
+	tasks   map[string]*progress.Task
 }
 
 func NewManager() *Manager {
@@ -152,15 +165,67 @@ func NewManager() *Manager {
 		skipStart:  false,
 		Version:    "",
 		sudoPass:   "",
+		Reporter:   progress.NewPlain(os.Stdout),
 	}
 }
 
-func info(message string) {
-	fmt.Println("[INFO] " + message)
+// reporter returns the manager's console reporter, defaulting to plain so
+// directly-constructed &Manager{} values (e.g. in tests) never nil-panic.
+func (m *Manager) reporter() progress.Reporter {
+	if m.Reporter == nil {
+		m.Reporter = progress.NewPlain(os.Stdout)
+	}
+	return m.Reporter
+}
+
+// info logs a non-component message above the live block (live mode) or as a
+// plain "[INFO] …" line (plain mode). It replaces the old package-level
+// info() so that, during a live render, stray log lines can't corrupt the
+// in-place block.
+func (m *Manager) info(message string) {
+	m.reporter().Log(message)
+}
+
+// registerTasks installs the per-instance task map for the duration of a
+// deploy/upgrade so callbacks deep in the call tree can find their line.
+func (m *Manager) registerTasks(tasks map[string]*progress.Task) {
+	m.tasksMu.Lock()
+	m.tasks = tasks
+	m.tasksMu.Unlock()
+}
+
+// taskFor returns the progress task for a component instance id. When none was
+// pre-registered (direct Deploy*Server calls, tests) it returns a detached
+// task so callers never need a nil check.
+func (m *Manager) taskFor(id string) *progress.Task {
+	m.tasksMu.RLock()
+	t := m.tasks[id]
+	m.tasksMu.RUnlock()
+	if t != nil {
+		return t
+	}
+	return m.reporter().AddTask(id, id)
+}
+
+// bindTask redirects an operator's streamed command output to the component's
+// progress line, so install/disk-prep output drives that line's detail (live
+// mode) instead of scrolling to stdout. No-op for operators that don't support
+// redirection (test fakes).
+func bindTask(op operator.CommandOperator, task *progress.Task) {
+	if s, ok := op.(operator.OutputSink); ok {
+		w := task.Writer()
+		s.SetOutput(w, w)
+	}
 }
 
 func (m *Manager) sudo(op operator.CommandOperator, cmd string) error {
-	info("[execute] " + cmd)
+	// In live mode the streamed command output already drives the component
+	// line, so suppress the verbose per-command trace that would otherwise
+	// scroll above the block. Plain mode keeps the historical "[INFO]
+	// [execute] …" line.
+	if !m.reporter().Live() {
+		m.info("[execute] " + cmd)
+	}
 	// Already root: run the command directly (the box may not even have
 	// sudo installed).
 	if m.User == "root" {

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/progress"
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
 	"github.com/seaweedfs/seaweed-up/pkg/config"
 	"github.com/seaweedfs/seaweed-up/pkg/operator"
@@ -185,6 +186,63 @@ func computeVolumeTargetDemand(volumes []*spec.VolumeServerSpec) (mountpoints, s
 	return mountpoints, servers
 }
 
+// buildDeployTasks pre-registers one progress line per component instance that
+// will be deployed (honoring the --component filter), in deploy order, so the
+// full cluster shows up immediately as Pending. The task ids match the
+// "<component><index>" instance names deployComponentBinary keys on.
+func (m *Manager) buildDeployTasks(rep progress.Reporter, s *spec.Specification) map[string]*progress.Task {
+	tasks := map[string]*progress.Task{}
+	add := func(comp string, i int, ip string) {
+		id := fmt.Sprintf("%s%d", comp, i)
+		tasks[id] = rep.AddTask(id, fmt.Sprintf("%-10s %s", id, ip))
+	}
+	if m.shouldInstall("master") {
+		for i, x := range s.MasterServers {
+			add("master", i, x.Ip)
+		}
+	}
+	if m.shouldInstall("volume") {
+		for i, x := range s.VolumeServers {
+			add("volume", i, x.Ip)
+		}
+	}
+	if m.shouldInstall("filer") {
+		for i, x := range s.FilerServers {
+			add("filer", i, x.Ip)
+		}
+	}
+	if m.shouldInstall("s3") {
+		for i, x := range s.S3Servers {
+			add("s3", i, x.Ip)
+		}
+	}
+	if m.shouldInstall("sftp") {
+		for i, x := range s.SftpServers {
+			add("sftp", i, x.Ip)
+		}
+	}
+	if m.shouldInstall("admin") {
+		for i, x := range s.AdminServers {
+			add("admin", i, x.Ip)
+		}
+	}
+	if m.shouldInstall("worker") {
+		for i, x := range s.WorkerServers {
+			add("worker", i, x.Ip)
+		}
+	}
+	if m.shouldInstall("envoy") {
+		for i, x := range s.EnvoyServers {
+			add("envoy", i, x.Ip)
+		}
+	}
+	if m.shouldInstall("monitoring") && s.Monitoring != nil {
+		tasks["monitoring"] = rep.AddTask("monitoring", fmt.Sprintf("%-10s %s", "monitoring", s.Monitoring.Host))
+	}
+	m.registerTasks(tasks)
+	return tasks
+}
+
 func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	if err := validateSingleAdminServer(specification); err != nil {
 		return err
@@ -223,12 +281,30 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 		masters = append(masters, fmt.Sprintf("%s:%d", masterSpec.Ip, masterSpec.Port))
 	}
 
+	// Bring up the live console: one line per component instance, shown as
+	// Pending until each is started. In live mode, route all other streamed
+	// command output (host prep ran already; security.toml, monitoring, etc.)
+	// through the reporter so it scrolls above the block instead of corrupting
+	// the in-place display.
+	rep := m.reporter()
+	tasks := m.buildDeployTasks(rep, specification)
+	rep.Start()
+	defer rep.Stop()
+	if rep.Live() {
+		lw := progress.NewLogWriter(rep)
+		operator.SetDefaultOutput(lw, lw)
+		defer operator.SetDefaultOutput(nil, nil)
+	}
+
 	if m.shouldInstall("master") {
 		for index, masterSpec := range specification.MasterServers {
+			task := tasks[fmt.Sprintf("master%d", index)]
+			task.Start()
 			if err := m.DeployMasterServer(masters, masterSpec, index); err != nil {
-				fmt.Printf("error is %v\n", err)
+				task.Fail(err)
 				return fmt.Errorf("deploy to master server %s:%d :%v", masterSpec.Ip, masterSpec.PortSsh, err)
 			}
+			task.Done()
 		}
 	}
 
@@ -250,7 +326,6 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	recordErr := func(err error) {
 		errMu.Lock()
 		defer errMu.Unlock()
-		fmt.Printf("[ERROR] %v\n", err)
 		deployErrors = append(deployErrors, err)
 	}
 
@@ -269,9 +344,14 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 
 		for index, volumeSpec := range specification.VolumeServers {
 			eg.Go(func() error {
+				task := tasks[fmt.Sprintf("volume%d", index)]
+				task.Start()
 				if err := m.DeployVolumeServer(masters, volumeSpec, index); err != nil {
 					wrapped := fmt.Errorf("deploy volume server %s:%d: %w", volumeSpec.Ip, volumeSpec.PortSsh, err)
+					task.Fail(wrapped)
 					recordErr(wrapped)
+				} else {
+					task.Done()
 				}
 				return nil
 			})
@@ -294,15 +374,21 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 	if m.shouldInstall("filer") || m.shouldInstall("admin") {
 		if err := m.EnsureSecurityToml(specification); err != nil {
 			securityErr = err
+			rep.LogError(err)
 			recordErr(err)
 		}
 	}
 	if m.shouldInstall("filer") && securityErr == nil {
 		for index, filerSpec := range specification.FilerServers {
 			eg.Go(func() error {
+				task := tasks[fmt.Sprintf("filer%d", index)]
+				task.Start()
 				if err := m.DeployFilerServer(masters, filerSpec, index); err != nil {
 					wrapped := fmt.Errorf("deploy filer server %s:%d: %w", filerSpec.Ip, filerSpec.PortSsh, err)
+					task.Fail(wrapped)
 					recordErr(wrapped)
+				} else {
+					task.Done()
 				}
 				return nil
 			})
@@ -334,14 +420,18 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 		recordS3Err := func(err error) {
 			s3ErrMu.Lock()
 			defer s3ErrMu.Unlock()
-			fmt.Printf("[ERROR] %v\n", err)
 			s3Errors = append(s3Errors, err)
 		}
 		for index, s3Spec := range specification.S3Servers {
 			s3eg.Go(func() error {
+				task := tasks[fmt.Sprintf("s3%d", index)]
+				task.Start()
 				if err := m.DeployS3Server(s3Spec, index); err != nil {
 					wrapped := fmt.Errorf("deploy s3 server %s:%d: %w", s3Spec.Ip, s3Spec.PortSsh, err)
+					task.Fail(wrapped)
 					recordS3Err(wrapped)
+				} else {
+					task.Done()
 				}
 				return nil
 			})
@@ -360,9 +450,13 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 			return err
 		}
 		for index, sftpSpec := range specification.SftpServers {
+			task := tasks[fmt.Sprintf("sftp%d", index)]
+			task.Start()
 			if err := m.DeploySftpServer(masters, sftpSpec, index); err != nil {
+				task.Fail(err)
 				return fmt.Errorf("deploy to sftp server %s:%d :%v", sftpSpec.Ip, sftpSpec.PortSsh, err)
 			}
+			task.Done()
 		}
 	}
 
@@ -381,14 +475,18 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 		recordAdminErr := func(err error) {
 			adminErrMu.Lock()
 			defer adminErrMu.Unlock()
-			fmt.Printf("[ERROR] %v\n", err)
 			adminErrors = append(adminErrors, err)
 		}
 		for index, adminSpec := range specification.AdminServers {
 			adminEg.Go(func() error {
+				task := tasks[fmt.Sprintf("admin%d", index)]
+				task.Start()
 				if err := m.DeployAdminServer(masters, adminSpec, index); err != nil {
 					wrapped := fmt.Errorf("deploy admin server %s:%d: %w", adminSpec.Ip, adminSpec.PortSsh, err)
+					task.Fail(wrapped)
 					recordAdminErr(wrapped)
+				} else {
+					task.Done()
 				}
 				return nil
 			})
@@ -425,14 +523,18 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 		recordWorkerErr := func(err error) {
 			workerErrMu.Lock()
 			defer workerErrMu.Unlock()
-			fmt.Printf("[ERROR] %v\n", err)
 			workerErrors = append(workerErrors, err)
 		}
 		for index, workerSpec := range specification.WorkerServers {
 			workerEg.Go(func() error {
+				task := tasks[fmt.Sprintf("worker%d", index)]
+				task.Start()
 				if err := m.DeployWorkerServer(defaultAdmins, workerSpec, index); err != nil {
 					wrapped := fmt.Errorf("deploy worker server %s:%d: %w", workerSpec.Ip, workerSpec.PortSsh, err)
+					task.Fail(wrapped)
 					recordWorkerErr(wrapped)
+				} else {
+					task.Done()
 				}
 				return nil
 			})
@@ -471,15 +573,28 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 			case envoySpec.Version == "":
 				envoySpec.Version = latestFallback
 			}
+			task := tasks[fmt.Sprintf("envoy%d", index)]
+			task.Start()
 			if err := m.DeployEnvoyServer(specification.FilerServers, envoySpec, index); err != nil {
+				task.Fail(err)
 				return fmt.Errorf("deploy to envoy server %s:%d :%v", envoySpec.Ip, envoySpec.PortSsh, err)
 			}
+			task.Done()
 		}
 	}
 
 	if m.shouldInstall("monitoring") && specification.Monitoring != nil {
+		if task := tasks["monitoring"]; task != nil {
+			task.Start()
+		}
 		if err := m.DeployMonitoring(specification); err != nil {
+			if task := tasks["monitoring"]; task != nil {
+				task.Fail(err)
+			}
 			return fmt.Errorf("deploy monitoring: %w", err)
+		}
+		if task := tasks["monitoring"]; task != nil {
+			task.Done()
 		}
 	}
 	return nil
@@ -561,7 +676,10 @@ func (m *Manager) deployComponentInstance(op operator.CommandOperator, component
 // weed-volume binary). Only the volume deploy/upgrade paths pass a non-empty
 // engine; every other component installs the Go weed binary as before.
 func (m *Manager) deployComponentBinary(op operator.CommandOperator, component string, componentInstance string, engine string, cliOptions *bytes.Buffer, extras ...extraConfigFile) error {
-	info("Deploying " + componentInstance + "...")
+	// Route this instance's streamed install output to its own progress line.
+	task := m.taskFor(componentInstance)
+	bindTask(op, task)
+	task.Detail("Deploying " + componentInstance + "...")
 
 	dir := "/tmp/seaweed-up." + randstr.String(6)
 
@@ -675,12 +793,10 @@ func (m *Manager) deployComponentBinary(op operator.CommandOperator, component s
 		}
 	}
 
-	info("Installing " + componentInstance + "...")
+	task.Detail("Installing " + componentInstance + "...")
 	err = op.Execute(fmt.Sprintf("cat %s/install_%s.sh | SUDO_PASS=%s sh -\n", dir, componentInstance, shellSingleQuote(m.sudoPass)))
 	if err != nil {
 		return fmt.Errorf("error received during installation: %s", err)
 	}
-
-	info("Done.")
 	return nil
 }

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/progress"
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
 	"github.com/seaweedfs/seaweed-up/pkg/operator"
 )
@@ -114,9 +115,9 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 	targets := buildUpgradeTargets(specification, scheme)
 
 	if opts.DryRun {
-		info(fmt.Sprintf("Dry-run: rolling upgrade plan to version %q (previous=%q)", targetVersion, previousVersion))
+		m.info(fmt.Sprintf("Dry-run: rolling upgrade plan to version %q (previous=%q)", targetVersion, previousVersion))
 		for _, t := range targets {
-			info(fmt.Sprintf("  would upgrade %s (%s)", t.describe, t.component))
+			m.info(fmt.Sprintf("  would upgrade %s (%s)", t.describe, t.component))
 		}
 		return nil
 	}
@@ -138,14 +139,32 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 		workerAdmins = resolved
 	}
 
-	info(fmt.Sprintf("Starting rolling upgrade to version %q (previous=%q)", targetVersion, previousVersion))
+	// Bring up the live console: one line per upgrade target, in rolling
+	// order. In live mode route incidental command output through the reporter
+	// so it scrolls above the block.
+	rep := m.reporter()
+	upTasks := map[string]*progress.Task{}
+	for _, t := range targets {
+		id := fmt.Sprintf("%s%d", t.component, t.index)
+		upTasks[id] = rep.AddTask(id, fmt.Sprintf("%-10s %s", id, t.describe))
+	}
+	m.registerTasks(upTasks)
+	rep.Start()
+	defer rep.Stop()
+	if rep.Live() {
+		lw := progress.NewLogWriter(rep)
+		operator.SetDefaultOutput(lw, lw)
+		defer operator.SetDefaultOutput(nil, nil)
+	}
+
+	m.info(fmt.Sprintf("Starting rolling upgrade to version %q (previous=%q)", targetVersion, previousVersion))
 
 	// rollbackHost reinstalls the given previous version on t, if any.
 	rollbackHost := func(t upgradeTarget, prev string, cause error) error {
 		if !opts.RollbackOnFailure || prev == "" {
 			return cause
 		}
-		info(fmt.Sprintf("Rolling back %s to version %q", t.describe, prev))
+		m.info(fmt.Sprintf("Rolling back %s to version %q", t.describe, prev))
 		m.Version = prev
 		// Clear any resolved dev asset so the rollback installs the concrete
 		// previous version through the versioned path. Without this, m.devAsset
@@ -163,7 +182,9 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 	}
 
 	for _, t := range targets {
-		info(fmt.Sprintf("Upgrading %s...", t.describe))
+		task := upTasks[fmt.Sprintf("%s%d", t.component, t.index)]
+		task.Start()
+		task.Detail("upgrading")
 
 		// Capture the version running on this host right before we touch it.
 		// Today this is homogeneous across the cluster (sourced from
@@ -174,9 +195,11 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 
 		m.Version = targetVersion
 		if err := m.upgradeOneHost(specification, masters, workerAdmins, t); err != nil {
+			task.Fail(err)
 			return rollbackHost(t, hostPrev, fmt.Errorf("upgrade %s: %w", t.describe, err))
 		}
 
+		task.Detail("waiting for healthy")
 		sshAddr := net.JoinHostPort(t.ip, strconv.Itoa(t.portSsh))
 		var healthErr error
 		if t.healthURL != "" {
@@ -187,15 +210,15 @@ func (m *Manager) UpgradeCluster(specification *spec.Specification, targetVersio
 			healthErr = m.waitForServiceActiveViaSSH(sshAddr, unit, opts.HealthTimeout, opts.HealthInterval)
 		}
 		if healthErr != nil {
-			info(fmt.Sprintf("Health check failed for %s: %v", t.describe, healthErr))
+			task.Fail(fmt.Errorf("health check failed: %w", healthErr))
 			return rollbackHost(t, hostPrev, fmt.Errorf("health check failed for %s: %w", t.describe, healthErr))
 		}
 
-		info(fmt.Sprintf("%s upgraded and healthy", t.describe))
+		task.Done()
 	}
 
 	m.Version = targetVersion
-	info(fmt.Sprintf("Rolling upgrade to %q complete", targetVersion))
+	m.info(fmt.Sprintf("Rolling upgrade to %q complete", targetVersion))
 	return nil
 }
 
@@ -351,11 +374,12 @@ func (m *Manager) upgradeOneHost(specification *spec.Specification, masters, wor
 func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 	if err := hooks.stop(); err != nil {
 		// Best-effort stop: log and continue to reinstall which will restart the unit.
-		info(fmt.Sprintf("stop %s returned: %v (continuing)", t.describe, err))
+		m.info(fmt.Sprintf("stop %s returned: %v (continuing)", t.describe, err))
 	}
 	componentInstance := fmt.Sprintf("%s%d", hooks.serviceName, t.index)
 	deploy := func() error {
 		return operator.ExecuteRemote(hooks.sshAddr, m.User, m.IdentityFile, m.sudoPass, func(op operator.CommandOperator) error {
+			bindTask(op, m.taskFor(componentInstance))
 			var buf bytes.Buffer
 			hooks.writeConfig(&buf)
 			var extras []extraConfigFile
@@ -391,7 +415,7 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 			return nil
 		}
 		if i < attempts-1 {
-			info(fmt.Sprintf("deploy %s attempt %d/%d failed: %v (retrying)", t.describe, i+1, attempts, lastErr))
+			m.info(fmt.Sprintf("deploy %s attempt %d/%d failed: %v (retrying)", t.describe, i+1, attempts, lastErr))
 		}
 	}
 	return lastErr

--- a/pkg/cluster/progress/factory.go
+++ b/pkg/cluster/progress/factory.go
@@ -1,0 +1,43 @@
+package progress
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+)
+
+// New returns a live reporter when w is a real terminal and plain is false;
+// otherwise a plain reporter. This is the single decision point: pipes, CI,
+// and --plain all fall back to the historical line-by-line output.
+func New(w *os.File, plain bool) Reporter {
+	if plain || !term.IsTerminal(int(w.Fd())) {
+		return NewPlain(w)
+	}
+	lr := newLiveReporter(w)
+	lr.utf8 = detectUTF8()
+	lr.widthFn = func() int { return terminalWidth(w) }
+	lr.nowFn = time.Now
+	return lr
+}
+
+// terminalWidth returns the terminal's column count, or defaultWidth if it
+// can't be determined.
+func terminalWidth(w *os.File) int {
+	if cols, _, err := term.GetSize(int(w.Fd())); err == nil && cols > 0 {
+		return cols
+	}
+	return defaultWidth
+}
+
+// detectUTF8 reports whether the locale looks UTF-8 capable, gating the
+// braille spinner / unicode icons vs. an ASCII fallback.
+func detectUTF8() bool {
+	for _, v := range []string{os.Getenv("LC_ALL"), os.Getenv("LC_CTYPE"), os.Getenv("LANG")} {
+		if v != "" {
+			return strings.Contains(strings.ToLower(v), "utf")
+		}
+	}
+	return false
+}

--- a/pkg/cluster/progress/live.go
+++ b/pkg/cluster/progress/live.go
@@ -1,0 +1,291 @@
+package progress
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/fatih/color"
+)
+
+// liveReporter repaints a fixed block of one line per Task in place using ANSI
+// cursor control. A single goroutine owns the terminal: worker goroutines only
+// mutate their own Task (under its lock); the repaint loop reads snapshots.
+type liveReporter struct {
+	w        io.Writer
+	interval time.Duration
+	widthFn  func() int
+	nowFn    func() time.Time
+	utf8     bool
+
+	mu        sync.Mutex
+	tasks     []*Task
+	pending   []string // log lines / failure dumps to print above the block
+	prevLines int
+	frame     int
+	started   bool
+	ticker    *time.Ticker
+	done      chan struct{}
+	loopDone  chan struct{}
+	stopOnce  sync.Once
+}
+
+func newLiveReporter(w io.Writer) *liveReporter {
+	return newLiveReporterWith(w, defaultWidth, time.Now)
+}
+
+// newLiveReporterWith is the test seam: a fixed terminal width and an
+// injectable clock let the live path run deterministically under non-TTY
+// `go test`, where it would otherwise never be selected.
+func newLiveReporterWith(w io.Writer, width int, now func() time.Time) *liveReporter {
+	return &liveReporter{
+		w:        w,
+		interval: 100 * time.Millisecond,
+		widthFn:  func() int { return width },
+		nowFn:    now,
+		utf8:     true,
+		done:     make(chan struct{}),
+		loopDone: make(chan struct{}),
+	}
+}
+
+func (r *liveReporter) AddTask(id, label string) *Task {
+	t := &Task{id: id, label: label, rep: r, state: StatePending}
+	r.mu.Lock()
+	r.tasks = append(r.tasks, t)
+	r.mu.Unlock()
+	return t
+}
+
+func (r *liveReporter) Log(msg string)     { r.enqueue(msg) }
+func (r *liveReporter) LogError(err error) { r.enqueue(color.New(color.FgRed).Sprintf("%v", err)) }
+
+func (r *liveReporter) Live() bool { return true }
+
+func (r *liveReporter) enqueue(line string) {
+	r.mu.Lock()
+	r.pending = append(r.pending, line)
+	r.mu.Unlock()
+}
+
+func (r *liveReporter) Start() {
+	r.mu.Lock()
+	if r.started {
+		r.mu.Unlock()
+		return
+	}
+	r.started = true
+	r.ticker = time.NewTicker(r.interval)
+	r.mu.Unlock()
+	go r.loop()
+}
+
+func (r *liveReporter) loop() {
+	defer close(r.loopDone)
+	for {
+		select {
+		case <-r.done:
+			r.mu.Lock()
+			r.render(true)
+			r.mu.Unlock()
+			return
+		case <-r.ticker.C:
+			r.mu.Lock()
+			r.frame++
+			r.render(false)
+			r.mu.Unlock()
+		}
+	}
+}
+
+func (r *liveReporter) Stop() {
+	r.stopOnce.Do(func() {
+		r.mu.Lock()
+		started := r.started
+		r.mu.Unlock()
+		if !started {
+			// Never started (no repaint goroutine): render once synchronously.
+			r.mu.Lock()
+			r.render(true)
+			r.mu.Unlock()
+			return
+		}
+		r.ticker.Stop()
+		close(r.done)
+		<-r.loopDone // the loop performs the final render, so no concurrent paint
+	})
+}
+
+// --- reporterHooks ---
+
+func (r *liveReporter) taskDetail(t *Task, msg string) {} // ticker repaints
+
+// taskStateChanged dumps a failed task's captured output tail above the block,
+// since its scrolling output was hidden by the live line.
+func (r *liveReporter) taskStateChanged(t *Task) {
+	state, detail, _, _ := t.snapshot()
+	if state != StateFailed {
+		return
+	}
+	lines := t.tailLines()
+	r.mu.Lock()
+	r.pending = append(r.pending, color.New(color.FgRed).Sprintf("%s %s failed: %s", r.failIcon(), t.label, detail))
+	for _, ln := range lines {
+		r.pending = append(r.pending, "    "+ln)
+	}
+	r.mu.Unlock()
+}
+
+func (r *liveReporter) streamWriter(t *Task) io.Writer { return newTaskWriter(t) }
+func (r *liveReporter) clock() time.Time               { return r.nowFn() }
+
+// --- rendering ---
+
+// render paints one frame. Caller holds r.mu.
+func (r *liveReporter) render(final bool) {
+	var b strings.Builder
+	if r.prevLines > 0 {
+		fmt.Fprintf(&b, "\x1b[%dA", r.prevLines) // cursor up to top of block
+	}
+	if r.prevLines > 0 || len(r.pending) > 0 {
+		b.WriteString("\x1b[J") // clear from cursor to end of screen
+	}
+	for _, ln := range r.pending {
+		b.WriteString(ln)
+		b.WriteByte('\n')
+	}
+	r.pending = nil
+
+	width := r.widthFn()
+	if width <= 0 {
+		width = defaultWidth
+	}
+	for _, t := range r.tasks {
+		b.WriteString(r.renderLine(t, final, width))
+		b.WriteByte('\n')
+	}
+	r.prevLines = len(r.tasks)
+	io.WriteString(r.w, b.String())
+}
+
+func (r *liveReporter) renderLine(t *Task, final bool, width int) string {
+	state, detail, start, end := t.snapshot()
+	icon := r.coloredIcon(state, final)
+	elapsed := r.elapsed(state, start, end)
+
+	tail := ""
+	if elapsed != "" {
+		tail = "  " + elapsed
+	}
+	content := t.label
+	if detail != "" {
+		content = t.label + "  " + detail
+	}
+	reserved := 2 // icon + following space
+	avail := width - reserved - runeLen(tail)
+	if avail < 10 {
+		avail = 10
+	}
+	content = r.truncate(content, avail)
+	pad := width - reserved - runeLen(content) - runeLen(tail)
+	if pad < 0 {
+		pad = 0
+	}
+	return icon + " " + content + strings.Repeat(" ", pad) + tail
+}
+
+func (r *liveReporter) elapsed(state State, start, end time.Time) string {
+	if start.IsZero() {
+		return ""
+	}
+	var d time.Duration
+	if (state == StateDone || state == StateFailed) && !end.IsZero() {
+		d = end.Sub(start)
+	} else {
+		d = r.nowFn().Sub(start)
+	}
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
+}
+
+var (
+	spinnerUTF   = []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+	spinnerASCII = []rune{'|', '/', '-', '\\'}
+)
+
+func (r *liveReporter) coloredIcon(state State, final bool) string {
+	switch state {
+	case StateDone:
+		return color.New(color.FgGreen).Sprint(r.doneIcon())
+	case StateFailed:
+		return color.New(color.FgRed).Sprint(r.failIcon())
+	case StateSkipped:
+		return color.New(color.Faint).Sprint(r.skipIcon())
+	case StateRunning:
+		if final {
+			return color.New(color.FgGreen).Sprint(r.doneIcon())
+		}
+		sp := spinnerASCII
+		if r.utf8 {
+			sp = spinnerUTF
+		}
+		return color.New(color.FgCyan).Sprint(string(sp[r.frame%len(sp)]))
+	default:
+		return color.New(color.Faint).Sprint(r.pendingIcon())
+	}
+}
+
+func (r *liveReporter) doneIcon() string {
+	if r.utf8 {
+		return "✓"
+	}
+	return "+"
+}
+func (r *liveReporter) failIcon() string {
+	if r.utf8 {
+		return "✗"
+	}
+	return "x"
+}
+func (r *liveReporter) pendingIcon() string {
+	if r.utf8 {
+		return "·"
+	}
+	return "."
+}
+func (r *liveReporter) skipIcon() string { return "-" }
+
+func (r *liveReporter) truncate(s string, max int) string {
+	if runeLen(s) <= max {
+		return s
+	}
+	ell := "…"
+	if !r.utf8 {
+		ell = ".."
+	}
+	keep := max - runeLen(ell)
+	if keep < 0 {
+		keep = 0
+	}
+	out := make([]rune, 0, keep)
+	for i, rr := range s {
+		_ = i
+		if len(out) >= keep {
+			break
+		}
+		out = append(out, rr)
+	}
+	return string(out) + ell
+}
+
+func runeLen(s string) int { return utf8.RuneCountInString(s) }
+
+const defaultWidth = 100

--- a/pkg/cluster/progress/live_test.go
+++ b/pkg/cluster/progress/live_test.go
@@ -1,0 +1,108 @@
+package progress
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+
+func stripANSI(s string) string { return ansiRe.ReplaceAllString(s, "") }
+
+// fixedNow returns a clock so elapsed times are deterministic.
+func fixedNow() func() time.Time {
+	tm := time.Unix(1000, 0)
+	return func() time.Time { return tm }
+}
+
+func TestLiveFinalFrame(t *testing.T) {
+	var buf bytes.Buffer
+	r := newLiveReporterWith(&buf, 80, fixedNow())
+
+	done := r.AddTask("volume0", "volume0 10.0.0.1:8080")
+	failed := r.AddTask("master0", "master0 10.0.0.1:9333")
+	r.AddTask("filer0", "filer0 10.0.0.1:8888") // stays Pending
+
+	done.Start()
+	done.Detail("installing")
+	done.Done()
+
+	failed.Start()
+	fmt.Fprintln(failed.Writer(), "  -> Downloading weed")
+	fmt.Fprintln(failed.Writer(), "curl: (22) 404 Not Found")
+	failed.Fail(errors.New("install failed"))
+
+	// pending stays Pending (never started)
+	r.Stop() // not started → one synchronous final render
+
+	out := stripANSI(buf.String())
+
+	for _, want := range []string{
+		"volume0 10.0.0.1:8080",
+		"master0 10.0.0.1:9333",
+		"filer0 10.0.0.1:8888",
+		"✓", // done icon
+		"✗", // failed icon
+		"·", // pending icon
+		"master0 10.0.0.1:9333 failed: install failed", // failure header
+		"curl: (22) 404 Not Found",                     // dumped tail line
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("final frame missing %q\n--- frame ---\n%s", want, out)
+		}
+	}
+}
+
+func TestLiveTruncatesToWidth(t *testing.T) {
+	var buf bytes.Buffer
+	width := 40
+	r := newLiveReporterWith(&buf, width, fixedNow())
+	task := r.AddTask("volume0", "volume0")
+	task.Start()
+	task.Detail(strings.Repeat("x", 200)) // far wider than the terminal
+	r.Stop()
+
+	for _, line := range strings.Split(stripANSI(buf.String()), "\n") {
+		if strings.Contains(line, "volume0") {
+			if l := len([]rune(line)); l > width {
+				t.Errorf("line exceeds width %d: %d runes\n%q", width, l, line)
+			}
+			if !strings.Contains(line, "…") {
+				t.Errorf("over-long line should be truncated with an ellipsis: %q", line)
+			}
+		}
+	}
+}
+
+func TestLiveStartStopNoDeadlock(t *testing.T) {
+	var buf bytes.Buffer
+	r := newLiveReporterWith(&buf, 80, fixedNow())
+	r.interval = time.Millisecond // tick fast so the loop runs a few frames
+	task := r.AddTask("volume0", "volume0")
+	r.Start()
+	task.Start()
+	time.Sleep(5 * time.Millisecond)
+	task.Done()
+	r.Stop()
+	r.Stop() // idempotent
+
+	if !strings.Contains(stripANSI(buf.String()), "volume0") {
+		t.Error("expected the task to be rendered")
+	}
+}
+
+func TestLiveLogAppearsAboveBlock(t *testing.T) {
+	var buf bytes.Buffer
+	r := newLiveReporterWith(&buf, 80, fixedNow())
+	r.AddTask("volume0", "volume0")
+	r.Log("Resolved dev build 20260613")
+	r.Stop()
+	if !strings.Contains(stripANSI(buf.String()), "Resolved dev build 20260613") {
+		t.Error("Log line should be flushed into the rendered output")
+	}
+}

--- a/pkg/cluster/progress/plain.go
+++ b/pkg/cluster/progress/plain.go
@@ -1,0 +1,86 @@
+package progress
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// plainReporter reproduces the historical line-by-line output: component
+// messages and the streamed command output scroll as [INFO]/[ERROR] lines and
+// raw passthrough, with no in-place updating. Used for non-TTY stdout, the
+// --plain flag, and tests, so CI logs and log-scraping stay unchanged.
+type plainReporter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewPlain returns a plain reporter writing to w. The default reporter on a
+// freshly-constructed Manager, which is what keeps non-TTY tests green.
+func NewPlain(w io.Writer) Reporter {
+	return &plainReporter{w: w}
+}
+
+func (r *plainReporter) AddTask(id, label string) *Task {
+	return &Task{id: id, label: label, rep: r, state: StatePending}
+}
+
+func (r *plainReporter) Log(msg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	fmt.Fprintln(r.w, "[INFO] "+msg)
+}
+
+func (r *plainReporter) LogError(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	fmt.Fprintf(r.w, "[ERROR] %v\n", err)
+}
+
+func (r *plainReporter) Start()     {}
+func (r *plainReporter) Stop()      {}
+func (r *plainReporter) Live() bool { return false }
+
+// taskDetail prints the action as an [INFO] line — the old info("Deploying
+// volume3…") behavior, preserved.
+func (r *plainReporter) taskDetail(t *Task, msg string) {
+	r.Log(msg)
+}
+
+// taskStateChanged is silent except on failure: today there is no per-state
+// line, and a failure prints a single [ERROR]. (Callers must not also LogError
+// the same error, to avoid duplicates.)
+func (r *plainReporter) taskStateChanged(t *Task) {
+	state, detail, _, _ := t.snapshot()
+	if state == StateFailed {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if detail != "" {
+			fmt.Fprintf(r.w, "[ERROR] %s\n", detail)
+		} else {
+			fmt.Fprintf(r.w, "[ERROR] %s failed\n", t.label)
+		}
+	}
+}
+
+// streamWriter passes streamed command output straight through (mutex-guarded
+// so concurrent component streams don't tear mid-write), matching the old
+// raw-to-stdout behavior.
+func (r *plainReporter) streamWriter(t *Task) io.Writer {
+	return &lockedWriter{mu: &r.mu, w: r.w}
+}
+
+func (r *plainReporter) clock() time.Time { return time.Now() }
+
+// lockedWriter serializes writes to an underlying writer.
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  io.Writer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
+}

--- a/pkg/cluster/progress/plain_test.go
+++ b/pkg/cluster/progress/plain_test.go
@@ -1,0 +1,64 @@
+package progress
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestPlainReporterOutput(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewPlain(&buf)
+	r.Start()
+
+	r.Log("Starting rolling upgrade")
+	r.LogError(errors.New("boom"))
+
+	task := r.AddTask("volume0", "volume0 10.0.0.1:8080")
+	task.Detail("Deploying volume0...") // -> [INFO] line
+	task.Start()                        // silent
+	fmt.Fprintln(task.Writer(), "  -> Downloading weed")
+	task.Done() // silent
+
+	r.Stop()
+	out := buf.String()
+
+	for _, want := range []string{
+		"[INFO] Starting rolling upgrade\n",
+		"[ERROR] boom\n",
+		"[INFO] Deploying volume0...\n",
+		"  -> Downloading weed\n", // streamed output passes through raw
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plain output missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+	// No ANSI escapes in plain mode.
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("plain output must not contain ANSI escapes:\n%q", out)
+	}
+}
+
+func TestPlainReporterFailPrintsError(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewPlain(&buf)
+	task := r.AddTask("master0", "master0 10.0.0.1:9333")
+	task.Fail(errors.New("health check failed"))
+	if got := buf.String(); !strings.Contains(got, "[ERROR] health check failed\n") {
+		t.Errorf("Fail should print the error in plain mode, got %q", got)
+	}
+}
+
+func TestPlainReporterStateTransitionsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewPlain(&buf)
+	task := r.AddTask("filer0", "filer0")
+	task.Start()
+	task.SetState(StateRunning)
+	task.Done()
+	if got := buf.String(); got != "" {
+		t.Errorf("Start/Running/Done should be silent in plain mode, got %q", got)
+	}
+}

--- a/pkg/cluster/progress/reporter.go
+++ b/pkg/cluster/progress/reporter.go
@@ -1,0 +1,156 @@
+// Package progress renders a docker-compose-style live console for cluster
+// operations: one in-place-updating line per component instance (master0,
+// volume3, …) showing a spinner, state, the latest action, and elapsed time.
+//
+// It has two implementations behind the Reporter interface:
+//   - live  — an ANSI renderer that repaints fixed lines in place (TTY only).
+//   - plain — line-by-line [INFO]/[ERROR] logging identical to the old output
+//     (used when stdout is not a TTY, when --plain is passed, and in tests).
+//
+// Construct one with New. A Reporter is safe for concurrent use: deploy fans
+// component work out across many goroutines, each owning its own Task.
+package progress
+
+import (
+	"io"
+	"sync"
+	"time"
+)
+
+// State is the lifecycle stage of a single component Task.
+type State int
+
+const (
+	StatePending State = iota // queued, not started
+	StateRunning              // in progress (animated spinner)
+	StateDone                 // finished successfully
+	StateFailed               // finished with an error
+	StateSkipped              // not selected for this run (e.g. --component filter)
+)
+
+// Reporter drives the console. One Task per component instance.
+type Reporter interface {
+	// AddTask registers a component line shown as Pending until started.
+	// id is a stable key ("volume3"); label is the display text
+	// ("volume3 10.0.0.4:8080"). Call before Start (or any time; live
+	// appends to the block).
+	AddTask(id, label string) *Task
+	// Log prints a line above the live block — non-component messages such
+	// as "Starting rolling upgrade …". Plain mode prints "[INFO] <msg>".
+	Log(msg string)
+	// LogError prints an error line above the block. Plain: "[ERROR] <err>".
+	LogError(err error)
+	// Start begins rendering (live: launches the repaint goroutine).
+	Start()
+	// Stop flushes the final frame and releases the terminal. Idempotent.
+	Stop()
+	// Live reports whether this reporter renders an in-place block. Callers
+	// use it to suppress verbose per-command tracing (which would scroll
+	// above the block) that the live detail line already conveys.
+	Live() bool
+}
+
+// reporterHooks is the private callback surface a Task uses to notify its
+// owning Reporter of changes. Live ignores most (its ticker repaints); plain
+// turns them into log lines.
+type reporterHooks interface {
+	taskDetail(t *Task, msg string) // detail already stored; decide to print
+	taskStateChanged(t *Task)       // state already stored
+	streamWriter(t *Task) io.Writer // sink for streamed command output
+	clock() time.Time
+}
+
+// Task is a handle to one component instance's line. Its mutating methods are
+// safe to call from the single goroutine that owns the task; the renderer
+// reads a snapshot under the same mutex.
+type Task struct {
+	id    string
+	label string
+	rep   reporterHooks
+
+	mu     sync.Mutex
+	state  State
+	detail string
+	start  time.Time
+	end    time.Time
+	tail   *ring // bounded recent output, dumped on failure (live only)
+}
+
+// Start marks the task running and stamps its start time.
+func (t *Task) Start() {
+	t.mu.Lock()
+	t.state = StateRunning
+	if t.start.IsZero() {
+		t.start = t.rep.clock()
+	}
+	t.mu.Unlock()
+	t.rep.taskStateChanged(t)
+}
+
+// Detail sets the short current-action string shown on the task's line.
+func (t *Task) Detail(msg string) {
+	t.mu.Lock()
+	t.detail = msg
+	t.mu.Unlock()
+	t.rep.taskDetail(t, msg)
+}
+
+// SetState changes the task state without other side effects.
+func (t *Task) SetState(s State) {
+	t.mu.Lock()
+	t.state = s
+	if s == StateRunning && t.start.IsZero() {
+		t.start = t.rep.clock()
+	}
+	if (s == StateDone || s == StateFailed) && t.end.IsZero() {
+		t.end = t.rep.clock()
+	}
+	t.mu.Unlock()
+	t.rep.taskStateChanged(t)
+}
+
+// Done marks the task finished successfully.
+func (t *Task) Done() {
+	t.mu.Lock()
+	t.state = StateDone
+	t.end = t.rep.clock()
+	t.mu.Unlock()
+	t.rep.taskStateChanged(t)
+}
+
+// Fail marks the task failed and records the error as its detail.
+func (t *Task) Fail(err error) {
+	t.mu.Lock()
+	t.state = StateFailed
+	t.end = t.rep.clock()
+	if err != nil {
+		t.detail = err.Error()
+	}
+	t.mu.Unlock()
+	t.rep.taskStateChanged(t)
+}
+
+// Writer returns an io.Writer sink for streamed command output. In live mode
+// it splits lines, surfaces the last non-empty one as the task's detail, and
+// keeps a bounded tail for the on-failure dump; in plain mode it passes
+// through to the console so output scrolls as before.
+func (t *Task) Writer() io.Writer {
+	return t.rep.streamWriter(t)
+}
+
+// snapshot copies the fields the renderer needs under the task lock.
+func (t *Task) snapshot() (state State, detail string, start, end time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.state, t.detail, t.start, t.end
+}
+
+// tailLines returns a copy of the recent-output buffer (nil if none).
+func (t *Task) tailLines() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.tail == nil {
+		return nil
+	}
+	return t.tail.lines()
+}

--- a/pkg/cluster/progress/writer.go
+++ b/pkg/cluster/progress/writer.go
@@ -1,0 +1,130 @@
+package progress
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"sync"
+)
+
+// ring is a fixed-capacity FIFO of the most recent output lines, used to dump
+// a component's tail when it fails (its scrolling output was hidden by the
+// live block).
+type ring struct {
+	buf  []string
+	max  int
+	next int
+	full bool
+}
+
+func newRing(max int) *ring {
+	if max <= 0 {
+		max = 20
+	}
+	return &ring{buf: make([]string, 0, max), max: max}
+}
+
+func (r *ring) push(line string) {
+	if len(r.buf) < r.max {
+		r.buf = append(r.buf, line)
+		return
+	}
+	r.buf[r.next] = line
+	r.next = (r.next + 1) % r.max
+	r.full = true
+}
+
+// lines returns the buffered lines in chronological order.
+func (r *ring) lines() []string {
+	if !r.full {
+		out := make([]string, len(r.buf))
+		copy(out, r.buf)
+		return out
+	}
+	out := make([]string, 0, r.max)
+	out = append(out, r.buf[r.next:]...)
+	out = append(out, r.buf[:r.next]...)
+	return out
+}
+
+// logWriter turns streamed bytes into Reporter.Log lines. It is the default
+// sink during a live render for operators that aren't bound to a specific
+// task (host prep, security.toml, monitoring): their output scrolls above the
+// block as ordinary log lines instead of corrupting the in-place display.
+type logWriter struct {
+	rep Reporter
+	mu  sync.Mutex
+	buf []byte
+}
+
+// NewLogWriter returns an io.Writer that emits each complete line it receives
+// as a Reporter.Log message.
+func NewLogWriter(rep Reporter) io.Writer { return &logWriter{rep: rep} }
+
+func (w *logWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.buf = append(w.buf, p...)
+	var lines []string
+	for {
+		i := bytes.IndexByte(w.buf, '\n')
+		if i < 0 {
+			break
+		}
+		lines = append(lines, strings.TrimRight(string(w.buf[:i]), "\r"))
+		w.buf = w.buf[i+1:]
+	}
+	w.mu.Unlock()
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			w.rep.Log(line)
+		}
+	}
+	return len(p), nil
+}
+
+// taskWriter is the live-mode sink for streamed command output. It buffers
+// partial writes, and on every complete line: trims a trailing '\r', sets the
+// task's detail to the last non-empty line, and appends to the task's tail
+// ring. Width-agnostic — truncation happens at paint time.
+type taskWriter struct {
+	task *Task
+	mu   sync.Mutex
+	buf  []byte
+}
+
+func newTaskWriter(t *Task) *taskWriter {
+	t.mu.Lock()
+	if t.tail == nil {
+		t.tail = newRing(20)
+	}
+	t.mu.Unlock()
+	return &taskWriter{task: t}
+}
+
+func (w *taskWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.buf = append(w.buf, p...)
+	var lines []string
+	for {
+		i := bytes.IndexByte(w.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := strings.TrimRight(string(w.buf[:i]), "\r")
+		w.buf = w.buf[i+1:]
+		lines = append(lines, line)
+	}
+	w.mu.Unlock()
+
+	for _, line := range lines {
+		w.task.mu.Lock()
+		if w.task.tail != nil {
+			w.task.tail.push(line)
+		}
+		w.task.mu.Unlock()
+		if s := strings.TrimSpace(line); s != "" {
+			w.task.Detail(s) // surfaces as the live line's detail
+		}
+	}
+	return len(p), nil
+}

--- a/pkg/cluster/progress/writer_test.go
+++ b/pkg/cluster/progress/writer_test.go
@@ -1,0 +1,53 @@
+package progress
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func newTestLive() *liveReporter {
+	return newLiveReporterWith(nil, 80, func() time.Time { return time.Unix(1000, 0) })
+}
+
+func TestTaskWriterLastNonEmptyLine(t *testing.T) {
+	r := newTestLive()
+	task := r.AddTask("volume0", "volume0")
+	w := task.Writer()
+
+	// Partial write (no newline yet) → detail unchanged.
+	fmt.Fprint(w, "down")
+	if _, d, _, _ := task.snapshot(); d != "" {
+		t.Errorf("partial line should not set detail, got %q", d)
+	}
+	// Complete the line plus a blank line; detail is the last NON-empty line.
+	fmt.Fprint(w, "loading\n\n")
+	if _, d, _, _ := task.snapshot(); d != "downloading" {
+		t.Errorf("detail = %q, want %q", d, "downloading")
+	}
+	// CRLF is trimmed.
+	fmt.Fprint(w, "verifying\r\n")
+	if _, d, _, _ := task.snapshot(); d != "verifying" {
+		t.Errorf("detail = %q, want %q (CRLF not trimmed?)", d, "verifying")
+	}
+}
+
+func TestTaskWriterTailRingBufferCap(t *testing.T) {
+	r := newTestLive()
+	task := r.AddTask("volume0", "volume0")
+	w := task.Writer()
+	for i := 0; i < 50; i++ {
+		fmt.Fprintf(w, "line %d\n", i)
+	}
+	lines := task.tailLines()
+	if len(lines) != 20 {
+		t.Fatalf("tail kept %d lines, want cap 20", len(lines))
+	}
+	// Oldest dropped, newest retained, in chronological order.
+	if lines[0] != "line 30" {
+		t.Errorf("tail[0] = %q, want %q", lines[0], "line 30")
+	}
+	if lines[19] != "line 49" {
+		t.Errorf("tail[19] = %q, want %q", lines[19], "line 49")
+	}
+}

--- a/pkg/operator/local.go
+++ b/pkg/operator/local.go
@@ -3,39 +3,53 @@ package operator
 import (
 	"io"
 	"os"
+	"os/exec"
 	"strconv"
-
-	goexecute "github.com/alexellis/go-execute/pkg/v1"
 )
 
 type LocalOperator struct {
+	// stdout/stderr redirect command output when non-nil (set via
+	// SetOutput); nil falls back to os.Stdout/os.Stderr.
+	stdout io.Writer
+	stderr io.Writer
 }
 
 func NewLocalOperator() *LocalOperator {
 	return &LocalOperator{}
 }
 
-func (e LocalOperator) Output(command string) ([]byte, error) {
+// SetOutput implements OutputSink: command output is streamed to the given
+// writers instead of os.Stdout/os.Stderr. Passing nil resets to os.Std*.
+func (e *LocalOperator) SetOutput(stdout, stderr io.Writer) {
+	e.stdout = stdout
+	e.stderr = stderr
+}
+
+func (e *LocalOperator) Output(command string) ([]byte, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (e LocalOperator) Execute(command string) error {
-	task := goexecute.ExecTask{
-		Command:     command,
-		Shell:       true,
-		StreamStdio: true,
+// Execute runs command through bash, streaming stdout/stderr live to the
+// configured sink (default os.Stdout/os.Stderr). Replaces go-execute's
+// StreamStdio, which hardcodes os.Stdout and so can't be redirected into the
+// live progress console.
+func (e *LocalOperator) Execute(command string) error {
+	cmd := exec.Command("/bin/bash", "-c", command)
+	if e.stdout != nil {
+		cmd.Stdout = e.stdout
+	} else {
+		cmd.Stdout = os.Stdout
 	}
-
-	_, err := task.Execute()
-	if err != nil {
-		return err
+	if e.stderr != nil {
+		cmd.Stderr = e.stderr
+	} else {
+		cmd.Stderr = os.Stderr
 	}
-
-	return nil
+	return cmd.Run()
 }
 
-func (e LocalOperator) UploadFile(path string, remotePath string, mode string) error {
+func (e *LocalOperator) UploadFile(path string, remotePath string, mode string) error {
 	source, err := os.Open(expandPath(path))
 	if err != nil {
 		return err
@@ -45,7 +59,7 @@ func (e LocalOperator) UploadFile(path string, remotePath string, mode string) e
 	return e.Upload(source, remotePath, mode)
 }
 
-func (e LocalOperator) Upload(source io.Reader, remotePath string, mode string) error {
+func (e *LocalOperator) Upload(source io.Reader, remotePath string, mode string) error {
 	permissions, err := strconv.ParseInt(mode, 8, 32)
 	if err != nil {
 		return err

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -30,7 +30,53 @@ type CommandOperator interface {
 	UploadFile(path string, remotePath string, mode string) error
 }
 
+// OutputSink is an optional capability: an operator implementing it streams
+// command stdout/stderr to the supplied writers instead of the process
+// os.Stdout/os.Stderr. The live progress console needs exclusive control of
+// the real stdout, so it redirects each component's streamed output into a
+// per-task sink. It is intentionally NOT part of CommandOperator so the many
+// hand-rolled test fakes keep compiling — callers type-assert and only call
+// SetOutput when the operator supports it.
+type OutputSink interface {
+	// SetOutput redirects streamed command output. A nil writer resets that
+	// stream to its os.Std* default.
+	SetOutput(stdout, stderr io.Writer)
+}
+
 type Callback func(CommandOperator) error
+
+// Default streamed-output destination. Every operator created by
+// ExecuteRemote/ExecuteLocal inherits these writers, so a process can route
+// all command output (e.g. into a live progress console) by setting them once
+// before a batch of operations instead of threading a writer through every
+// call site. A callback may still override per-operator via OutputSink.
+var (
+	defaultOutMu  sync.RWMutex
+	defaultStdout io.Writer = os.Stdout
+	defaultStderr io.Writer = os.Stderr
+)
+
+// SetDefaultOutput sets the stdout/stderr writers newly created operators
+// stream to. A nil writer resets that stream to its os.Std* default. Set it
+// before a batch of operations and restore (nil) afterwards; it is read when
+// each operator is created.
+func SetDefaultOutput(stdout, stderr io.Writer) {
+	defaultOutMu.Lock()
+	defer defaultOutMu.Unlock()
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	defaultStdout, defaultStderr = stdout, stderr
+}
+
+func currentDefaultOutput() (io.Writer, io.Writer) {
+	defaultOutMu.RLock()
+	defer defaultOutMu.RUnlock()
+	return defaultStdout, defaultStderr
+}
 
 // BastionConfig describes an SSH jump host. When one is installed via
 // SetBastion, every ExecuteRemote connection is dialed *through* the
@@ -156,7 +202,9 @@ func closeBastionLocked() {
 }
 
 func ExecuteLocal(callback Callback) error {
-	return callback(NewLocalOperator())
+	op := NewLocalOperator()
+	op.SetOutput(currentDefaultOutput())
+	return callback(op)
 }
 
 func ExecuteRemote(host string, user string, privateKey string, password string, callback Callback) error {
@@ -295,6 +343,7 @@ func executeRemote(address string, user string, authMethod ssh.AuthMethod, callb
 
 	defer operator.Close()
 
+	operator.SetOutput(currentDefaultOutput())
 	return callback(operator)
 }
 

--- a/pkg/operator/setoutput_test.go
+++ b/pkg/operator/setoutput_test.go
@@ -1,0 +1,81 @@
+package operator
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// LocalOperator must satisfy the optional OutputSink interface so the live
+// progress console can redirect its streamed output.
+func TestLocalOperatorImplementsOutputSink(t *testing.T) {
+	var op CommandOperator = NewLocalOperator()
+	if _, ok := op.(OutputSink); !ok {
+		t.Fatal("NewLocalOperator() should implement OutputSink")
+	}
+}
+
+// A bare fake that only implements CommandOperator must NOT be an OutputSink,
+// documenting the optional-interface contract that keeps test fakes working.
+type bareOp struct{}
+
+func (bareOp) Execute(string) error                    { return nil }
+func (bareOp) Output(string) ([]byte, error)           { return nil, nil }
+func (bareOp) Upload(io.Reader, string, string) error  { return nil }
+func (bareOp) UploadFile(string, string, string) error { return nil }
+
+func TestBareFakeIsNotOutputSink(t *testing.T) {
+	var op CommandOperator = bareOp{}
+	if _, ok := op.(OutputSink); ok {
+		t.Fatal("a fake without SetOutput must not satisfy OutputSink")
+	}
+}
+
+func TestLocalOperatorSetOutputRedirects(t *testing.T) {
+	op := NewLocalOperator()
+	var out, errb bytes.Buffer
+	op.SetOutput(&out, &errb)
+
+	if err := op.Execute("echo hi; echo oops 1>&2"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "hi" {
+		t.Errorf("stdout: got %q, want %q", got, "hi")
+	}
+	if got := strings.TrimSpace(errb.String()); got != "oops" {
+		t.Errorf("stderr: got %q, want %q", got, "oops")
+	}
+}
+
+// Passing nil resets the sink back to the os.Std* defaults.
+func TestLocalOperatorSetOutputNilResets(t *testing.T) {
+	op := NewLocalOperator()
+	op.SetOutput(&bytes.Buffer{}, &bytes.Buffer{})
+	op.SetOutput(nil, nil)
+	if op.stdout != nil || op.stderr != nil {
+		t.Fatal("SetOutput(nil,nil) should clear the writers")
+	}
+	// Execute must still succeed writing to the default os.Stdout.
+	if err := op.Execute("true"); err != nil {
+		t.Fatalf("Execute after reset: %v", err)
+	}
+	_ = os.Stdout
+}
+
+// White-box: the SSH operator's outW/errW fall back to os.Std* when unset.
+func TestSSHOperatorOutputFallback(t *testing.T) {
+	s := &SSHOperator{}
+	if s.outW() != os.Stdout {
+		t.Error("outW() should default to os.Stdout")
+	}
+	if s.errW() != os.Stderr {
+		t.Error("errW() should default to os.Stderr")
+	}
+	var buf bytes.Buffer
+	s.SetOutput(&buf, &buf)
+	if s.outW() != &buf || s.errW() != &buf {
+		t.Error("SetOutput should redirect outW/errW")
+	}
+}

--- a/pkg/operator/ssh.go
+++ b/pkg/operator/ssh.go
@@ -16,6 +16,32 @@ type SSHOperator struct {
 	// chain — target client, bastion client, and any ssh-agent socket.
 	// When nil (direct connections) Close just closes conn.
 	cleanup func() error
+	// stdout/stderr redirect streamed command output when non-nil (set via
+	// SetOutput); nil falls back to os.Stdout/os.Stderr. One operator is
+	// owned by one goroutine, so these need no locking.
+	stdout io.Writer
+	stderr io.Writer
+}
+
+// SetOutput implements OutputSink: streamed Execute output (and Output's
+// stderr) is redirected to the given writers. Passing nil resets to os.Std*.
+func (s *SSHOperator) SetOutput(stdout, stderr io.Writer) {
+	s.stdout = stdout
+	s.stderr = stderr
+}
+
+func (s *SSHOperator) outW() io.Writer {
+	if s.stdout != nil {
+		return s.stdout
+	}
+	return os.Stdout
+}
+
+func (s *SSHOperator) errW() io.Writer {
+	if s.stderr != nil {
+		return s.stderr
+	}
+	return os.Stderr
 }
 
 func NewSSHOperator(address string, config *ssh.ClientConfig) (*SSHOperator, error) {
@@ -77,14 +103,14 @@ func newSSHOperatorViaBastion(b *BastionConfig, targetAddr string, config *ssh.C
 	return nil, lastErr
 }
 
-func (s SSHOperator) Close() error {
+func (s *SSHOperator) Close() error {
 	if s.cleanup != nil {
 		return s.cleanup()
 	}
 	return s.conn.Close()
 }
 
-func (s SSHOperator) Output(command string) (output []byte, err error) {
+func (s *SSHOperator) Output(command string) (output []byte, err error) {
 	sess, err := s.conn.NewSession()
 	if err != nil {
 		return nil, err
@@ -92,13 +118,15 @@ func (s SSHOperator) Output(command string) (output []byte, err error) {
 
 	defer sess.Close()
 
-	sess.Stderr = os.Stderr
+	// Only stderr is redirected; stdout is returned to the caller (upgrade
+	// health/version probes parse it), so it must not go to the sink.
+	sess.Stderr = s.errW()
 	output, err = sess.Output(command)
 
 	return output, err
 }
 
-func (s SSHOperator) Execute(command string) error {
+func (s *SSHOperator) Execute(command string) error {
 	sess, err := s.conn.NewSession()
 	if err != nil {
 		return err
@@ -106,19 +134,19 @@ func (s SSHOperator) Execute(command string) error {
 
 	defer sess.Close()
 
-	sess.Stdout = os.Stdout
-	sess.Stderr = os.Stderr
+	sess.Stdout = s.outW()
+	sess.Stderr = s.errW()
 	err = sess.Run(command)
 
 	return err
 }
 
-func (s SSHOperator) Upload(source io.Reader, remotePath string, mode string) error {
+func (s *SSHOperator) Upload(source io.Reader, remotePath string, mode string) error {
 	client, _ := scp.NewClientBySSH(s.conn)
 	return client.CopyFile(context.Background(), source, remotePath, mode)
 }
 
-func (s SSHOperator) UploadFile(path string, remotePath string, mode string) error {
+func (s *SSHOperator) UploadFile(path string, remotePath string, mode string) error {
 	source, err := os.Open(expandPath(path))
 	if err != nil {
 		return err


### PR DESCRIPTION
## What

Replaces the interleaved scrolling `[INFO]` lines + streamed SSH output during `cluster deploy`, `cluster upgrade`, and `cluster status` with a **docker-compose-style live console**: one in-place-updating line per component instance.

```
✓ master0    10.0.0.1
✓ master1    10.0.0.2
✓ volume0    10.0.0.1
⠋ volume1    10.0.0.2  -> Downloading weed-volume 20260613-0656              3.1s
⠋ volume2    10.0.0.3  -> Verifying checksum                                 2.8s
⠋ filer0     10.0.0.1  Installing filer0...                                  1.2s
· s30        10.0.0.4
```

Each line shows a spinner/state icon (`⠋` running, `✓` done, `✗` failed, `·` pending), the instance label, its latest action, and elapsed time. The full cluster shows up front as Pending.

**Fallback is automatic and exact:** when stdout is not a TTY (CI, pipes) or `--plain` is passed, it reverts to the previous line-by-line `[INFO]`/`[ERROR]` output, so logs and tests are unchanged.

## How

**`pkg/cluster/progress` (new package)** — `Reporter` interface with two implementations:
- `plain` — byte-compatible line-by-line logging (the default in `NewManager`, which keeps every existing test green).
- `live` — a single mutex-guarded repaint goroutine owns the terminal; worker goroutines only mutate their own `Task`. Each `Task` has a line-splitting `Writer()` that surfaces the last output line as the live detail and keeps a bounded ring buffer, **dumped above the block on failure** so a failed component's hidden output isn't lost.

**Operator output redirection (the crux)** — `SSHOperator`/`LocalOperator` streamed straight to `os.Stdout`, which fights an in-place renderer:
- New **optional** `OutputSink` interface (deliberately *not* added to `CommandOperator`, so the hand-rolled test fakes keep compiling); both operators gain `SetOutput`. `LocalOperator.Execute` now drives `os/exec` directly because go-execute hardcodes `os.Stdout` (go-execute dropped from go.mod).
- A package-level **default output** every new operator inherits, so the manager routes all incidental command output (host prep, `security.toml`, monitoring) through the reporter during a live render instead of corrupting the block.

**Manager wiring** — `info()` is now a `*Manager` method routing through the reporter; the five `[ERROR]` printfs and the per-component "Deploying/Installing" messages become `Task` state/detail updates; `sudo()` suppresses its verbose `[execute]` trace in live mode. `DeployCluster`/`UpgradeCluster` pre-register a `Task` per instance, bind each operator's sink to its line, and mark `Start`/`Done`/`Fail` per phase.

**cmd** — `--plain` on all three commands; `status` gains a compose-style `● green/red` one-line-per-component view, with the tabwriter table kept for `--plain` / non-TTY / `--json`.

## Tests

- `pkg/cluster/progress`: plain output assertions (exact `[INFO]`/`[ERROR]`, silent state transitions), live final-frame snapshot via an injected writer + fixed width/clock (labels, icons, truncation, failure-tail dump), writer line-splitting + ring-buffer cap. Run under `-race`.
- `pkg/operator`: `SetOutput` redirect on the real local-exec path; the optional-interface contract (`NewLocalOperator` is an `OutputSink`, a bare fake is not); `outW/errW` nil-fallback.
- Full suite (`go build`, `go vet`, `go test ./...`) green; the default plain reporter keeps non-TTY tests byte-compatible.

## Notes

No new dependencies (uses the already-present `golang.org/x/term` and `fatih/color`). Built in internally-safe phases (operator sink → progress package → deploy → upgrade → cmd/status); each compiles and tests green on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--plain` flag to `cluster deploy`, `cluster status`, and `cluster upgrade` commands to disable live progress rendering and use line-by-line logging instead.
  * Implemented live progress reporter for real-time, in-place updating of component deployment and upgrade status in terminal environments.

* **Improvements**
  * Improved operator output handling to support configurable stdout/stderr routing for better integration with progress reporting.

* **Chores**
  * Removed unused external dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->