### PR TITLE
fix: handle write returns in progress console (errcheck/gosec)

### DIFF
--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -467,7 +467,7 @@ func renderStatusCompose(s *spec.Specification, ch *health.ClusterHealth, verbos
 	green := color.New(color.FgGreen).SprintFunc()
 	red := color.New(color.FgRed).SprintFunc()
 
-	fmt.Fprintf(w, "  %-8s %-24s %-5s %-14s %s\n", "KIND", "ADDRESS", "STATE", "VERSION", "DETAIL")
+	_, _ = fmt.Fprintf(w, "  %-8s %-24s %-5s %-14s %s\n", "KIND", "ADDRESS", "STATE", "VERSION", "DETAIL")
 	row := func(r health.ProbeResult) {
 		dot, stateStr := green("●"), "OK"
 		if !r.Healthy {
@@ -486,7 +486,7 @@ func renderStatusCompose(s *spec.Specification, ch *health.ClusterHealth, verbos
 		if detail == "" {
 			detail = "-"
 		}
-		fmt.Fprintf(w, "%s %-8s %-24s %-5s %-14s %s\n", dot, r.Kind, r.Address, stateStr, orDash(r.Version), detail)
+		_, _ = fmt.Fprintf(w, "%s %-8s %-24s %-5s %-14s %s\n", dot, r.Kind, r.Address, stateStr, orDash(r.Version), detail)
 	}
 	for _, r := range ch.Masters {
 		row(r)

--- a/pkg/cluster/progress/live.go
+++ b/pkg/cluster/progress/live.go
@@ -168,7 +168,7 @@ func (r *liveReporter) render(final bool) {
 		b.WriteByte('\n')
 	}
 	r.prevLines = len(r.tasks)
-	io.WriteString(r.w, b.String())
+	_, _ = io.WriteString(r.w, b.String())
 }
 
 func (r *liveReporter) renderLine(t *Task, final bool, width int) string {

--- a/pkg/cluster/progress/live.go
+++ b/pkg/cluster/progress/live.go
@@ -1,6 +1,7 @@
 package progress
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -146,7 +147,7 @@ func (r *liveReporter) clock() time.Time               { return r.nowFn() }
 
 // render paints one frame. Caller holds r.mu.
 func (r *liveReporter) render(final bool) {
-	var b strings.Builder
+	var b bytes.Buffer
 	if r.prevLines > 0 {
 		fmt.Fprintf(&b, "\x1b[%dA", r.prevLines) // cursor up to top of block
 	}
@@ -168,7 +169,7 @@ func (r *liveReporter) render(final bool) {
 		b.WriteByte('\n')
 	}
 	r.prevLines = len(r.tasks)
-	_, _ = io.WriteString(r.w, b.String())
+	_, _ = b.WriteTo(r.w) // writes the buffered bytes directly, no string copy
 }
 
 func (r *liveReporter) renderLine(t *Task, final bool, width int) string {

--- a/pkg/cluster/progress/plain.go
+++ b/pkg/cluster/progress/plain.go
@@ -29,13 +29,13 @@ func (r *plainReporter) AddTask(id, label string) *Task {
 func (r *plainReporter) Log(msg string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	fmt.Fprintln(r.w, "[INFO] "+msg)
+	_, _ = fmt.Fprintln(r.w, "[INFO] "+msg)
 }
 
 func (r *plainReporter) LogError(err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	fmt.Fprintf(r.w, "[ERROR] %v\n", err)
+	_, _ = fmt.Fprintf(r.w, "[ERROR] %v\n", err)
 }
 
 func (r *plainReporter) Start()     {}
@@ -57,9 +57,9 @@ func (r *plainReporter) taskStateChanged(t *Task) {
 		r.mu.Lock()
 		defer r.mu.Unlock()
 		if detail != "" {
-			fmt.Fprintf(r.w, "[ERROR] %s\n", detail)
+			_, _ = fmt.Fprintf(r.w, "[ERROR] %s\n", detail)
 		} else {
-			fmt.Fprintf(r.w, "[ERROR] %s failed\n", t.label)
+			_, _ = fmt.Fprintf(r.w, "[ERROR] %s failed\n", t.label)
 		}
 	}
 }

--- a/pkg/cluster/progress/plain.go
+++ b/pkg/cluster/progress/plain.go
@@ -29,7 +29,7 @@ func (r *plainReporter) AddTask(id, label string) *Task {
 func (r *plainReporter) Log(msg string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	_, _ = fmt.Fprintln(r.w, "[INFO] "+msg)
+	_, _ = fmt.Fprintln(r.w, "[INFO]", msg)
 }
 
 func (r *plainReporter) LogError(err error) {


### PR DESCRIPTION
## What

The docker-compose console (#99) merged with two failing CI jobs — **Lint (errcheck)** and **Security Scan (gosec G104)** — both caused by unchecked write returns in the new code. This fixes them.

## Failures addressed

**Lint / errcheck — 7 unchecked write returns:**
- `pkg/cluster/progress/plain.go:32,38,60,62` — `fmt.Fprintln`/`Fprintf` in `Log`/`LogError`/`taskStateChanged`
- `pkg/cluster/progress/live.go:171` — `io.WriteString` in the renderer
- `cmd/cluster_impl.go:470,489` — `fmt.Fprintf` in `renderStatusCompose`

**Security Scan / gosec G104** — the same `live.go:171` `io.WriteString`.

## Fix

These are best-effort terminal/buffer paints in `Reporter` methods that return no error, so handling a write failure isn't meaningful. Explicitly discard the returns with `_, _ =`. errcheck is configured with `check-blank: false` and gosec treats an explicit blank assignment as handled, so both jobs pass with no behavior change.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — green
- `gosec -exclude=… ./...` → **Issues: 0** (was 1)
- `golangci-lint run ./pkg/cluster/progress/... ./cmd/...` → **0 issues**

(The unrelated `pkg/cluster/filer/reflect.go` govet "inline" hint a newer local golangci-lint emits is pre-existing — from a different commit, not flagged by CI — and is intentionally left untouched.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the reliability of console/status output by standardizing how write operations report results and by buffering rendered progress frames before emitting them.
  * Updated info/error line printing to use consistent, line-based formatting while preserving the existing `[ERROR]`/`[INFO]` message formats and current behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->