### PR TITLE
fix: route status/upgrade/scale HTTP probes through the bastion

### DIFF
--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -928,10 +928,14 @@ func newUpgradeHTTPTransport(insecureSkipTLSVerify bool, clusterName string) *ht
 			}
 		}
 	}
-	// Tunnel probes through the jump host when one is configured (loadClusterSpec
-	// installs it via applyBastionFromSpec), so the upgrade version probe and the
-	// scale-in master/drain checks reach private addresses instead of failing.
-	return &http.Transport{TLSClientConfig: tlsConfig, DialContext: operator.DialContext}
+	// Clone of http.DefaultTransport (keeps proxy/idle/handshake defaults) with
+	// DialContext routing through the jump host when one is configured
+	// (loadClusterSpec installs it via applyBastionFromSpec), so the upgrade
+	// version probe and the scale-in master/drain checks reach private addresses
+	// instead of failing.
+	transport := operator.HTTPTransport()
+	transport.TLSClientConfig = tlsConfig
+	return transport
 }
 
 func runClusterScaleOut(clusterName string, opts *ClusterScaleOutOptions) error {

--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -928,7 +928,10 @@ func newUpgradeHTTPTransport(insecureSkipTLSVerify bool, clusterName string) *ht
 			}
 		}
 	}
-	return &http.Transport{TLSClientConfig: tlsConfig}
+	// Tunnel probes through the jump host when one is configured (loadClusterSpec
+	// installs it via applyBastionFromSpec), so the upgrade version probe and the
+	// scale-in master/drain checks reach private addresses instead of failing.
+	return &http.Transport{TLSClientConfig: tlsConfig, DialContext: operator.DialContext}
 }
 
 func runClusterScaleOut(clusterName string, opts *ClusterScaleOutOptions) error {

--- a/pkg/cluster/health/health.go
+++ b/pkg/cluster/health/health.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+	"github.com/seaweedfs/seaweed-up/pkg/operator"
 )
 
 // serverHeaderVersionRe matches "SeaweedFS <version>" in an HTTP Server header,
@@ -134,6 +135,9 @@ func NewProber(timeout time.Duration) *Prober {
 		Scheme:  "http",
 		Client: &http.Client{
 			Timeout: timeout,
+			// Tunnel through the jump host when one is configured so status
+			// probes reach private component addresses; direct otherwise.
+			Transport: &http.Transport{DialContext: operator.DialContext},
 		},
 	}
 }
@@ -166,7 +170,7 @@ func NewProberForSpec(timeout time.Duration, s *spec.Specification, clusterCertD
 	}
 	p.Client = &http.Client{
 		Timeout:   timeout,
-		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+		Transport: &http.Transport{TLSClientConfig: tlsCfg, DialContext: operator.DialContext},
 	}
 	return p
 }

--- a/pkg/cluster/health/health.go
+++ b/pkg/cluster/health/health.go
@@ -135,9 +135,10 @@ func NewProber(timeout time.Duration) *Prober {
 		Scheme:  "http",
 		Client: &http.Client{
 			Timeout: timeout,
-			// Tunnel through the jump host when one is configured so status
-			// probes reach private component addresses; direct otherwise.
-			Transport: &http.Transport{DialContext: operator.DialContext},
+			// Clone of http.DefaultTransport with DialContext routing through
+			// the jump host (when configured) so status probes reach private
+			// component addresses; direct otherwise.
+			Transport: operator.HTTPTransport(),
 		},
 	}
 }
@@ -168,9 +169,11 @@ func NewProberForSpec(timeout time.Duration, s *spec.Specification, clusterCertD
 			}
 		}
 	}
+	transport := operator.HTTPTransport()
+	transport.TLSClientConfig = tlsCfg
 	p.Client = &http.Client{
 		Timeout:   timeout,
-		Transport: &http.Transport{TLSClientConfig: tlsCfg, DialContext: operator.DialContext},
+		Transport: transport,
 	}
 	return p
 }

--- a/pkg/operator/dialcontext_test.go
+++ b/pkg/operator/dialcontext_test.go
@@ -12,6 +12,7 @@ import (
 // that keeps status/upgrade probes working on flat networks.
 func TestDialContextDirectWhenNoBastion(t *testing.T) {
 	SetBastion(nil)
+	defer SetBastion(nil) // restore deterministic state even if the test fails
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, "ok")
 	}))
@@ -40,5 +41,18 @@ func TestDialContextRoutesThroughBastion(t *testing.T) {
 
 	if _, err := DialContext(context.Background(), "tcp", "10.255.255.1:9333"); err == nil {
 		t.Fatal("expected an error dialing through an unreachable bastion, got nil")
+	}
+}
+
+// A dial through the bastion must honor a cancelled/expired context instead of
+// blocking, so a caller's timeout isn't ignored on the tunnel path.
+func TestDialContextHonorsCanceledContext(t *testing.T) {
+	SetBastion(&BastionConfig{Host: "127.0.0.1:1"})
+	defer SetBastion(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := DialContext(ctx, "tcp", "10.255.255.1:9333"); err == nil {
+		t.Fatal("expected a context error, got nil")
 	}
 }

--- a/pkg/operator/dialcontext_test.go
+++ b/pkg/operator/dialcontext_test.go
@@ -1,0 +1,44 @@
+package operator
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// With no jump host configured, DialContext connects directly — the fallback
+// that keeps status/upgrade probes working on flat networks.
+func TestDialContextDirectWhenNoBastion(t *testing.T) {
+	SetBastion(nil)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &http.Transport{DialContext: DialContext}}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET via DialContext: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want %q", string(body), "ok")
+	}
+}
+
+// When a jump host is configured but unreachable, DialContext returns an error
+// (it routes through the bastion) rather than silently connecting directly.
+func TestDialContextRoutesThroughBastion(t *testing.T) {
+	SetBastion(&BastionConfig{Host: "127.0.0.1:1"}) // nothing listening there
+	defer SetBastion(nil)
+
+	if _, err := DialContext(context.Background(), "tcp", "10.255.255.1:9333"); err == nil {
+		t.Fatal("expected an error dialing through an unreachable bastion, got nil")
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/user"
 	"strconv"
@@ -143,23 +144,65 @@ func currentBastion() *BastionConfig {
 // scale-in master probes) ride the same tunnel the SSH operator uses instead
 // of failing to connect. The bastion is read at dial time, so callers don't
 // need to order construction against SetBastion.
+//
+// ssh.Client.Dial is synchronous and ignores context, so the tunnel dial runs
+// in a goroutine and we select on ctx: if the caller's deadline fires first we
+// return promptly and close any connection the goroutine later establishes,
+// rather than blocking on an unreachable address past the timeout.
 func DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	if b := currentBastion(); b != nil && b.Host != "" {
-		client, err := sharedBastionClient(b)
-		if err != nil {
-			return nil, err
-		}
-		// ssh.Client.Dial has no ctx; the caller's http.Client timeout still
-		// bounds the request. A failed tunnel dial usually means the shared
-		// bastion connection dropped, so drop it to force a re-dial next time.
-		conn, err := client.Dial(network, addr)
-		if err != nil {
-			dropBastion(client)
-			return nil, err
-		}
-		return conn, nil
+	b := currentBastion()
+	if b == nil || b.Host == "" {
+		return (&net.Dialer{}).DialContext(ctx, network, addr)
 	}
-	return (&net.Dialer{}).DialContext(ctx, network, addr)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	client, err := sharedBastionClient(b)
+	if err != nil {
+		return nil, err
+	}
+
+	type dialResult struct {
+		conn net.Conn
+		err  error
+	}
+	ch := make(chan dialResult, 1)
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		conn, derr := client.Dial(network, addr)
+		select {
+		case ch <- dialResult{conn, derr}:
+		case <-done:
+			if derr == nil {
+				_ = conn.Close() // caller already gave up; don't leak the conn
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-ch:
+		if res.err != nil {
+			// A failed tunnel dial usually means the shared bastion connection
+			// dropped; drop it so the next attempt re-dials.
+			dropBastion(client)
+			return nil, res.err
+		}
+		return res.conn, nil
+	}
+}
+
+// HTTPTransport returns a clone of http.DefaultTransport — preserving its proxy,
+// connection-pool, and handshake/idle-timeout defaults — with DialContext set to
+// route through the configured jump host (see DialContext). Callers may further
+// set TLSClientConfig. Use this instead of a bare &http.Transport{} so probes
+// keep the standard transport behaviors.
+func HTTPTransport() *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DialContext = DialContext
+	return t
 }
 
 // sharedBastionClient returns the process-wide bastion connection,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -133,6 +134,32 @@ func currentBastion() *BastionConfig {
 	bastionMu.Lock()
 	defer bastionMu.Unlock()
 	return defaultBastion
+}
+
+// DialContext dials network/addr, tunneling through the configured jump host
+// when one is installed (see SetBastion) and connecting directly otherwise.
+// It is a drop-in for http.Transport.DialContext, so HTTP clients that must
+// reach private component addresses (the status health prober, upgrade and
+// scale-in master probes) ride the same tunnel the SSH operator uses instead
+// of failing to connect. The bastion is read at dial time, so callers don't
+// need to order construction against SetBastion.
+func DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	if b := currentBastion(); b != nil && b.Host != "" {
+		client, err := sharedBastionClient(b)
+		if err != nil {
+			return nil, err
+		}
+		// ssh.Client.Dial has no ctx; the caller's http.Client timeout still
+		// bounds the request. A failed tunnel dial usually means the shared
+		// bastion connection dropped, so drop it to force a re-dial next time.
+		conn, err := client.Dial(network, addr)
+		if err != nil {
+			dropBastion(client)
+			return nil, err
+		}
+		return conn, nil
+	}
+	return (&net.Dialer{}).DialContext(ctx, network, addr)
 }
 
 // sharedBastionClient returns the process-wide bastion connection,


### PR DESCRIPTION
## Problem

When a cluster's nodes are reachable only through a jump host (`global.bastion`), `seaweed-up`'s SSH operations all tunnel correctly — but two commands issue **HTTP probes straight to component/master IPs**, which the control machine can't reach:

- **`cluster status`** — the health prober connects directly to master/volume/filer ports, so behind a bastion it reports every component down (false negative).
- **`cluster scale in`** — its pre-flight master health check is a direct HTTP request, so it aborts with `no responsive master found` and never gets to the (SSH-tunneled) drain/teardown.

(`cluster upgrade` already sidestepped this by probing the current version over SSH on the node.)

I noticed these while documenting bastion operation for the wiki.

## Fix

Add **`operator.DialContext`** — a drop-in for `http.Transport.DialContext` that tunnels TCP through the configured jump host when one is installed (via the existing `sharedBastionClient`), and connects directly otherwise. The bastion is read at **dial time**, so there's no construction-vs-`SetBastion` ordering to get wrong; a failed tunnel dial drops the shared bastion connection so the next attempt re-dials.

Wired into:
- the health prober's HTTP clients (`NewProber` and `NewProberForSpec`) → fixes `cluster status`
- `newUpgradeHTTPTransport` → fixes the `scale in` master/drain probes (and makes `upgrade`'s direct path work too)

`loadClusterSpec` already installs the bastion (`applyBastionFromSpec` → `operator.SetBastion`) for every command that loads the spec, so these probes now ride the same tunnel as the SSH operations with no other wiring.

## No behavior change on flat networks

With no bastion configured, `DialContext` falls back to a plain `net.Dialer`, so direct-network deployments are unaffected — confirmed by the existing health test suite (which probes `httptest` servers through the prober).

## Tests / checks

- New `pkg/operator/dialcontext_test.go`: direct-dial fallback reaches an `httptest` server; a configured-but-unreachable bastion makes `DialContext` error (routes through the tunnel) instead of silently connecting direct.
- `go build` / `go vet` / `go test ./...` green; `golangci-lint` and `gosec` report 0 issues on the touched packages.

## Out of scope (noted, not fixed here)

`cluster scale in` still removes only volume servers (it doesn't stop the s3/worker on the host or update the YAML), and evacuation needs free capacity on the remaining servers. Those are separate limitations, documented in the wiki, left for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HTTP probes during cluster upgrades now route through configured bastion hosts when installed, matching network tunneling behavior of other cluster operations
  * Cluster health checks now support bastion/jump host routing for consistent private node access across all monitoring and management operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->