### PR TITLE
fix: prometheus job names match the bundled dashboard (seaweedfs-*)

### DIFF
--- a/pkg/cluster/observability/observability.go
+++ b/pkg/cluster/observability/observability.go
@@ -144,15 +144,19 @@ func RenderPromConfig(s *spec.Specification) string {
 		hosts[f.Ip] = struct{}{}
 	}
 
-	writeJob(name+"-master", masters)
-	writeJob(name+"-volume", volumes)
-	writeJob(name+"-filer", filers)
+	// Job names use the fixed "seaweedfs-<component>" convention so they match
+	// the bundled Grafana dashboard's `job="seaweedfs-..."` selectors (and the
+	// upstream SeaweedFS convention). The cluster is distinguished by the
+	// `cluster` label written above, not by the job name.
+	writeJob("seaweedfs-master", masters)
+	writeJob("seaweedfs-volume", volumes)
+	writeJob("seaweedfs-filer", filers)
 
 	var nodeTargets []string
 	for h := range hosts {
 		nodeTargets = append(nodeTargets, fmt.Sprintf("%s:%d", h, NodeExporterPort))
 	}
-	writeJob(name+"-node-exporter", nodeTargets)
+	writeJob("seaweedfs-node-exporter", nodeTargets)
 
 	return b.String()
 }

--- a/pkg/cluster/observability/observability_test.go
+++ b/pkg/cluster/observability/observability_test.go
@@ -50,8 +50,11 @@ func TestRenderPromConfigGolden(t *testing.T) {
 
 	got := RenderPromConfig(s)
 
+	// Job names are the fixed "seaweedfs-<component>" convention (matching the
+	// bundled Grafana dashboard's selectors); the cluster name appears only in
+	// the `cluster` label, not the job name.
 	want := `scrape_configs:
-  - job_name: "golden-master"
+  - job_name: "seaweedfs-master"
     metrics_path: /metrics
     static_configs:
       - targets:
@@ -59,14 +62,14 @@ func TestRenderPromConfigGolden(t *testing.T) {
           - "10.0.0.2:9324"
         labels:
           cluster: "golden"
-  - job_name: "golden-volume"
+  - job_name: "seaweedfs-volume"
     metrics_path: /metrics
     static_configs:
       - targets:
           - "10.0.0.3:9324"
         labels:
           cluster: "golden"
-  - job_name: "golden-filer"
+  - job_name: "seaweedfs-filer"
     metrics_path: /metrics
     static_configs:
       - targets:
@@ -80,7 +83,7 @@ func TestRenderPromConfigGolden(t *testing.T) {
 
 	// The node_exporter job is rendered last with a map-ordered target list,
 	// so verify its presence and unique hosts rather than exact ordering.
-	if !strings.Contains(got, `job_name: "golden-node-exporter"`) {
+	if !strings.Contains(got, `job_name: "seaweedfs-node-exporter"`) {
 		t.Error("missing node-exporter job")
 	}
 	for _, ip := range []string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"} {


### PR DESCRIPTION
## Problem

`cluster prometheus-config` named scrape jobs **`<cluster_name>-<component>`** (e.g. `seaweed-filer` for a cluster named `seaweed`), but the bundled Grafana dashboard (`cluster dashboard install`) hardcodes **`job="seaweedfs-<component>"`** selectors — the upstream SeaweedFS convention.

They only line up when the cluster is literally named `seaweedfs`. For any other name, the dashboard's per-instance **Go-runtime** panels (the *Filer Instances* / *Master Instances* rows: `go_goroutines{job="seaweedfs-filer"}`, memory, GC) match zero series and show **no data** — even though the filers/masters are being scraped fine. (The request/latency panels don't filter on `job`, which is why only the "Instances" rows looked broken.)

Observed on a cluster named `seaweed`: `go_goroutines{job="seaweedfs-filer"}` → 0 series, but `go_goroutines{job="seaweed-filer"}` → 3 series.

## Fix

Emit the fixed `seaweedfs-<component>` job name (master/volume/filer/node-exporter) and keep the cluster name in the existing `cluster` label that's already attached to every target. The dashboard's selectors now match for **any** `cluster_name`, and clusters are still distinguishable via the `cluster` label.

## Tests

Updated the `RenderPromConfig` golden test to assert `job_name: "seaweedfs-<component>"` with `cluster: "<name>"` (it previously pinned the name-prefixed job). `go build` / `go test ./...` / `golangci-lint` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated Prometheus metrics naming to use a consistent `seaweedfs-<component>` convention (seaweedfs-master, seaweedfs-volume, seaweedfs-filer, seaweedfs-node-exporter) for improved compatibility with the bundled Grafana dashboard. Cluster identification now uses a separate label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->