### PR TITLE
observability: guard time()-based dashboard panels against unset gauges

### DIFF
--- a/pkg/cluster/observability/dashboard.json
+++ b/pkg/cluster/observability/dashboard.json
@@ -5064,7 +5064,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - SeaweedFS_filerSync_sync_offset{cluster=~\"$cluster\"} / 1e9",
+              "expr": "time() - (SeaweedFS_filerSync_sync_offset{cluster=~\"$cluster\"} > 0) / 1e9",
               "range": true,
               "refId": "A",
               "legendFormat": "{{clientName}} {{path}}"
@@ -5160,7 +5160,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - max by (clientName, path) (SeaweedFS_filer_last_send_timestamp_of_subscribe{cluster=~\"$cluster\"}) / 1e9",
+              "expr": "time() - max by (clientName, path) (SeaweedFS_filer_last_send_timestamp_of_subscribe{cluster=~\"$cluster\"} > 0) / 1e9",
               "range": true,
               "refId": "A",
               "legendFormat": "{{clientName}} {{path}}"

--- a/pkg/cluster/observability/dashboard.json
+++ b/pkg/cluster/observability/dashboard.json
@@ -1750,7 +1750,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - SeaweedFS_master_start_time_seconds{cluster=~\"$cluster\"}",
+              "expr": "time() - (SeaweedFS_master_start_time_seconds{cluster=~\"$cluster\"} > 0)",
               "range": true,
               "refId": "A",
               "legendFormat": "{{instance}}"
@@ -3585,7 +3585,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - max by (mode) (SeaweedFS_volumeServer_scrub_last_time_seconds{cluster=~\"$cluster\"})",
+              "expr": "time() - max by (mode) (SeaweedFS_volumeServer_scrub_last_time_seconds{cluster=~\"$cluster\"} > 0)",
               "range": true,
               "refId": "A",
               "legendFormat": "{{mode}}"
@@ -3681,7 +3681,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - SeaweedFS_volumeServer_start_time_seconds{cluster=~\"$cluster\"}",
+              "expr": "time() - (SeaweedFS_volumeServer_start_time_seconds{cluster=~\"$cluster\"} > 0)",
               "range": true,
               "refId": "A",
               "legendFormat": "{{instance}}"
@@ -6804,7 +6804,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - max by (shard) (SeaweedFS_s3_lifecycle_cursor_min_ts_ns{cluster=~\"$cluster\"}) / 1e9",
+              "expr": "time() - max by (shard) (SeaweedFS_s3_lifecycle_cursor_min_ts_ns{cluster=~\"$cluster\"} > 0) / 1e9",
               "range": true,
               "refId": "A",
               "legendFormat": "shard {{shard}}"
@@ -7199,7 +7199,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "time() - max by (shard) (SeaweedFS_s3_lifecycle_daily_run_last_walked_ns{cluster=~\"$cluster\"}) / 1e9",
+              "expr": "time() - max by (shard) (SeaweedFS_s3_lifecycle_daily_run_last_walked_ns{cluster=~\"$cluster\"} > 0) / 1e9",
               "range": true,
               "refId": "A",
               "legendFormat": "shard {{shard}}"


### PR DESCRIPTION
The bundled Grafana dashboard's uptime/age panels compute `time() - <gauge>`. When a gauge is unset or zero (e.g. a target whose `start_time` hasn't been scraped yet), the expression yields the full Unix epoch as a duration — surfacing as nonsense like "Volume Server Uptime: 56.4 years".

Wrap each affected gauge with `> 0` so absent/zero samples drop out of the result instead of rendering epoch garbage. Five panels are affected:

- Master uptime (`SeaweedFS_master_start_time_seconds`)
- Volume Server uptime (`SeaweedFS_volumeServer_start_time_seconds`)
- Volume scrub age (`SeaweedFS_volumeServer_scrub_last_time_seconds`)
- S3 lifecycle cursor age (`SeaweedFS_s3_lifecycle_cursor_min_ts_ns`)
- S3 lifecycle daily-run age (`SeaweedFS_s3_lifecycle_daily_run_last_walked_ns`)

This keeps the vendored copy byte-identical to the canonical dashboard in the main SeaweedFS repo (`other/metrics/grafana_seaweedfs.json`), which carries the same fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed observability dashboard to accurately display uptime and time-based metrics by improving underlying query calculations for Master Uptime, Volume Server Uptime, Lifecycle Cursor Lag, and related indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->