### PR TITLE
observability: rename Metadata Subscription Lag panel to Time Since Last Subscription Send

### DIFF
--- a/pkg/cluster/observability/dashboard.json
+++ b/pkg/cluster/observability/dashboard.json
@@ -5077,8 +5077,8 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "title": "Metadata Subscription Lag",
-          "description": "Seconds since the filer last sent a metadata-subscription event (per client/path); only present with active subscribers",
+          "title": "Time Since Last Subscription Send",
+          "description": "Seconds since the filer last sent to a metadata subscription (real event or idle heartbeat), per client/path. Low for healthy caught-up subscribers; clients that don't request idle heartbeats show time since the last real event.",
           "type": "timeseries",
           "id": 156,
           "gridPos": {


### PR DESCRIPTION
Mirrors the canonical SeaweedFS dashboard change (seaweedfs/seaweedfs#9966): the panel formerly named **"Metadata Subscription Lag"** tracks time since the filer last sent to a metadata subscription. On an idle cluster, with no metadata writes on a subscriber's path, that value naturally grows — the old name made a healthy idle cluster look broken.

Renames it to **"Time Since Last Subscription Send"** and clarifies the description. Keeps the vendored `pkg/cluster/observability/dashboard.json` byte-identical to `other/metrics/grafana_seaweedfs.json` upstream.