### PR TITLE
fix: rust volume options use -disk (singular) and --options

### DIFF
--- a/pkg/cluster/spec/volume_server_spec.go
+++ b/pkg/cluster/spec/volume_server_spec.go
@@ -76,7 +76,11 @@ func (vs *VolumeServerSpec) WriteToBuffer(masters []string, buf *bytes.Buffer) {
 	}
 	addToBuffer(buf, "dir", strings.Join(dirs, ","))
 	addToBuffer(buf, "max", strings.Join(maxes, ","))
-	addToBuffer(buf, "disks", strings.Join(disks, ","))
+	// Both `weed volume` (Go) and `weed-volume` (Rust) take the disk-type
+	// flag as -disk (singular). The plural "disks" key was silently ignored
+	// by Go's lenient -options reader but rejected outright by the Rust
+	// binary's strict parser ("unexpected argument '--disks'").
+	addToBuffer(buf, "disk", strings.Join(disks, ","))
 	// `weed volume -dir.idx=<path>` puts the per-volume .idx files in
 	// a single shared directory rather than next to the data files in
 	// each -dir entry. Used to keep indexes on a small fast disk while

--- a/pkg/cluster/spec/volume_server_spec_test.go
+++ b/pkg/cluster/spec/volume_server_spec_test.go
@@ -1,0 +1,32 @@
+package spec
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Both Go `weed volume` and Rust `weed-volume` take the disk-type flag as
+// -disk (singular). The options key must therefore be "disk", not "disks":
+// Go's lenient -options reader ignored the plural key, but the Rust binary's
+// strict parser rejects it ("unexpected argument '--disks'") and crash-loops.
+func TestVolumeServerSpec_WriteToBuffer_DiskKeyIsSingular(t *testing.T) {
+	vs := &VolumeServerSpec{
+		Ip:   "10.0.0.1",
+		Port: 8080,
+		Folders: []*FolderSpec{
+			{Folder: "/data/v1/disk1", DiskType: "hdd", Max: 100},
+			{Folder: "/data/v1/disk2", DiskType: "ssd", Max: 50},
+		},
+	}
+	var buf bytes.Buffer
+	vs.WriteToBuffer([]string{"10.0.0.1:9333"}, &buf)
+	got := buf.String()
+
+	if strings.Contains(got, "disks=") {
+		t.Errorf("options must not use the plural 'disks=' key; Rust weed-volume rejects it:\n%s", got)
+	}
+	if !strings.Contains(got, "disk=hdd,ssd\n") {
+		t.Errorf("expected singular 'disk=hdd,ssd', got:\n%s", got)
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -278,7 +278,7 @@ StartLimitIntervalSec=10
 
 [Service]
 WorkingDirectory=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR}
-{{if .RustVolume}}ExecStart=${BIN_DIR}/${BINARY} -options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options{{else}}ExecStart=${BIN_DIR}/${BINARY} -logdir=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR} -alsologtostderr=false -config_dir=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR} ${COMPONENT} -options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options{{end}}
+{{if .RustVolume}}ExecStart=${BIN_DIR}/${BINARY} --options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options{{else}}ExecStart=${BIN_DIR}/${BINARY} -logdir=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR} -alsologtostderr=false -config_dir=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR} ${COMPONENT} -options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options{{end}}
 ExecReload=/bin/kill -s HUP \$MAINPID
 KillMode=process
 KillSignal=SIGINT


### PR DESCRIPTION
## Problem

A rust volume server (`engine: rust`) deployed from a **tagged release** `weed-volume` binary crash-loops on startup:

```
error: unexpected argument '--disks' found
  tip: a similar argument exists: '--disk'
Usage: weed-volume --options <OPTIONS> --ip <IP> --port <PORT> ...
status=2/INVALIDARGUMENT
```

## Root cause

Two mismatches between seaweed-up's generated config and the actual volume-server CLI — which is **`-disk` / `--disk` (singular) for both** Go `weed volume` and Rust `weed-volume`:

1. **`disks` vs `disk`** — `VolumeServerSpec.WriteToBuffer` rendered the options key as `disks` (plural). Go's lenient `-options` reader silently *ignored* the unrecognized key (falling back to the default disk type — a latent bug that happened to be harmless when all disks are `hdd`), but the Rust binary's strict parser rejects `--disks` outright. The `FolderSpec` field is already `yaml:"disk"`, so the rendered key should match.

2. **`-options=` vs `--options=`** — the Rust volume systemd unit invoked the binary with single-dash `-options=`. The release Rust binary's parser requires the double-dash `--options`.

The original rolling **dev** `weed-volume` binary had a lenient parser that accepted both `-options=` and `disks=`, which is why existing dev-asset deploys worked; the strictness only surfaces with the tagged-release binary.

## Fix

- `pkg/cluster/spec/volume_server_spec.go`: render the disk-type key as `disk`.
- `scripts/install.sh`: the Rust volume `ExecStart` uses `--options=` (double dash). The Go branch is unchanged (`weed volume -options=` still valid).

## Tests

- `TestVolumeServerSpec_WriteToBuffer_DiskKeyIsSingular` — asserts the rendered options use `disk=` and never `disks=`. Fails on the old code, passes with the fix. Full `pkg/cluster/spec` + `pkg/cluster/manager` suites pass.

## Verification

Confirmed on a live 5-node cluster: with these two changes the 4.34 release `weed-volume` starts, binds, and registers cleanly on all volume servers.

Note for review: the `--options` change targets the strict (clap-based) release/current rust binary; please confirm it's also accepted by whatever `weed-volume` the `dev` release currently ships.