### PR TITLE
test: fix stale rust volume render assertion (follow-up to #110)

### DIFF
--- a/scripts/install_render_test.go
+++ b/scripts/install_render_test.go
@@ -64,7 +64,7 @@ func TestInstallScript_RustVolumePath(t *testing.T) {
 		"weed-volume_large_disk_${OS}_${SUFFIX}.tar.gz",             // versioned per-arch release asset
 		".weed-volume-version",                                       // version marker
 		`RUST_VERSION_ID="${SEAWEED_VERSION}:${RUST_ASSET}"`,         // composite key: version + flavor
-		"ExecStart=${BIN_DIR}/${BINARY} -options=",                   // no `weed volume` subcommand / go globals
+		"ExecStart=${BIN_DIR}/${BINARY} --options=",                  // double-dash --options (Rust binary); no `weed volume` subcommand / go globals
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("rust volume install script missing %q", want)


### PR DESCRIPTION
#110 was merged at its first commit, before the render-test update was pushed, so `main` is currently red: `scripts/install.sh` emits the Rust `ExecStart` with double-dash `--options=` (the fix), but `TestInstallScript_RustVolumePath` still asserts the old single-dash `-options=`.

This applies the one-line assertion update that didn't make it into the merge. `go test ./scripts/` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for the Rust-volume install script output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->