### PR TITLE
deploy: skip non-weed release tags when resolving latest version

### DIFF
--- a/cmd/cluster_impl.go
+++ b/cmd/cluster_impl.go
@@ -232,7 +232,7 @@ func runClusterDeploy(cmd *cobra.Command, args []string, opts *ClusterDeployOpti
 	// version from the public artifactory repo instead of the OSS repo.
 	if mgr.Version == "" {
 		owner, repo := mgr.ReleaseOwnerRepo()
-		latest, err := config.GitHubLatestRelease(cmd.Context(), "0", owner, repo)
+		latest, err := config.GitHubLatestRelease(cmd.Context(), "0", owner, repo, config.IsWeedReleaseTag)
 		if err != nil {
 			return fmt.Errorf("unable to get latest version from %s/%s: %w", owner, repo, err)
 		}

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -556,7 +556,7 @@ func (m *Manager) DeployCluster(specification *spec.Specification) error {
 		if m.EnvoyVersion == "" {
 			for _, es := range specification.EnvoyServers {
 				if es.Version == "" {
-					latest, err := config.GitHubLatestRelease(context.Background(), "0", "envoyproxy", "envoy")
+					latest, err := config.GitHubLatestRelease(context.Background(), "0", "envoyproxy", "envoy", nil)
 					if err != nil {
 						return errors.Wrapf(err, "unable to get latest envoy version, pin one with --envoy-version")
 					}

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -64,9 +65,40 @@ func setGithubAuthHeaders(req *http.Request) {
 	}
 }
 
+// weedReleaseTagRE matches numeric weed release tags like "4.40". The
+// enterprise release repo also hosts other product lines (e.g. seaweed-vfs
+// client packages tagged "vfs-0.1.6") that carry no weed server assets.
+var weedReleaseTagRE = regexp.MustCompile(`^\d+\.\d+`)
+
+// IsWeedReleaseTag reports whether tag names a weed server release.
+func IsWeedReleaseTag(tag string) bool {
+	return weedReleaseTagRE.MatchString(tag)
+}
+
+// pickRelease selects the release for ver from releaseList: the newest tag
+// accepted by tagFilter when ver is "0" (nil accepts all), or the exact tag
+// match otherwise. Returns a zero Release when nothing matches.
+func pickRelease(releaseList []Release, ver string, tagFilter func(string) bool) Release {
+	if ver == "0" {
+		for _, r := range releaseList {
+			if tagFilter == nil || tagFilter(r.TagName) {
+				return r
+			}
+		}
+		return Release{}
+	}
+	for _, r := range releaseList {
+		if r.TagName == ver {
+			return r
+		}
+	}
+	return Release{}
+}
+
 // GitHubLatestRelease uses the GitHub API to get information about the specific
-// release of a repository.
-func GitHubLatestRelease(ctx context.Context, ver string, owner, repo string) (Release, error) {
+// release of a repository. When ver is "0", the newest release whose tag passes
+// tagFilter is picked; pass nil to accept every tag.
+func GitHubLatestRelease(ctx context.Context, ver string, owner, repo string, tagFilter func(string) bool) (Release, error) {
 	ctx, cancel := context.WithTimeout(ctx, githubAPITimeout)
 	defer cancel()
 
@@ -105,26 +137,18 @@ func GitHubLatestRelease(ctx context.Context, ver string, owner, repo string) (R
 		return Release{}, err
 	}
 
-	var release Release
 	var releaseList []Release
 	err = json.Unmarshal(buf, &releaseList)
 	if err != nil {
 		return Release{}, err
 	}
-	if ver == "0" {
-		release = releaseList[0]
-		log.Printf("latest version is %v / %v", release.TagName, release.PublishedAt.Local())
-	} else {
-		for _, r := range releaseList {
-			if r.TagName == ver {
-				release = r
-				break
-			}
-		}
-	}
+	release := pickRelease(releaseList, ver, tagFilter)
 
 	if release.TagName == "" {
 		return Release{}, fmt.Errorf("can not find the specific version")
+	}
+	if ver == "0" {
+		log.Printf("latest version is %v / %v", release.TagName, release.PublishedAt.Local())
 	}
 
 	release.Version = release.TagName

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -65,10 +65,11 @@ func setGithubAuthHeaders(req *http.Request) {
 	}
 }
 
-// weedReleaseTagRE matches numeric weed release tags like "4.40". The
-// enterprise release repo also hosts other product lines (e.g. seaweed-vfs
-// client packages tagged "vfs-0.1.6") that carry no weed server assets.
-var weedReleaseTagRE = regexp.MustCompile(`^\d+\.\d+`)
+// weedReleaseTagRE matches numeric weed release tags like "4.40" (an
+// optional "v" prefix is tolerated). The enterprise release repo also hosts
+// other product lines (e.g. seaweed-vfs client packages tagged "vfs-0.1.6")
+// that carry no weed server assets.
+var weedReleaseTagRE = regexp.MustCompile(`^v?\d+\.\d+`)
 
 // IsWeedReleaseTag reports whether tag names a weed server release.
 func IsWeedReleaseTag(tag string) bool {

--- a/pkg/config/version_test.go
+++ b/pkg/config/version_test.go
@@ -1,0 +1,48 @@
+package config
+
+import "testing"
+
+func TestPickRelease(t *testing.T) {
+	// Mirrors the enterprise release repo, which interleaves seaweed-vfs
+	// client releases with weed server releases, newest first.
+	releases := []Release{
+		{TagName: "vfs-0.1.6"},
+		{TagName: "4.40"},
+		{TagName: "vfs-0.1.5"},
+		{TagName: "4.39"},
+	}
+
+	tests := []struct {
+		name      string
+		ver       string
+		tagFilter func(string) bool
+		want      string
+	}{
+		{name: "latest skips non-weed tags", ver: "0", tagFilter: IsWeedReleaseTag, want: "4.40"},
+		{name: "latest without filter", ver: "0", want: "vfs-0.1.6"},
+		{name: "exact version", ver: "4.39", tagFilter: IsWeedReleaseTag, want: "4.39"},
+		{name: "unknown version", ver: "9.99", want: ""},
+	}
+	for _, tt := range tests {
+		if got := pickRelease(releases, tt.ver, tt.tagFilter).TagName; got != tt.want {
+			t.Errorf("%s: got %q, want %q", tt.name, got, tt.want)
+		}
+	}
+
+	if got := pickRelease(nil, "0", nil).TagName; got != "" {
+		t.Errorf("empty release list: got %q, want empty", got)
+	}
+}
+
+func TestIsWeedReleaseTag(t *testing.T) {
+	for tag, want := range map[string]bool{
+		"4.40":      true,
+		"3.59":      true,
+		"vfs-0.1.6": false,
+		"dev":       false,
+	} {
+		if got := IsWeedReleaseTag(tag); got != want {
+			t.Errorf("IsWeedReleaseTag(%q) = %v, want %v", tag, got, want)
+		}
+	}
+}

--- a/pkg/config/version_test.go
+++ b/pkg/config/version_test.go
@@ -37,6 +37,7 @@ func TestPickRelease(t *testing.T) {
 func TestIsWeedReleaseTag(t *testing.T) {
 	for tag, want := range map[string]bool{
 		"4.40":      true,
+		"v4.40":     true,
 		"3.59":      true,
 		"vfs-0.1.6": false,
 		"dev":       false,


### PR DESCRIPTION
## Problem

The Integration Enterprise workflow failed on main ([run 29791369499](https://github.com/seaweedfs/seaweed-up/actions/runs/29791369499/job/88555233962)):

```
2026/07/21 05:59:20 latest version is vfs-0.1.6 / 2026-07-21 00:32:49 +0000 UTC
[INFO] -> Downloading vfs-0.1.6 weed-enterprise-linux_amd64_large_disk.tar.gz
[ERROR] error received during installation: Process exited with status 22
```

The enterprise release repo (seaweedfs/artifactory) hosts two product lines: enterprise weed releases (`4.40`, `4.39`, …) and seaweed-vfs client releases (`vfs-0.1.6`, …). `GitHubLatestRelease` with ver `"0"` blindly took `releaseList[0]`, so whenever a vfs release is the newest (most of the time, since vfs cuts follow enterprise cuts), a versionless `--enterprise` deploy resolves to a vfs tag whose release has no `weed-enterprise-*.tar.gz` asset — the remote `curl -f` gets a 404 and exits 22.

## Fix

- `GitHubLatestRelease` takes a tag filter applied when resolving the latest release; the weed lookup passes `IsWeedReleaseTag` (numeric `^\d+\.\d+` tags), so `vfs-*` (and `dev`) tags are skipped. The envoy lookup passes nil and behaves as before.
- Selection logic extracted into `pickRelease` and unit-tested with the interleaved vfs/weed tag layout that broke.

With the filter, the failed run would resolve `4.40` instead of `vfs-0.1.6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic version selection for cluster deployments.
  * Latest releases are now correctly filtered to select compatible Weed server versions.
  * Preserved exact-version selection while improving handling of unavailable or unmatched releases.

* **Tests**
  * Added coverage for release selection, version filtering, and unsupported release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->