### PR TITLE
Deploy Lance catalogs and the Rust maintenance worker

### DIFF
--- a/.github/workflows/integration-enterprise.yml
+++ b/.github/workflows/integration-enterprise.yml
@@ -158,7 +158,15 @@ jobs:
       - name: Write and read a file via filer
         run: |
           echo "hello-enterprise" > /tmp/test.txt
-          curl -sf -F file=@/tmp/test.txt http://172.28.0.10:8888/test/test.txt
+          # The first write races volume registration and can 500 — retry it;
+          # the read after a successful write is deterministic.
+          for i in $(seq 1 30); do
+            if curl -sf -F file=@/tmp/test.txt http://172.28.0.10:8888/test/test.txt; then
+              break
+            fi
+            [ "$i" = "30" ] && { echo "filer write never succeeded"; exit 1; }
+            sleep 2
+          done
           body=$(curl -sf http://172.28.0.10:8888/test/test.txt)
           echo "Read back: $body"
           echo "$body" | grep -q hello-enterprise

--- a/.github/workflows/integration-worker.yml
+++ b/.github/workflows/integration-worker.yml
@@ -128,11 +128,12 @@ jobs:
       - name: Deploy cluster with worker
         working-directory: test/integration
         run: |
+          set -o pipefail
           ../../seaweed-up cluster deploy test-worker \
             -f testdata/cluster-worker.yaml \
             -u root \
             --identity .ssh/id_rsa_test \
-            --yes
+            --yes 2>&1 | tee deploy.log
 
           echo "Waiting for services to initialize..."
           sleep 30
@@ -153,6 +154,23 @@ jobs:
             exit 1
           fi
           echo "Worker service verified active on host3"
+
+      - name: Verify Lance worker deployed or skipped with a warning
+        working-directory: test/integration
+        run: |
+          # Either the Lance unit is active (release ships weed-worker) or the
+          # skip warning was logged; silence means the Lance path never ran.
+          state=$(docker exec seaweed-up-host3 systemctl is-active seaweed_worker-lance0 2>/dev/null || true)
+          echo "seaweed_worker-lance0 state: $state"
+          if [ "$state" = "active" ]; then
+            echo "Lance worker unit verified active on host3"
+          elif grep -q "skipping the Lance maintenance worker" deploy.log; then
+            echo "Lance worker skipped with a warning (release carries no weed-worker asset yet)"
+          else
+            echo "Neither an active seaweed_worker-lance0 unit nor a skip warning found"
+            docker exec seaweed-up-host3 journalctl -u seaweed_worker-lance0 --no-pager -n 100 2>&1 || true
+            exit 1
+          fi
 
       - name: Archive logs
         if: always()

--- a/pkg/cluster/manager/deploy_worker_server.go
+++ b/pkg/cluster/manager/deploy_worker_server.go
@@ -3,6 +3,9 @@ package manager
 import (
 	"bytes"
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
 
 	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
 	"github.com/seaweedfs/seaweed-up/pkg/operator"
@@ -12,6 +15,15 @@ import (
 // data directories and systemd unit naming (e.g. "worker0").
 func workerComponentInstance(index int) string {
 	return fmt.Sprintf("worker%d", index)
+}
+
+// workerLanceComponent is the companion Rust weed-worker unit on every worker
+// host; it maintains Lance tables, which the Go worker's job types cannot.
+const workerLanceComponent = "worker-lance"
+
+// workerLanceComponentInstance returns the companion unit's instance name.
+func workerLanceComponentInstance(index int) string {
+	return fmt.Sprintf("%s%d", workerLanceComponent, index)
 }
 
 // runWorkerRemote executes fn against the worker host over SSH.
@@ -30,13 +42,89 @@ func (m *Manager) runWorkerSystemctl(w *spec.WorkerServerSpec, index int, action
 
 func (m *Manager) DeployWorkerServer(admins []string, w *spec.WorkerServerSpec, index int) error {
 	return m.runWorkerRemote(w, func(op operator.CommandOperator) error {
-		component := "worker"
-		componentInstance := workerComponentInstance(index)
-		var buf bytes.Buffer
-		w.WriteToBuffer(admins, &buf)
-
-		return m.deployComponentInstance(op, component, componentInstance, &buf)
+		return m.deployWorkerInstances(op, admins, w, index)
 	})
+}
+
+// deployWorkerInstances installs the Go unit and, when the host qualifies,
+// the companion Lance unit in one SSH session.
+func (m *Manager) deployWorkerInstances(op operator.CommandOperator, admins []string, w *spec.WorkerServerSpec, index int) error {
+	var buf bytes.Buffer
+	w.WriteToBuffer(admins, &buf)
+	if err := m.deployComponentInstance(op, "worker", workerComponentInstance(index), &buf); err != nil {
+		return err
+	}
+	return m.deployLanceWorker(op, admins, w, index)
+}
+
+// deployLanceWorker installs the companion Rust weed-worker unit; it skips,
+// never fails the host, when the host or release cannot run it.
+func (m *Manager) deployLanceWorker(op operator.CommandOperator, admins []string, w *spec.WorkerServerSpec, index int) error {
+	if w.Namespace == "" {
+		m.info(fmt.Sprintf("worker %s: no Lance namespace resolvable (no s3_servers and no worker_servers[].namespace); skipping the Lance maintenance worker", w.Ip))
+		return nil
+	}
+	uname, err := op.Output("uname -s -m")
+	if err != nil {
+		m.info(fmt.Sprintf("worker %s: cannot detect the host platform (%v); skipping the Lance maintenance worker", w.Ip, err))
+		return nil
+	}
+	arch, reason := lanceWorkerAssetArch(string(uname))
+	if reason != "" {
+		m.info(fmt.Sprintf("worker %s: %s; skipping the Lance maintenance worker", w.Ip, reason))
+		return nil
+	}
+
+	// Probed from the control host so a 404 skips instead of failing
+	// mid-install; only a definite 404 means "predates weed-worker".
+	owner, repo := m.ReleaseOwnerRepo()
+	asset := fmt.Sprintf("weed-worker_linux_%s.tar.gz", arch)
+	assetURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s", owner, repo, m.Version, asset)
+	switch status, err := lanceAssetHead(assetURL); {
+	case err != nil:
+		return fmt.Errorf("check the weed-worker release asset %s: %w", assetURL, err)
+	case status == http.StatusNotFound:
+		m.info(fmt.Sprintf("worker %s: release %s does not ship %s (it predates the Rust worker); skipping the Lance maintenance worker", w.Ip, m.Version, asset))
+		return nil
+	case status != http.StatusOK:
+		return fmt.Errorf("check the weed-worker release asset %s: HTTP %d", assetURL, status)
+	}
+
+	var buf bytes.Buffer
+	w.WriteLanceToBuffer(admins, &buf)
+	return m.deployComponentInstance(op, workerLanceComponent, workerLanceComponentInstance(index), &buf)
+}
+
+// lanceAssetHead issues the probe's HEAD; a var so tests stub the network away.
+var lanceAssetHead = func(url string) (int, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Head(url)
+	if err != nil {
+		return 0, err
+	}
+	// A HEAD carries no body worth reading; the status is the answer.
+	_ = resp.Body.Close()
+	return resp.StatusCode, nil
+}
+
+// lanceWorkerAssetArch maps `uname -s -m` to the release asset arch, or gives
+// the reason weed-worker cannot run there (linux amd64/arm64 only).
+func lanceWorkerAssetArch(unameOut string) (arch, reason string) {
+	fields := strings.Fields(unameOut)
+	if len(fields) < 2 {
+		return "", fmt.Sprintf("unexpected uname output %q", strings.TrimSpace(unameOut))
+	}
+	osName, machine := fields[0], fields[1]
+	if !strings.EqualFold(osName, "Linux") {
+		return "", fmt.Sprintf("weed-worker is published for linux only; host reports %s", osName)
+	}
+	switch machine {
+	case "x86_64", "amd64":
+		return "amd64", ""
+	case "aarch64", "arm64":
+		return "arm64", ""
+	}
+	return "", fmt.Sprintf("weed-worker is published for linux amd64/arm64 only; host is %s", machine)
 }
 
 func (m *Manager) ResetWorkerServer(w *spec.WorkerServerSpec, index int) error {

--- a/pkg/cluster/manager/deploy_worker_server_test.go
+++ b/pkg/cluster/manager/deploy_worker_server_test.go
@@ -1,0 +1,208 @@
+package manager
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweed-up/pkg/cluster/spec"
+)
+
+func workerInstallScripts(t *testing.T, op *fakeOperator) (goUnit, lanceUnit bool) {
+	t.Helper()
+	for path := range op.uploads {
+		if strings.HasSuffix(path, "/install_worker0.sh") {
+			goUnit = true
+		}
+		if strings.HasSuffix(path, "/install_worker-lance0.sh") {
+			lanceUnit = true
+		}
+	}
+	return
+}
+
+// stubLanceAssetHead swaps the release-asset probe for the test's duration.
+func stubLanceAssetHead(t *testing.T, fn func(url string) (int, error)) {
+	t.Helper()
+	old := lanceAssetHead
+	lanceAssetHead = fn
+	t.Cleanup(func() { lanceAssetHead = old })
+}
+
+func TestDeployWorkerInstances_BothUnits(t *testing.T) {
+	m := &Manager{User: "root", Version: "4.44"}
+	op := newFakeOperator()
+	op.outputFn = func(cmd string) ([]byte, error) { return []byte("Linux x86_64\n"), nil }
+	var probedURL string
+	stubLanceAssetHead(t, func(url string) (int, error) { probedURL = url; return 200, nil })
+
+	w := &spec.WorkerServerSpec{Ip: "10.0.0.10", Namespace: "http://10.0.0.51:9101", LanceMetricsPort: 9328}
+	if err := m.deployWorkerInstances(op, []string{"10.0.0.100:23646"}, w, 0); err != nil {
+		t.Fatalf("deployWorkerInstances: %v", err)
+	}
+
+	wantURL := "https://github.com/seaweedfs/seaweedfs/releases/download/4.44/weed-worker_linux_amd64.tar.gz"
+	if probedURL != wantURL {
+		t.Errorf("asset probe URL: got %q want %q", probedURL, wantURL)
+	}
+
+	goUnit, lanceUnit := workerInstallScripts(t, op)
+	if !goUnit || !lanceUnit {
+		t.Fatalf("expected both worker units (go=%v lance=%v); uploads: %v", goUnit, lanceUnit, keys(op.uploads))
+	}
+
+	for path, content := range op.uploads {
+		if strings.HasSuffix(path, "/install_worker-lance0.sh") {
+			for _, want := range []string{
+				"BINARY=weed-worker",
+				"weed-worker_${OS}_${SUFFIX}.tar.gz",
+				"ExecStart=${BIN_DIR}/${BINARY} --admin 10.0.0.100:23646 --namespace http://10.0.0.51:9101 --metrics-port 9328 --metrics-ip 0.0.0.0",
+			} {
+				if !strings.Contains(content, want) {
+					t.Errorf("lance install script missing %q", want)
+				}
+			}
+		}
+		if strings.HasSuffix(path, "/install_worker0.sh") {
+			if !strings.Contains(content, "BINARY=weed") || strings.Contains(content, "BINARY=weed-worker") {
+				t.Errorf("go worker install script should install weed")
+			}
+		}
+	}
+}
+
+func TestDeployWorkerInstances_SkipsLanceOffPlatform(t *testing.T) {
+	for _, uname := range []string{"Darwin arm64", "Linux armv7l", "Linux riscv64"} {
+		m := &Manager{User: "root", Version: "4.44"}
+		op := newFakeOperator()
+		op.outputFn = func(cmd string) ([]byte, error) { return []byte(uname + "\n"), nil }
+		stubLanceAssetHead(t, func(url string) (int, error) {
+			t.Errorf("uname %q: no asset probe expected for an unsupported platform", uname)
+			return 0, nil
+		})
+
+		w := &spec.WorkerServerSpec{Ip: "10.0.0.10", Namespace: "http://10.0.0.51:9101"}
+		if err := m.deployWorkerInstances(op, []string{"10.0.0.100:23646"}, w, 0); err != nil {
+			t.Fatalf("uname %q: deployWorkerInstances should not fail the host: %v", uname, err)
+		}
+		goUnit, lanceUnit := workerInstallScripts(t, op)
+		if !goUnit {
+			t.Errorf("uname %q: the Go worker unit must always deploy", uname)
+		}
+		if lanceUnit {
+			t.Errorf("uname %q: the Lance unit should be skipped", uname)
+		}
+	}
+}
+
+func TestDeployWorkerInstances_SkipsLanceWithoutNamespace(t *testing.T) {
+	m := &Manager{User: "root", Version: "4.44"}
+	op := newFakeOperator()
+	op.outputFn = func(cmd string) ([]byte, error) { return []byte("Linux x86_64\n"), nil }
+	stubLanceAssetHead(t, func(url string) (int, error) {
+		t.Error("no asset probe expected when the namespace is missing")
+		return 0, nil
+	})
+
+	w := &spec.WorkerServerSpec{Ip: "10.0.0.10"} // Namespace empty after prepare()
+	if err := m.deployWorkerInstances(op, []string{"10.0.0.100:23646"}, w, 0); err != nil {
+		t.Fatalf("deployWorkerInstances should not fail the host: %v", err)
+	}
+	goUnit, lanceUnit := workerInstallScripts(t, op)
+	if !goUnit {
+		t.Error("the Go worker unit must always deploy")
+	}
+	if lanceUnit {
+		t.Error("the Lance unit should be skipped without a namespace")
+	}
+	for _, cmd := range op.executed {
+		if strings.Contains(cmd, "uname") {
+			t.Errorf("no uname probe expected when the namespace is missing, got %q", cmd)
+		}
+	}
+}
+
+func TestDeployWorkerInstances_SkipsLanceOnOlderRelease(t *testing.T) {
+	m := &Manager{User: "root", Version: "4.44"}
+	op := newFakeOperator()
+	op.outputFn = func(cmd string) ([]byte, error) { return []byte("Linux x86_64\n"), nil }
+	stubLanceAssetHead(t, func(url string) (int, error) { return 404, nil })
+
+	w := &spec.WorkerServerSpec{Ip: "10.0.0.10", Namespace: "http://10.0.0.51:9101"}
+	if err := m.deployWorkerInstances(op, []string{"10.0.0.100:23646"}, w, 0); err != nil {
+		t.Fatalf("a release without the asset should not fail the host: %v", err)
+	}
+	goUnit, lanceUnit := workerInstallScripts(t, op)
+	if !goUnit {
+		t.Error("the Go worker unit must always deploy")
+	}
+	if lanceUnit {
+		t.Error("the Lance unit should be skipped when the release lacks the asset")
+	}
+}
+
+// Only a definite 404 reads as "predates weed-worker"; anything else must
+// error, not skip.
+func TestDeployWorkerInstances_ProbeFailureIsAnError(t *testing.T) {
+	for name, fn := range map[string]func(url string) (int, error){
+		"http 403":      func(string) (int, error) { return 403, nil },
+		"network error": func(string) (int, error) { return 0, errors.New("dial tcp: timeout") },
+	} {
+		m := &Manager{User: "root", Version: "4.44"}
+		op := newFakeOperator()
+		op.outputFn = func(cmd string) ([]byte, error) { return []byte("Linux x86_64\n"), nil }
+		stubLanceAssetHead(t, fn)
+
+		w := &spec.WorkerServerSpec{Ip: "10.0.0.10", Namespace: "http://10.0.0.51:9101"}
+		err := m.deployWorkerInstances(op, []string{"10.0.0.100:23646"}, w, 0)
+		if err == nil {
+			t.Errorf("%s: expected an error, not a silent skip", name)
+		}
+		if goUnit, _ := workerInstallScripts(t, op); !goUnit {
+			t.Errorf("%s: the Go worker unit deploys before the probe", name)
+		}
+	}
+}
+
+func TestLanceWorkerAssetArch(t *testing.T) {
+	cases := map[string]string{ // uname output -> asset arch ("" = skip)
+		"Linux x86_64":  "amd64",
+		"Linux amd64":   "amd64",
+		"Linux aarch64": "arm64",
+		"Linux arm64":   "arm64",
+		"Darwin arm64":  "",
+		"Linux armv7l":  "",
+		"Linux riscv64": "",
+		"garbage":       "",
+	}
+	for uname, wantArch := range cases {
+		arch, reason := lanceWorkerAssetArch(uname)
+		if arch != wantArch {
+			t.Errorf("uname %q: arch %q, want %q", uname, arch, wantArch)
+		}
+		if (wantArch == "") == (reason == "") {
+			t.Errorf("uname %q: arch %q and reason %q should be mutually exclusive", uname, arch, reason)
+		}
+	}
+}
+
+func TestRustWorkerArgs(t *testing.T) {
+	var buf bytes.Buffer
+	w := &spec.WorkerServerSpec{Ip: "10.0.0.10", Namespace: "http://10.0.0.51:9101"}
+	w.WriteLanceToBuffer([]string{"10.0.0.100:23646"}, &buf)
+
+	got := rustWorkerArgs(&buf)
+	want := "--admin 10.0.0.100:23646 --namespace http://10.0.0.51:9101"
+	if got != want {
+		t.Fatalf("rustWorkerArgs: got %q want %q", got, want)
+	}
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/cluster/manager/host_prep_test.go
+++ b/pkg/cluster/manager/host_prep_test.go
@@ -15,6 +15,8 @@ type fakeOperator struct {
 	executed []string
 	uploads  map[string]string
 	execErr  error
+	// outputFn, when set, answers Output calls (e.g. the uname probe).
+	outputFn func(cmd string) ([]byte, error)
 }
 
 func newFakeOperator() *fakeOperator {
@@ -28,6 +30,9 @@ func (f *fakeOperator) Execute(cmd string) error {
 
 func (f *fakeOperator) Output(cmd string) ([]byte, error) {
 	f.executed = append(f.executed, cmd)
+	if f.outputFn != nil {
+		return f.outputFn(cmd)
+	}
 	return nil, f.execErr
 }
 

--- a/pkg/cluster/manager/manager_deploy.go
+++ b/pkg/cluster/manager/manager_deploy.go
@@ -658,6 +658,15 @@ func (m *Manager) prepare(specification *spec.Specification) {
 	}
 	for _, workerSpec := range specification.WorkerServers {
 		workerSpec.PortSsh = utils.NvlInt(workerSpec.PortSsh, m.SshPort, 22)
+		// Default the Lance namespace to the first s3 server's port.lance.
+		if workerSpec.Namespace == "" && len(specification.S3Servers) > 0 {
+			s3Spec := specification.S3Servers[0]
+			lancePort := s3Spec.PortLance
+			if lancePort == 0 {
+				lancePort = 9101
+			}
+			workerSpec.Namespace = "http://" + net.JoinHostPort(s3Spec.Ip, strconv.Itoa(lancePort))
+		}
 	}
 	// The monitoring host's SSH port isn't a struct-tag default, so normalize
 	// it here like every other server; otherwise lifecycle commands would dial
@@ -665,6 +674,24 @@ func (m *Manager) prepare(specification *spec.Specification) {
 	if specification.Monitoring != nil {
 		specification.Monitoring.PortSsh = utils.NvlInt(specification.Monitoring.PortSsh, m.SshPort, 22)
 	}
+}
+
+// rustWorkerArgs turns rendered worker-lance options into `--key value` flags:
+// weed-worker reads no options file, so they go on the ExecStart line.
+func rustWorkerArgs(cliOptions *bytes.Buffer) string {
+	var args []string
+	for _, line := range strings.Split(cliOptions.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		args = append(args, "--"+k, v)
+	}
+	return strings.Join(args, " ")
 }
 
 func (m *Manager) deployComponentInstance(op operator.CommandOperator, component string, componentInstance string, cliOptions *bytes.Buffer, extras ...extraConfigFile) error {
@@ -710,12 +737,16 @@ func (m *Manager) deployComponentBinary(op operator.CommandOperator, component s
 		fullSuffix = ""
 	}
 
-	// Rust volume servers install the standalone weed-volume binary; every
-	// other component (and Go volume servers) install weed.
+	// Rust volume servers install weed-volume, the worker-lance component
+	// weed-worker; everything else installs weed.
 	rustVolume := engine == "rust" || engine == "weed-volume"
+	rustWorker := component == workerLanceComponent
 	binary := "weed"
-	if rustVolume {
+	switch {
+	case rustVolume:
 		binary = "weed-volume"
+	case rustWorker:
+		binary = "weed-worker"
 	}
 
 	data := map[string]interface{}{
@@ -723,6 +754,8 @@ func (m *Manager) deployComponentBinary(op operator.CommandOperator, component s
 		"ComponentInstance": componentInstance,
 		"Binary":            binary,
 		"RustVolume":        rustVolume,
+		"RustWorker":        rustWorker,
+		"RustWorkerArgs":    "",
 		"ConfigDir":         m.confDir,
 		"DataDir":           m.dataDir,
 		"TmpDir":            dir,
@@ -752,6 +785,9 @@ func (m *Manager) deployComponentBinary(op operator.CommandOperator, component s
 		data["DevAssetURL"] = m.devAsset.DownloadURL
 		data["DevMd5URL"] = m.devAsset.Md5URL
 		data["DevBuildID"] = m.devAsset.BuildID
+	}
+	if rustWorker {
+		data["RustWorkerArgs"] = rustWorkerArgs(cliOptions)
 	}
 	if rustVolume && m.rustDevAsset != nil {
 		data["RustDevAssetURL"] = m.rustDevAsset.DownloadURL

--- a/pkg/cluster/manager/manager_deploy_test.go
+++ b/pkg/cluster/manager/manager_deploy_test.go
@@ -303,3 +303,43 @@ func TestResolveWorkerDefaultAdmins(t *testing.T) {
 		}
 	})
 }
+
+// TestPrepare_DerivesLanceNamespace covers the worker namespace default.
+func TestPrepare_DerivesLanceNamespace(t *testing.T) {
+	m := &Manager{User: "root"} // root skips the sudo password prompt
+
+	sp := &spec.Specification{
+		S3Servers: []*spec.S3ServerSpec{{Ip: "10.0.0.51"}},
+		WorkerServers: []*spec.WorkerServerSpec{
+			{Ip: "10.0.0.10"},
+			{Ip: "10.0.0.11", Namespace: "http://lance.example:9200"},
+		},
+	}
+	m.prepare(sp)
+
+	if got, want := sp.WorkerServers[0].Namespace, "http://10.0.0.51:9101"; got != want {
+		t.Errorf("derived namespace: got %q want %q", got, want)
+	}
+	if got, want := sp.WorkerServers[1].Namespace, "http://lance.example:9200"; got != want {
+		t.Errorf("explicit namespace must win, got %q want %q", got, want)
+	}
+
+	sp2 := &spec.Specification{
+		S3Servers: []*spec.S3ServerSpec{{Ip: "10.0.0.51", PortLance: 9200}},
+		WorkerServers: []*spec.WorkerServerSpec{
+			{Ip: "10.0.0.10"},
+		},
+	}
+	m.prepare(sp2)
+	if got, want := sp2.WorkerServers[0].Namespace, "http://10.0.0.51:9200"; got != want {
+		t.Errorf("derived namespace with explicit port.lance: got %q want %q", got, want)
+	}
+
+	sp3 := &spec.Specification{
+		WorkerServers: []*spec.WorkerServerSpec{{Ip: "10.0.0.10"}},
+	}
+	m.prepare(sp3)
+	if got := sp3.WorkerServers[0].Namespace; got != "" {
+		t.Errorf("no s3 servers: namespace should stay empty, got %q", got)
+	}
+}

--- a/pkg/cluster/manager/manager_upgrade.go
+++ b/pkg/cluster/manager/manager_upgrade.go
@@ -68,6 +68,9 @@ type componentHooks struct {
 	// fresh on every deploy attempt because each extra carries a single-use
 	// Reader the retry loop would otherwise exhaust. May be nil.
 	extras func() ([]extraConfigFile, error)
+	// postDeploy runs inside the SSH session after the main unit is
+	// reinstalled (worker hosts reinstall the companion Lance unit). May be nil.
+	postDeploy func(op operator.CommandOperator) error
 	// engine selects the volume binary ("" Go weed, "rust" weed-volume);
 	// empty for non-volume components.
 	engine string
@@ -361,6 +364,9 @@ func (m *Manager) upgradeOneHost(specification *spec.Specification, masters, wor
 			sshAddr:     net.JoinHostPort(w.Ip, strconv.Itoa(w.PortSsh)),
 			stop:        func() error { return m.StopWorkerServer(w, t.index) },
 			writeConfig: func(buf *bytes.Buffer) { w.WriteToBuffer(workerAdmins, buf) },
+			postDeploy: func(op operator.CommandOperator) error {
+				return m.deployLanceWorker(op, workerAdmins, w, t.index)
+			},
 		}
 	default:
 		return fmt.Errorf("unknown component: %s", t.component)
@@ -397,6 +403,11 @@ func (m *Manager) runUpgradeHost(t upgradeTarget, hooks componentHooks) error {
 			}
 			if err := m.deployComponentBinary(op, hooks.serviceName, componentInstance, hooks.engine, &buf, extras...); err != nil {
 				return err
+			}
+			if hooks.postDeploy != nil {
+				if err := hooks.postDeploy(op); err != nil {
+					return err
+				}
 			}
 			return m.sudo(op, fmt.Sprintf("systemctl restart seaweed_%s.service", componentInstance))
 		})

--- a/pkg/cluster/observability/dashboard.json
+++ b/pkg/cluster/observability/dashboard.json
@@ -8473,6 +8473,959 @@
     },
     {
       "type": "row",
+      "title": "Plugin Workers",
+      "collapsed": true,
+      "id": 229,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "Plugin Workers Connected",
+          "description": "Workers with a live control stream. Unlike the Admin/Maintenance row, this counts plugin workers, which is what a Rust or Go plugin worker actually is.",
+          "type": "stat",
+          "id": 219,
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 28
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "count(SeaweedFS_worker_connected{cluster=~\"$cluster\"} == 1) or vector(0)",
+              "instant": true,
+              "range": false,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "Worker Job Failures (1h)",
+          "description": "Jobs that ended in failure across all workers in the last hour.",
+          "type": "stat",
+          "id": 220,
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 28
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(SeaweedFS_worker_jobs_total{cluster=~\"$cluster\",result=\"failed\"}[1h])) or vector(0)",
+              "instant": true,
+              "range": false,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "Objects Seen vs Skipped",
+          "description": "A sweep that proposes nothing because there was nothing to do and one that proposes nothing because it could read nothing produce the same proposal count. Skips are the difference, and are the thing to alert on.",
+          "type": "timeseries",
+          "id": 221,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 32
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "unit": "ops",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job_type) (rate(SeaweedFS_worker_objects_seen_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+              "range": true,
+              "refId": "A",
+              "legendFormat": "seen {{job_type}}"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job_type, reason) (rate(SeaweedFS_worker_objects_skipped_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+              "range": true,
+              "refId": "B",
+              "legendFormat": "skipped {{job_type}} ({{reason}})"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "Detections and Proposals",
+          "description": "Detection sweeps by outcome, and the work they handed to admin.",
+          "type": "timeseries",
+          "id": 222,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 32
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "unit": "ops",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job_type, result) (rate(SeaweedFS_worker_detections_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+              "range": true,
+              "refId": "A",
+              "legendFormat": "detections {{job_type}} ({{result}})"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job_type) (rate(SeaweedFS_worker_proposals_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+              "range": true,
+              "refId": "B",
+              "legendFormat": "proposals {{job_type}}"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "Jobs Executed",
+          "description": "Jobs run by these workers, by outcome.",
+          "type": "timeseries",
+          "id": 223,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 40
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "unit": "ops",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job_type, result) (rate(SeaweedFS_worker_jobs_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+              "range": true,
+              "refId": "A",
+              "legendFormat": "{{job_type}} ({{result}})"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "Job Duration p99",
+          "description": "How long a job takes, per job type.",
+          "type": "timeseries",
+          "id": 224,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 40
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "unit": "s",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_worker_job_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le, job_type))",
+              "range": true,
+              "refId": "A",
+              "legendFormat": "{{job_type}}"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "Worker Slots",
+          "description": "Capacity a worker advertised and how much of it is in use. Held slots are what admin schedules against.",
+          "type": "timeseries",
+          "id": 225,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 48
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (lane) (SeaweedFS_worker_slots_used{cluster=~\"$cluster\"})",
+              "range": true,
+              "refId": "A",
+              "legendFormat": "used {{lane}}"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (lane) (SeaweedFS_worker_slots_total{cluster=~\"$cluster\"})",
+              "range": true,
+              "refId": "B",
+              "legendFormat": "total {{lane}}"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "Control Stream Events",
+          "description": "Connects, closes and failures. A worker that reconnects steadily is usually two workers sharing one id, evicting each other.",
+          "type": "timeseries",
+          "id": 226,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 48
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "unit": "ops",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (event) (rate(SeaweedFS_worker_stream_events_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+              "range": true,
+              "refId": "A",
+              "legendFormat": "{{event}}"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "Lance Maintenance Reclaimed",
+          "description": "What the Lance jobs actually removed. A job that runs every minute and reclaims nothing is a different thing from a job that never runs.",
+          "type": "timeseries",
+          "id": 227,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 56
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "unit": "ops",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(SeaweedFS_worker_lance_fragments_removed_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+              "range": true,
+              "refId": "A",
+              "legendFormat": "fragments merged"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(SeaweedFS_worker_lance_rows_indexed_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+              "range": true,
+              "refId": "B",
+              "legendFormat": "rows indexed"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(SeaweedFS_worker_lance_versions_removed_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+              "range": true,
+              "refId": "C",
+              "legendFormat": "versions removed"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "Storage Reclaimed",
+          "description": "Bytes freed by version cleanup. Its own panel because bytes and counts do not belong on one axis.",
+          "type": "timeseries",
+          "id": 228,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 56
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "unit": "Bps",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(SeaweedFS_worker_lance_bytes_reclaimed_total{cluster=~\"$cluster\"}[$__rate_interval]))",
+              "range": true,
+              "refId": "A",
+              "legendFormat": "reclaimed"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "row",
       "title": "Go Runtime",
       "collapsed": true,
       "id": 200,
@@ -8480,7 +9433,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 28
       },
       "panels": [
         {

--- a/pkg/cluster/observability/observability.go
+++ b/pkg/cluster/observability/observability.go
@@ -149,6 +149,21 @@ func RenderPromConfig(s *spec.Specification) string {
 		hosts[f.Ip] = struct{}{}
 	}
 
+	// Worker metrics are opt-in (no auto-assignment). Worker hosts carry no
+	// node_exporter, so they stay out of that job.
+	var workers []string
+	for _, w := range s.WorkerServers {
+		if w == nil {
+			continue
+		}
+		if w.MetricsPort != 0 {
+			workers = append(workers, fmt.Sprintf("%s:%d", w.Ip, w.MetricsPort))
+		}
+		if w.LanceMetricsPort != 0 {
+			workers = append(workers, fmt.Sprintf("%s:%d", w.Ip, w.LanceMetricsPort))
+		}
+	}
+
 	// Job names use the fixed "seaweedfs-<component>" convention so they match
 	// the bundled Grafana dashboard's `job="seaweedfs-..."` selectors (and the
 	// upstream SeaweedFS convention). The cluster is distinguished by the
@@ -156,6 +171,7 @@ func RenderPromConfig(s *spec.Specification) string {
 	writeJob("seaweedfs-master", masters)
 	writeJob("seaweedfs-volume", volumes)
 	writeJob("seaweedfs-filer", filers)
+	writeJob("seaweedfs-worker", workers)
 
 	var nodeTargets []string
 	for h := range hosts {

--- a/pkg/cluster/observability/observability_test.go
+++ b/pkg/cluster/observability/observability_test.go
@@ -124,3 +124,45 @@ func TestNodeExporterUnitContainsPort(t *testing.T) {
 		t.Error("systemd unit missing ExecStart")
 	}
 }
+
+// Worker metrics are opt-in; worker hosts must not join the node_exporter job.
+func TestRenderPromConfigWorkerTargets(t *testing.T) {
+	s := &spec.Specification{
+		Name: "golden",
+		MasterServers: []*spec.MasterServerSpec{
+			{Ip: "10.0.0.1", MetricsPort: 9324},
+		},
+		WorkerServers: []*spec.WorkerServerSpec{
+			{Ip: "10.0.0.71", MetricsPort: 9327, LanceMetricsPort: 9328},
+			{Ip: "10.0.0.72"}, // no metrics ports: contributes no targets
+		},
+	}
+
+	got := RenderPromConfig(s)
+	want := `  - job_name: "seaweedfs-worker"
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - "10.0.0.71:9327"
+          - "10.0.0.71:9328"
+        labels:
+          cluster: "golden"
+`
+	if !strings.Contains(got, want) {
+		t.Errorf("worker job mismatch:\nwant block:\n%s\ngot:\n%s", want, got)
+	}
+	if strings.Contains(got, "10.0.0.72") {
+		t.Error("a worker without metrics ports should contribute no targets")
+	}
+	if strings.Contains(got, "10.0.0.71:9100") {
+		t.Error("worker hosts must not join the node_exporter job")
+	}
+
+	s2 := &spec.Specification{
+		MasterServers: []*spec.MasterServerSpec{{Ip: "10.0.0.1"}},
+		WorkerServers: []*spec.WorkerServerSpec{{Ip: "10.0.0.71"}},
+	}
+	if strings.Contains(RenderPromConfig(s2), "seaweedfs-worker") {
+		t.Error("no worker job expected when no worker exposes metrics")
+	}
+}

--- a/pkg/cluster/spec/s3_server_spec.go
+++ b/pkg/cluster/spec/s3_server_spec.go
@@ -8,12 +8,16 @@ import (
 // It is deployed as a separate process running `weed s3`, talking to an
 // existing filer endpoint.
 type S3ServerSpec struct {
-	Ip          string                 `yaml:"ip"`
-	PortSsh     int                    `yaml:"port.ssh" default:"22"`
-	IpBind      string                 `yaml:"ip.bind,omitempty"`
-	Port        int                    `yaml:"port" default:"8333"`
-	PortGrpc    int                    `yaml:"port.grpc,omitempty"`
-	MetricsPort int                    `yaml:"metrics_port,omitempty"`
+	Ip       string `yaml:"ip"`
+	PortSsh  int    `yaml:"port.ssh" default:"22"`
+	IpBind   string `yaml:"ip.bind,omitempty"`
+	Port     int    `yaml:"port" default:"8333"`
+	PortGrpc int    `yaml:"port.grpc,omitempty"`
+	// PortIceberg / PortLance map to `weed s3 -port.iceberg` / `-port.lance`;
+	// zero omits the option so the weed defaults (8181/9101) hold.
+	PortIceberg int `yaml:"port.iceberg,omitempty"`
+	PortLance   int `yaml:"port.lance,omitempty"`
+	MetricsPort int `yaml:"metrics_port,omitempty"`
 	// Filer is the ip:port of the filer this gateway connects to. If empty,
 	// the deploy logic will default it to the first filer in the spec.
 	Filer string `yaml:"filer,omitempty"`
@@ -31,6 +35,8 @@ func (s *S3ServerSpec) WriteToBuffer(buf *bytes.Buffer, s3ConfigPath string) {
 	addToBuffer(buf, "ip.bind", s.IpBind)
 	addToBufferInt(buf, "port", s.Port, 8333)
 	addToBufferInt(buf, "port.grpc", s.PortGrpc, 0)
+	addToBufferInt(buf, "port.iceberg", s.PortIceberg, 0)
+	addToBufferInt(buf, "port.lance", s.PortLance, 0)
 	addToBufferInt(buf, "metricsPort", s.MetricsPort, 0)
 	addToBuffer(buf, "filer", s.Filer)
 	if s3ConfigPath != "" {

--- a/pkg/cluster/spec/s3_server_spec_test.go
+++ b/pkg/cluster/spec/s3_server_spec_test.go
@@ -27,6 +27,8 @@ func TestS3ServerSpec_WriteToBuffer_AllFields(t *testing.T) {
 		IpBind:      "0.0.0.0",
 		Port:        8443,
 		PortGrpc:    18443,
+		PortIceberg: 8181,
+		PortLance:   9101,
 		MetricsPort: 9091,
 		Filer:       "10.0.0.2:8888",
 	}
@@ -38,6 +40,8 @@ func TestS3ServerSpec_WriteToBuffer_AllFields(t *testing.T) {
 		"ip.bind=0.0.0.0\n" +
 		"port=8443\n" +
 		"port.grpc=18443\n" +
+		"port.iceberg=8181\n" +
+		"port.lance=9101\n" +
 		"metricsPort=9091\n" +
 		"filer=10.0.0.2:8888\n" +
 		"config=/etc/seaweed/s30.d/s3.json\n"

--- a/pkg/cluster/spec/worker_server_spec.go
+++ b/pkg/cluster/spec/worker_server_spec.go
@@ -29,6 +29,15 @@ type WorkerServerSpec struct {
 	Config  map[string]interface{} `yaml:"config,omitempty"`
 	Arch    string                 `yaml:"arch,omitempty"`
 	OS      string                 `yaml:"os,omitempty"`
+	// MetricsPort exposes the Go worker's /metrics (`weed worker -metricsPort`);
+	// the Rust unit has its own LanceMetricsPort so the two never share a port.
+	MetricsPort int `yaml:"metrics_port,omitempty"`
+	// LanceMetricsPort exposes the companion Rust unit's /metrics
+	// (`weed-worker --metrics-port`); 9328 continues the per-component series.
+	LanceMetricsPort int `yaml:"lance_metrics_port,omitempty"`
+	// Namespace is the companion Rust weed-worker's Lance namespace URL; empty
+	// derives from the first s3 server's port.lance (9101), else the unit skips.
+	Namespace string `yaml:"namespace,omitempty"`
 }
 
 // DefaultWorkerJobType is the value WriteToBuffer falls back to when
@@ -63,17 +72,14 @@ var workerReservedKeys = map[string]struct{}{
 // sorted key order, skipping any keys that collide with fields already
 // rendered from explicit struct fields.
 func (w *WorkerServerSpec) WriteToBuffer(admins []string, buf *bytes.Buffer) {
-	admin := w.Admin
-	if admin == "" && len(admins) > 0 {
-		admin = admins[0]
-	}
-	addToBuffer(buf, "admin", admin)
+	addToBuffer(buf, "admin", w.adminEndpoint(admins))
 
 	jobType := w.JobType
 	if jobType == "" {
 		jobType = DefaultWorkerJobType
 	}
 	addToBuffer(buf, "jobType", jobType)
+	addToBufferInt(buf, "metricsPort", w.MetricsPort, 0)
 
 	if len(w.Config) == 0 {
 		return
@@ -88,5 +94,28 @@ func (w *WorkerServerSpec) WriteToBuffer(admins []string, buf *bytes.Buffer) {
 	sort.Strings(keys)
 	for _, k := range keys {
 		fmt.Fprintf(buf, "%s=%v\n", k, w.Config[k])
+	}
+}
+
+// adminEndpoint is the explicit Admin field or the deploy-time default.
+func (w *WorkerServerSpec) adminEndpoint(admins []string) string {
+	if w.Admin != "" {
+		return w.Admin
+	}
+	if len(admins) > 0 {
+		return admins[0]
+	}
+	return ""
+}
+
+// WriteLanceToBuffer renders the companion Rust unit's options; the deploy
+// path turns them into ExecStart flags since weed-worker reads no options file.
+func (w *WorkerServerSpec) WriteLanceToBuffer(admins []string, buf *bytes.Buffer) {
+	addToBuffer(buf, "admin", w.adminEndpoint(admins))
+	addToBuffer(buf, "namespace", w.Namespace)
+	addToBufferInt(buf, "metrics-port", w.LanceMetricsPort, 0)
+	if w.LanceMetricsPort != 0 {
+		// weed-worker defaults metrics to loopback; prometheus scrapes remotely.
+		addToBuffer(buf, "metrics-ip", "0.0.0.0")
 	}
 }

--- a/pkg/cluster/spec/worker_server_spec_test.go
+++ b/pkg/cluster/spec/worker_server_spec_test.go
@@ -96,3 +96,56 @@ func TestWorkerServerSpec_WriteToBuffer_JobTypeInConfigSuppressed(t *testing.T) 
 		t.Errorf("Config jobType should be dropped by reserved-keys filter; got %q", got)
 	}
 }
+
+func TestWorkerServerSpec_WriteToBuffer_MetricsPort(t *testing.T) {
+	w := &WorkerServerSpec{
+		Ip:          "10.0.0.5",
+		Admin:       "10.0.0.1:23646",
+		MetricsPort: 9327,
+	}
+	var buf bytes.Buffer
+	w.WriteToBuffer(nil, &buf)
+
+	got := buf.String()
+	want := "admin=10.0.0.1:23646\njobType=all\nmetricsPort=9327\n"
+	if got != want {
+		t.Fatalf("WriteToBuffer metrics port: got %q want %q", got, want)
+	}
+}
+
+func TestWorkerServerSpec_WriteLanceToBuffer(t *testing.T) {
+	// Go-worker vocabulary (jobType, metricsPort, Config) must not leak in;
+	// a non-zero lance metrics port brings the 0.0.0.0 bind with it.
+	w := &WorkerServerSpec{
+		Ip:               "10.0.0.5",
+		Namespace:        "http://10.0.0.51:9101",
+		JobType:          "ec,balance",
+		MetricsPort:      9327,
+		LanceMetricsPort: 9328,
+		Config:           map[string]interface{}{"maxDetect": 2},
+	}
+	var buf bytes.Buffer
+	w.WriteLanceToBuffer([]string{"10.0.0.1:23646"}, &buf)
+
+	got := buf.String()
+	want := "admin=10.0.0.1:23646\nnamespace=http://10.0.0.51:9101\nmetrics-port=9328\nmetrics-ip=0.0.0.0\n"
+	if got != want {
+		t.Fatalf("WriteLanceToBuffer: got %q want %q", got, want)
+	}
+}
+
+func TestWorkerServerSpec_WriteLanceToBuffer_ExplicitAdmin(t *testing.T) {
+	w := &WorkerServerSpec{
+		Ip:        "10.0.0.5",
+		Admin:     "10.0.0.2:23646",
+		Namespace: "http://10.0.0.51:9101",
+	}
+	var buf bytes.Buffer
+	w.WriteLanceToBuffer([]string{"10.0.0.1:23646"}, &buf)
+
+	got := buf.String()
+	want := "admin=10.0.0.2:23646\nnamespace=http://10.0.0.51:9101\n"
+	if got != want {
+		t.Fatalf("WriteLanceToBuffer explicit admin: got %q want %q", got, want)
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -175,6 +175,39 @@ download_and_install() {
     $SUDO install -m 0755 "$TMP_DIR/${rustBin}" "${BIN_DIR}/${BINARY}"
     echo "${RUST_VERSION_ID}" | $SUDO tee "$MARKER" >/dev/null
   fi
+{{else}}{{if .RustWorker}}
+  # Rust maintenance worker. The release ships linux amd64/arm64 only;
+  # refuse other targets up front.
+  case $SUFFIX in
+  amd64 | arm64) ;;
+  *)
+    fatal "weed-worker is published for linux amd64/arm64 only; this host is ${ARCH}"
+    ;;
+  esac
+  # Marker-keyed idempotency: weed-worker's version scheme differs from the release tag.
+  MARKER="${BIN_DIR}/.weed-worker-version"
+  OS="linux"
+  WORKER_ASSET="weed-worker_${OS}_${SUFFIX}.tar.gz"
+  WORKER_VERSION_ID="${SEAWEED_VERSION}:${WORKER_ASSET}"
+  WORKER_URL="https://github.com/{{.ReleaseOwner}}/{{.ReleaseRepo}}/releases/download/${SEAWEED_VERSION}/${WORKER_ASSET}"
+  curID=""
+  [ -f "$MARKER" ] && curID=$(cat "$MARKER" 2>/dev/null)
+  if [ -x "${BIN_DIR}/${BINARY}" ] && [ "$curID" = "${WORKER_VERSION_ID}" ]; then
+    info "weed-worker ${WORKER_VERSION_ID} already installed, skipping"
+  else
+    info "Downloading weed-worker ${WORKER_VERSION_ID} (${WORKER_URL})"
+    curl {{.ProxyConfig}} --retry 3 --retry-delay 2 -o "$TMP_DIR/${WORKER_ASSET}" -sfL "${WORKER_URL}"
+    # Every worker asset ships a .md5; verification is mandatory.
+    curl {{.ProxyConfig}} --retry 3 --retry-delay 2 -o "$TMP_DIR/${WORKER_ASSET}.md5" -sfL "${WORKER_URL}.md5"
+    info "Verifying weed-worker ${WORKER_VERSION_ID}"
+    md5Value=$(awk '{print $1}' "$TMP_DIR/${WORKER_ASSET}.md5")
+    ( cd "$TMP_DIR" && echo "${md5Value}  ${WORKER_ASSET}" | md5sum -c )
+    # The archive holds a single file named weed-worker.
+    $SUDO tar xzf "$TMP_DIR/${WORKER_ASSET}" -C "$TMP_DIR"
+    [ -f "$TMP_DIR/weed-worker" ] || fatal "no weed-worker binary in ${WORKER_ASSET}"
+    $SUDO install -m 0755 "$TMP_DIR/weed-worker" "${BIN_DIR}/${BINARY}"
+    echo "${WORKER_VERSION_ID}" | $SUDO tee "$MARKER" >/dev/null
+  fi
 {{else}}{{if .DevAssetURL}}
   # Rolling "dev" build path. The version string ("dev") never changes, so
   # idempotency keys on the build datestamp ({{.DevBuildID}}) recorded in a
@@ -251,7 +284,7 @@ download_and_install() {
     info "Unpacking ${SEAWEED_VERSION} ${assetFileName}"
     $SUDO tar xvf "$TMP_DIR/seaweed_${SEAWEED_VERSION}_${assetFileName}" --directory $BIN_DIR
   fi
-{{end}}{{end}}
+{{end}}{{end}}{{end}}
 }
 
 create_user_and_config() {
@@ -278,7 +311,7 @@ StartLimitIntervalSec=10
 
 [Service]
 WorkingDirectory=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR}
-{{if .RustVolume}}ExecStart=${BIN_DIR}/${BINARY} --options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options{{else}}ExecStart=${BIN_DIR}/${BINARY} -logdir=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR} -alsologtostderr=false -config_dir=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR} ${COMPONENT} -options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options{{end}}
+{{if .RustVolume}}ExecStart=${BIN_DIR}/${BINARY} --options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options{{else}}{{if .RustWorker}}ExecStart=${BIN_DIR}/${BINARY} {{.RustWorkerArgs}}{{else}}ExecStart=${BIN_DIR}/${BINARY} -logdir=${SEAWEED_COMPONENT_INSTANCE_DATA_DIR} -alsologtostderr=false -config_dir=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR} ${COMPONENT} -options=${SEAWEED_COMPONENT_INSTANCE_CONFIG_DIR}/${COMPONENT}.options{{end}}{{end}}
 ExecReload=/bin/kill -s HUP \$MAINPID
 KillMode=process
 KillSignal=SIGINT

--- a/scripts/install_render_test.go
+++ b/scripts/install_render_test.go
@@ -18,6 +18,7 @@ func renderInstall(t *testing.T, data map[string]interface{}) string {
 		"DevAssetURL": "", "DevMd5URL": "", "DevBuildID": "",
 		"RustDevAssetURL": "", "RustDevMd5URL": "", "RustDevBuildID": "",
 		"Binary": "weed", "RustVolume": false, "Enterprise": false,
+		"RustWorker": false, "RustWorkerArgs": "",
 	}
 	for k, v := range data {
 		base[k] = v
@@ -61,10 +62,10 @@ func TestInstallScript_RustVolumePath(t *testing.T) {
 	})
 	for _, want := range []string{
 		"BINARY=weed-volume",
-		"weed-volume_large_disk_${OS}_${SUFFIX}.tar.gz",             // versioned per-arch release asset
-		".weed-volume-version",                                       // version marker
-		`RUST_VERSION_ID="${SEAWEED_VERSION}:${RUST_ASSET}"`,         // composite key: version + flavor
-		"ExecStart=${BIN_DIR}/${BINARY} --options=",                  // double-dash --options (Rust binary); no `weed volume` subcommand / go globals
+		"weed-volume_large_disk_${OS}_${SUFFIX}.tar.gz",      // versioned per-arch release asset
+		".weed-volume-version",                               // version marker
+		`RUST_VERSION_ID="${SEAWEED_VERSION}:${RUST_ASSET}"`, // composite key: version + flavor
+		"ExecStart=${BIN_DIR}/${BINARY} --options=",          // double-dash --options (Rust binary); no `weed volume` subcommand / go globals
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("rust volume install script missing %q", want)
@@ -95,7 +96,7 @@ func TestInstallScript_RustVolumeDevPath(t *testing.T) {
 	for _, want := range []string{
 		"BINARY=weed-volume",
 		"weed-volume-large-disk-20260613-0656-linux-amd64.tar.gz", // resolved dev asset URL
-		`RUST_VERSION_ID="20260613-0656"`,                          // keyed on dev build id, not "dev"
+		`RUST_VERSION_ID="20260613-0656"`,                         // keyed on dev build id, not "dev"
 		".weed-volume-version",
 		"skipping checksum verification", // best-effort md5 (dev lacks .md5)
 		`[ "$md5Code" = "404" ]`,         // only a genuine 404 is a soft skip
@@ -125,6 +126,38 @@ func TestInstallScript_RustVolumeEnterprisePath(t *testing.T) {
 	}
 	if strings.Contains(out, "weed-volume_large_disk_") {
 		t.Errorf("enterprise rust path should not use the OSS asset name")
+	}
+}
+
+func TestInstallScript_RustWorkerPath(t *testing.T) {
+	out := renderInstall(t, map[string]interface{}{
+		"Component": "worker-lance", "ComponentInstance": "worker-lance0",
+		"Binary": "weed-worker", "RustWorker": true, "Version": "4.44",
+		"RustWorkerArgs": "--admin 10.0.0.61:23646 --namespace http://10.0.0.51:9101",
+	})
+	for _, want := range []string{
+		"BINARY=weed-worker",
+		"weed-worker_${OS}_${SUFFIX}.tar.gz", // versioned per-arch release asset
+		".weed-worker-version",               // version marker
+		`WORKER_VERSION_ID="${SEAWEED_VERSION}:${WORKER_ASSET}"`,
+		"weed-worker is published for linux amd64/arm64 only", // arch guard
+		"md5sum -c",
+		// flags on the ExecStart line: weed-worker reads no options file
+		"ExecStart=${BIN_DIR}/${BINARY} --admin 10.0.0.61:23646 --namespace http://10.0.0.51:9101",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rust worker install script missing %q", want)
+		}
+	}
+	// must not take the Go weed download path or the go-style ExecStart
+	if strings.Contains(out, "_full_large_disk.tar.gz") {
+		t.Errorf("rust worker path should not download the Go weed tarball")
+	}
+	if strings.Contains(out, "-logdir=") || strings.Contains(out, "${COMPONENT} -options=") {
+		t.Errorf("rust worker ExecStart should not use go-style flags / subcommand")
+	}
+	if strings.Contains(out, "weed-volume") {
+		t.Errorf("rust worker path should not reference weed-volume")
 	}
 }
 

--- a/test/integration/testdata/cluster-worker.yaml
+++ b/test/integration/testdata/cluster-worker.yaml
@@ -20,6 +20,11 @@ filer_servers:
   - ip: 172.28.0.10
     port: 8888
 
+# An s3 server makes a Lance namespace derivable, so the deploy exercises the
+# worker host's Lance unit path.
+s3_servers:
+  - ip: 172.28.0.10
+
 worker_servers:
   - ip: 172.28.0.12
     admin: 172.28.0.10:23646


### PR DESCRIPTION
Three pieces to make a seaweed-up cluster serve and maintain Lance tables.

The s3 spec learns port.iceberg and port.lance, rendered like port.grpc: zero keeps the option out of the file so the weed defaults (8181/9101) hold.

The worker component deploys the Rust weed-worker alongside the Go worker instead of switching between them - the two have no overlapping functionality. The Go worker runs vacuum, balance, EC and iceberg maintenance; the Rust weed-worker is what maintains Lance tables (compaction, index coverage, version cleanup), a format the Go worker cannot read. So every worker host keeps its Go unit exactly as before and additionally gets a seaweed_worker-lance<N> unit installing the standalone weed-worker binary from the weed-worker_linux_{amd64,arm64}.tar.gz release asset, md5-verified; upgrades move both binaries in the same session. weed-worker reads no options file, so its flags go on the ExecStart line: --admin resolves exactly like the Go worker's, --namespace comes from a new namespace field and defaults to the first s3 server's port.lance listener. The Lance unit is skipped with a warning - the Go unit deploys normally, the host never fails - when no namespace resolves (no s3 servers, no override), when the host is not linux amd64/arm64, or when a HEAD probe shows the release carries no weed-worker asset yet (releases up to and including 4.44 predate the workflow that builds it); only a definite 404 reads as that, so a rate limit or network blip surfaces as an error instead of quietly skipping a unit the release does ship. Metrics are opt-in per unit: metrics_port for the Go worker (matching the sibling specs) and lance_metrics_port for the Rust unit (9328 by convention), rendered with a 0.0.0.0 --metrics-ip since weed-worker defaults metrics to loopback; both feed a new seaweedfs-worker scrape job, and the Rust listener is what lights up the dashboard's Lance panels.

The bundled Grafana dashboard picks up the upstream Plugin Workers row over the SeaweedFS_worker_* metrics, inserted between Admin / Maintenance and Go Runtime with the upstream ids; the panels already use the DS_PROMETHEUS variable and cluster selector the bundled dashboard expects.

https://claude.ai/code/session_01Rkp1Mw5E89Jp6dzJFYiMrm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker deployments now include a companion Lance maintenance worker on supported Linux hosts.
  * Added configurable worker metrics, namespace, Iceberg, and Lance gateway ports.
  * Worker settings can derive the Lance namespace automatically when not specified.
  * Added comprehensive Grafana dashboards for plugin worker health, jobs, processing, performance, and maintenance activity.
* **Bug Fixes**
  * Unsupported platforms or unavailable namespaces now skip Lance deployment without blocking Go worker deployment.
* **Improvements**
  * Worker upgrades now reinstall the companion Lance worker automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

