### PR TITLE
docs: add cluster_name to example specs, required for security.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,30 @@ Two example specs live under `examples/`:
   2 S3 gateways, 1 admin, 2 workers, and a co-located Prometheus + Grafana
   monitoring stack.
 
+## Cluster name
+
+Set a top-level `cluster_name` in every spec that has `filer_servers` or
+`admin_servers` (both example specs above set one):
+
+```yaml
+cluster_name: my-cluster
+```
+
+The filer needs a `jwt.filer_signing` key to register the IAM gRPC service
+the Admin UI Users tab calls, and the admin server signs Bearer tokens with
+that same key — this is required even with TLS off. `seaweed-up` generates
+that key on first deploy and persists it locally under
+`~/.seaweed-up/clusters/<cluster_name>/` so later runs (redeploys, scale
+out/in, upgrades) reuse it instead of rotating it and locking out existing
+tokens. Without a `cluster_name` there's nowhere stable to persist it, so
+`cluster deploy` fails fast with `cluster name is required to persist
+jwt.filer_signing key` rather than silently generating a throwaway one.
+`cluster_name` also doubles as the `<cluster-name>` argument to `cluster
+status` / `upgrade` / `scale` / `destroy`, and can be supplied as a
+positional argument to `cluster deploy` instead of in the YAML — e.g.
+`seaweed-up cluster deploy my-cluster -f cluster.yaml` (the positional
+argument, when given, overrides `cluster_name` in the file).
+
 ## Shared config defaults
 
 Cluster-wide values are written once and inherited by each entry, so you

--- a/examples/minimum.yaml
+++ b/examples/minimum.yaml
@@ -4,6 +4,8 @@
 # Good for local experimentation and smoke tests. For anything close to
 # production, see examples/typical.yaml.
 
+cluster_name: seaweed-minimum
+
 global:
   dir.conf: "/etc/seaweed"
   dir.data: "/opt/seaweed"

--- a/examples/typical.yaml
+++ b/examples/typical.yaml
@@ -9,6 +9,8 @@
 # throughput, increase s3_servers if S3 traffic saturates a gateway, and
 # increase worker_servers if background maintenance queues back up.
 
+cluster_name: seaweed-typical
+
 global:
   dir.conf: "/etc/seaweed"
   dir.data: "/opt/seaweed"


### PR DESCRIPTION
## Summary

- Both `examples/minimum.yaml` and `examples/typical.yaml` have `filer_servers` (and `typical.yaml` also has `admin_servers`), but neither sets `cluster_name`, and neither enables TLS. Running `seaweed-up cluster deploy -f examples/typical.yaml` (exactly as the README's own "Deploy" section instructs) fails immediately in `EnsureSecurityToml` with:
  ```
  ensure security.toml: cluster name is required to persist jwt.filer_signing key
  ```
  because `cluster_name` gates where the generated `jwt.filer_signing` key gets persisted (`~/.seaweed-up/clusters/<cluster_name>/`), and it's required as soon as any filer/admin host is in the spec — TLS or not.
- Add `cluster_name:` to both example specs, matching the placement/style already used by `cluster plan`'s generated output and its test fixtures (`pkg/cluster/plan/testdata/*.cluster.yaml`).
- Add a short "Cluster name" README section explaining why it's required and how it can also be supplied positionally to `cluster deploy`.

Verified by parsing + `Validate()`-ing both updated example files with the real `spec.Specification` loader (see test plan) and by running the existing test suite.

#### Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/... ./cmd/...` — all green
- [x] Loaded and validated both `examples/minimum.yaml` and `examples/typical.yaml` with `spec.Specification` + `yaml.v3.Unmarshal` + `Validate()`: both parse and validate successfully with `cluster_name` set (`seaweed-minimum` / `seaweed-typical`).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweed-up/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a required cluster name setting for configurations using filer or admin servers.
  * Cluster deployments now persist the generated signing key for reuse during redeploys, scaling, and upgrades.
  * The cluster name can be used with status, upgrade, scale, and destroy operations.
  * Added cluster name guidance to the README and example configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->